### PR TITLE
Have Redis tell us if perform_async succeeded

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -41,14 +41,13 @@ module Sidekiq
       Sidekiq.client_middleware.invoke(worker_class, item, queue) do
         payload = MultiJson.encode(item)
         Sidekiq.redis do |conn|
-          conn.multi do
+          _, pushed = conn.multi do
             conn.sadd('queues', queue)
             conn.rpush("queue:#{queue}", payload)
           end
         end
-        pushed = true
       end
-      pushed
+      !! pushed
     end
 
     # Redis compatibility helper.  Example usage:


### PR DESCRIPTION
If (for whatever reason) redis fails to add our work to the queue, make sure we reflect that in the return value of Sidekiq::Client.push.
