### PR TITLE
Fix for: sh: cannot create log/sidekiq.log: Directory nonexistent

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -19,7 +19,7 @@ Capistrano::Configuration.instance.load do
     desc "Start sidekiq"
     task :start do
       rails_env = fetch(:rails_env, "production")
-      run "cd #{current_path} && nohup bundle exec sidekiq -e #{rails_env} -C config/sidekiq.yml -P tmp/pids/sidekiq.pid &>> log/sidekiq.log &"
+      run "cd #{current_path} && nohup bundle exec sidekiq -e #{rails_env} -C config/sidekiq.yml -P tmp/pids/sidekiq.pid &>> #{current_path}/log/sidekiq.log &"
     end
 
     desc "Restart sidekiq"


### PR DESCRIPTION
Trying to do a cap deploy and it's complaining about the log file
