### PR TITLE
When writing multiple test blocks the jobs size was incorrect

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -26,6 +26,10 @@ module Sidekiq
         true
       end
 
+      def reset_jobs!
+        @pushed = []
+      end
+
       def jobs
         @pushed ||= []
       end

--- a/test/test_testing.rb
+++ b/test/test_testing.rb
@@ -11,13 +11,15 @@ class TestTesting < MiniTest::Unit::TestCase
       end
     end
 
-    it 'stubs the async call when in testing mode' do
+    it 'stubs the async call when in testing mode and be able to reset it' do
       begin
         # Override Sidekiq::Worker
         require 'sidekiq/testing'
         assert_equal 0, DirectWorker.jobs.size
         assert DirectWorker.perform_async(1, 2)
         assert_equal 1, DirectWorker.jobs.size
+        DirectWorker.reset_jobs!
+        assert_equal 0, DirectWorker.jobs.size
       ensure
         # Undo override
         Sidekiq::Worker::ClassMethods.class_eval do
@@ -27,6 +29,5 @@ class TestTesting < MiniTest::Unit::TestCase
         end
       end
     end
-
   end
 end


### PR DESCRIPTION
I have just transitioned a project using resque to use sidekiq (which is awesome!) but I couldn't see a nice way to reset the jobs array being kept when running tests.

Have therefore added a 'reset_jobs!' method to clear the jobs collected.  If there was another way to do this do let me know.

Also the test added to sidekiq would've been a separate but I had trouble re-applying the alias_method for perform_async.  So i guess sorry for adding the assertion to an existing test block.
