### PR TITLE
List queues stored by middleware

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -21,7 +21,7 @@ module Sidekiq
     end
 
     def self.queues
-      @queues ||= {}
+      self.redis.smembers('queues')
     end
 
     def self.redis


### PR DESCRIPTION
This simply implements the Sidekiq::Client.queues method to fetch the list of queues that's stored by the resque web compatibility middleware.
