### PR TITLE
Constrain MiniTest ~> v2.12.1

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency                  'connection_pool', '~> 0.9.0'
   gem.add_dependency                  'celluloid', '~> 0.10.0'
   gem.add_dependency                  'multi_json', '~> 1'
-  gem.add_development_dependency      'minitest'
+  gem.add_development_dependency      'minitest', '~> 2.12.1'
   gem.add_development_dependency      'sinatra'
   gem.add_development_dependency      'slim'
   gem.add_development_dependency      'rake'


### PR DESCRIPTION
Tests are broken by an [API change in MiniTest v3.0.0](https://github.com/seattlerb/minitest/blob/master/History.txt#L1-17).
