### PR TITLE
Send error backtraces to Airbrake.

### DIFF
--- a/lib/sidekiq/middleware/server/exception_handler.rb
+++ b/lib/sidekiq/middleware/server/exception_handler.rb
@@ -20,7 +20,8 @@ module Sidekiq
         def send_to_airbrake(msg, ex)
           ::Airbrake.notify(:error_class   => ex.class.name,
                             :error_message => "#{ex.class.name}: #{ex.message}",
-                            :parameters    => msg)
+                            :parameters    => msg,
+                            :backtrace     => ex.backtrace)
         end
 
         def send_to_exceptional(msg, ex)


### PR DESCRIPTION
As discussed in #54, sidekiq is not sending the backtrace information to Airbrake. This fixes it. I'm not sure how to test this without depending on Airbrake, so I didn't add any tests.
