### PR TITLE
Reset button on sidekiq monitoring page to remove list of workers

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -36,6 +36,17 @@ module Sidekiq
     use SprocketsMiddleware, :root => dir
 
     helpers do
+
+      def reset_worker_list
+        Sidekiq.redis do |conn|
+          workers = conn.smembers('workers')
+          workers.each do |name|
+            conn.srem('workers', name) # if name =~ /:#{process_id}-/
+          end
+      end
+
+      end
+
       def workers
         @workers ||= begin
           Sidekiq.redis do |conn|
@@ -92,6 +103,11 @@ module Sidekiq
 
     get "/" do
       slim :index
+    end
+
+    post "/reset" do
+      reset_worker_list 
+      redirect '/sidekiq'
     end
 
     get "/queues/:name" do

--- a/web/views/index.slim
+++ b/web/views/index.slim
@@ -5,6 +5,8 @@
   p Failed: #{failed}
   p Workers: #{workers.size}
   p Retries Pending: #{retry_count}
+  form(action="/sidekiq/reset" method="post")
+    button(class="btn" type="submit") Clear worker list 
 
 .tabbable
   ul.nav.nav-tabs


### PR DESCRIPTION
A rather simple solution so not sure if its exactly what you would like. A button that removes all workers from the worker set. 
