### PR TITLE
fix restart not restarting

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -13,7 +13,7 @@ Capistrano::Configuration.instance.load do
 
     desc "Stop sidekiq"
     task :stop do
-      run "sleep #{fetch :sidekiq_timeout} && kill -9 `cat #{current_path}/tmp/pids/sidekiq.pid` && rm #{current_path}/tmp/pids/sidekiq.pid"
+      run "sleep #{fetch :sidekiq_timeout} && kill `cat #{current_path}/tmp/pids/sidekiq.pid` && rm #{current_path}/tmp/pids/sidekiq.pid"
     end
 
     desc "Start sidekiq"
@@ -27,6 +27,11 @@ Capistrano::Configuration.instance.load do
       stop
       start
     end
-
+    
+    desc "Kill sidekiq"
+    task :kill do
+      run "kill -9 `cat #{current_path}/tmp/pids/sidekiq.pid` && rm #{current_path}/tmp/pids/sidekiq.pid"
+    end
+    
   end
 end


### PR DESCRIPTION
The first kill successes and cap task throws an error on the second kill. Maybe increase the default timeout to prevent job loss? Not sure if this is the best solution, but working for me. see issue #74

Better solution could be to use forman like resque advises, see http://michaelvanrooijen.com/articles/2011/06/08-managing-and-monitoring-your-ruby-application-with-foreman-and-upstart/
