### PR TITLE
Adding pidfile option

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -129,7 +129,7 @@ module Sidekiq
           @options[:processor_count] = arg.to_i
         end
 
-        o.on '-p', '--pidfile PATH', "path to use" do |arg|
+        o.on '-P', '--pidfile PATH', "path to use" do |arg|
           @options[:pidfile] = arg
         end
       end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -41,7 +41,7 @@ class TestCli < MiniTest::Unit::TestCase
         @tmp_path = @tmp_file.path
         @tmp_file.close!
         File.unlink @tmp_path if File.exist? @tmp_path
-        @cli.parse(['sidekiq', '-p', @tmp_path, '-r', './test/fake_env.rb'])
+        @cli.parse(['sidekiq', '-P', @tmp_path, '-r', './test/fake_env.rb'])
       end
 
       after do


### PR DESCRIPTION
Cribbed from puma. I tested manually too; worked like a charm.

``` sh
∴ ./bin/sidekiq -r ./test/fake_env.rb -p /tmp/sidekiq.pid
I, [2012-02-15T10:55:23.417538 #7122]  INFO -- : Booting sidekiq 0.6.0 with Redis at localhost:6379
I, [2012-02-15T10:55:23.495404 #7122]  INFO -- : Starting processing, hit Ctrl-C to stop
```

``` sh
∴ kill -s INT `cat /tmp/sidekiq.pid`
```

``` sh
I, [2012-02-15T10:55:53.290310 #7122]  INFO -- : Shutting down, pausing 5 seconds to let workers finish...
I, [2012-02-15T10:55:53.298585 #7122]  INFO -- : My tag: ':7122-'
I, [2012-02-15T10:55:53.299552 #7122]  INFO -- : Current workers: [...]
```
