### PR TITLE
If no content is returned, Rack throws an error:

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -21,7 +21,7 @@ module Sidekiq
     def call(env)
       # Solve the problem of people requesting /sidekiq when they need to request /sidekiq/ so
       # that relative links in templates resolve correctly.
-      return [301, { 'Location' => "#{env['SCRIPT_NAME']}/" }, []] if env['SCRIPT_NAME'] == env['REQUEST_PATH']
+      return [301, { 'Location' => "#{env['SCRIPT_NAME']}/" }, ['redirecting']] if env['SCRIPT_NAME'] == env['REQUEST_PATH']
 
       return @app.call(env) unless @matcher =~ env["PATH_INFO"]
       env['PATH_INFO'].sub!(@matcher,'')


### PR DESCRIPTION
/Users/matt/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/rack-1.4.1/lib/rack/lint.rb: in assert, line 19
/Users/matt/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/rack-1.4.1/lib/rack/lint.rb: in check_content_type
