### PR TITLE
Add perform method to workers in tests.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,7 +26,7 @@ end
 
 - Fix delayed extensions not available in workers [#152]
 
-- In test environments add the `#perform` class method to workers. This method
+- In test environments add the `#drain` class method to workers. This method
   executes all previously queued jobs. (panthomakos)
 
 1.1.4

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -34,7 +34,7 @@ module Sidekiq
         @pushed ||= []
       end
 
-      def perform
+      def drain
         while job = jobs.shift do
           new.perform(*job['args'])
         end

--- a/test/test_testing.rb
+++ b/test/test_testing.rb
@@ -89,7 +89,7 @@ class TestTesting < MiniTest::Unit::TestCase
 
       assert_equal 2, StoredWorker.jobs.size
       assert_raises PerformError do
-        StoredWorker.perform
+        StoredWorker.drain
       end
       assert_equal 0, StoredWorker.jobs.size
     end


### PR DESCRIPTION
Jobs are currently stored in the `#jobs` array. The `#perform` method allows workers to be execute all their previously queued jobs at once.
