### PR TITLE
Add hook_rails configuration option to make the Rails extensions optional

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -16,7 +16,7 @@ module Sidekiq
     :require => '.',
     :environment => nil,
     :timeout => 5,
-    :hook_rails => true,
+    :enable_rails_extensions => true,
   }
 
   def self.options

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -1,6 +1,6 @@
 module Sidekiq
   def self.hook_rails!
-    return unless Sidekiq.options[:hook_rails]
+    return unless Sidekiq.options[:enable_rails_extensions]
     if defined?(ActiveRecord)
       ActiveRecord::Base.extend(Sidekiq::Extensions::ActiveRecord)
       ActiveRecord::Base.send(:include, Sidekiq::Extensions::ActiveRecord)

--- a/test/test_extension_configuration.rb
+++ b/test/test_extension_configuration.rb
@@ -11,16 +11,16 @@ class TestExtensionConfiguration < MiniTest::Unit::TestCase
       Sidekiq.options = @options
     end
     
-    it 'should set hook_rails option to true by default' do
-      assert_equal true, Sidekiq.options[:hook_rails]
+    it 'should set enable_rails_extensions option to true by default' do
+      assert_equal true, Sidekiq.options[:enable_rails_extensions]
     end
 
-    it 'should extend ActiveRecord and ActiveMailer if hook_rails is true' do
+    it 'should extend ActiveRecord and ActiveMailer if enable_rails_extensions is true' do
       assert_equal ActionMailer::Base, Sidekiq.hook_rails!
     end
 
-    it 'should not extend ActiveRecord and ActiveMailer if hook_rails is false' do
-      Sidekiq.options = { :hook_rails => false }
+    it 'should not extend ActiveRecord and ActiveMailer if enable_rails_extensions is false' do
+      Sidekiq.options = { :enable_rails_extensions => false }
       assert_equal nil, Sidekiq.hook_rails!
     end
 


### PR DESCRIPTION
I want to incorporate sidekiq into an app that currently uses delayed_job, but at this time I don't want sidekiq to handle the cases where we use delay methods. This still extends ActiveRecord and ActiveMailer by default, but gives the option to disable it.
