### PR TITLE
By default jobs are added to the default queue.

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -2,8 +2,9 @@
 # Options here can still be overridden by cmd line args.
 #   sidekiq -C config.yml
 ---
-:verbose:      false
+:verbose: false
 :concurrency:  25
 :queues:
   - [often, 7]
+  - [default, 5]
   - [seldom, 3]


### PR DESCRIPTION
This example file was referenced in the docs as an example file for a production server.

I thought it would make more sense to add the default queue here too. If the person has forgotten to add the default queue, all the jobs would be queued and never be executed.

Is this a correct statement?
