### PR TITLE
Add quiet and stop in a single command (finish and exit)

### DIFF
--- a/bin/sidekiqctl
+++ b/bin/sidekiqctl
@@ -2,49 +2,72 @@
 
 require 'fileutils'
 
+class Sidekiqctl
+
+  attr_reader :stage, :pidfile, :timeout
+
+  def initialize(stage, pidfile, timeout)
+    @stage = stage
+    @pidfile = pidfile
+    @timeout = timeout
+
+    done 'No pidfile given' if !pidfile
+    done 'Pidfile does not exist' if !File.exist?(pidfile)
+    done 'Invalid pidfile content' if pid == 0
+
+    fetch_process
+
+    begin
+      send(stage)
+    rescue NoMethodError
+      done 'Invalid control command'
+    end
+  end
+
+  def fetch_process
+    Process.getpgid(pid)
+  rescue Errno::ESRCH
+    done "Process doesn't exist"
+  end
+
+  def done(msg)
+    puts msg
+    exit(0)
+  end
+
+  def pid
+    File.read(pidfile).to_i
+  end
+
+  def quiet
+    `kill -USR1 #{pid}`
+  end
+
+  def stop
+    `kill -TERM #{pid}`
+    timeout.times do
+      begin
+        Process.getpgid(pid)
+      rescue Errno::ESRCH
+        FileUtils.rm_f pidfile
+        done 'Sidekiq shut down gracefully.'
+      end
+      sleep 1
+    end
+    `kill -9 #{pid}`
+    done 'Sidekiq shut down forcefully.'
+  end
+
+  def shutdown
+    quiet
+    stop
+  end
+
+end
+
 stage = ARGV[0]
 pidfile = ARGV[1]
 timeout = ARGV[2].to_i
 timeout = 10 if timeout == 0
 
-def done(msg)
-  puts msg
-  exit(0)
-end
-
-done 'No pidfile given' if !pidfile
-done 'Pidfile does not exist' if !File.exist?(pidfile)
-
-pid = File.read(pidfile).to_i
-done 'Invalid pidfile content' if pid == 0
-
-begin
-  Process.getpgid(pid)
-rescue Errno::ESRCH
-  done "Process doesn't exist"
-end
-
-def quiet
-  `kill -USR1 #{pid}`
-end
-
-def stop
-  `kill -TERM #{pid}`
-  timeout.times do
-    begin
-      Process.getpgid(pid)
-    rescue Errno::ESRCH
-      FileUtils.rm_f pidfile
-      done 'Sidekiq shut down gracefully.'
-    end
-    sleep 1
-  end
-  `kill -9 #{pid}`
-  done 'Sidekiq shut down forcefully.'
-end
-
-case stage
-when 'quiet'          then quiet
-when 'stop'           then stop
-when 'quiet_and_stop' then quiet && stop
-end
+Sidekiqctl.new(stage, pidfile, timeout)


### PR DESCRIPTION
Would you be open to a single `quiet_and_stop` stage in `sidekiqctl`? I know you want to keep things simple and didn't want another signal added for this purpose, but I think having finish and exit functionality is pretty important.

We still don't have a very good solution for telling a worker to stop taking new jobs, finish what's already started, and exit gracefully when done unless it hits the timeout (in a single command).
