### PR TITLE
Made sidekiq/testing work for the #enqueue method.

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -66,7 +66,7 @@ module Sidekiq
     # Messages are enqueued to the 'default' queue.
     #
     def self.enqueue(klass, *args)
-      push('class' => klass, 'args' => args)
+      klass.perform_async(*args)
     end
   end
 end


### PR DESCRIPTION
Requiring `sidekiq/testing` now also stubs out the `Sidekiq::Client.enqueue` method so that the behavior is consistent with `perform_async`.

I also upgraded the testing tests so that they can be run in separate `it` blocks. The trick is to use `load` instead of `require` which allows the file to be re-executed.
