### PR TITLE
database configuration does not specify adapter

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -57,7 +57,7 @@ module Sidekiq
     end
 
     def detected_environment
-      @options[:environment] || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+      @options[:environment] ||= ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     end
 
     def boot_system


### PR DESCRIPTION
It seems that when the env config is nil then activerecord looks for a config that is not there and errors
