### PR TITLE
Fix Capistrano recipe to start Sidekiq as a background task

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -16,7 +16,7 @@ Capistrano::Configuration.instance.load do
     desc "Start sidekiq"
     task :start do
       rails_env = fetch(:rails_env, "production")
-      run "cd #{current_path} && bundle exec sidekiq -e #{rails_env} -C config/sidekiq.yml -P tmp/pids/sidekiq.pid >> log/sidekiq.log &"
+      run "cd #{current_path} && nohup bundle exec sidekiq -e #{rails_env} -C config/sidekiq.yml -P tmp/pids/sidekiq.pid >> log/sidekiq.log < /dev/null 2>&1 & sleep 1"
     end
 
     desc "Restart sidekiq"


### PR DESCRIPTION
Refs #52

Add redirection of standard output and error to /dev/null.
