### PR TITLE
do not halt deployment if no servers are going to run sidekiq workers

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -10,23 +10,23 @@ Capistrano::Configuration.instance.load do
   namespace :sidekiq do
 
     desc "Quiet sidekiq (stop accepting new work)"
-    task :quiet, :roles => lambda { fetch(:sidekiq_role) } do
+    task :quiet, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
       run "cd #{current_path} && if [ -f #{current_path}/tmp/pids/sidekiq.pid ]; then #{fetch(:bundle_cmd, "bundle")} exec sidekiqctl quiet #{current_path}/tmp/pids/sidekiq.pid ; fi"
     end
 
     desc "Stop sidekiq"
-    task :stop, :roles => lambda { fetch(:sidekiq_role) } do
+    task :stop, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
       run "cd #{current_path} && if [ -f #{current_path}/tmp/pids/sidekiq.pid ]; then #{fetch(:bundle_cmd, "bundle")} exec sidekiqctl stop #{current_path}/tmp/pids/sidekiq.pid #{fetch :sidekiq_timeout} ; fi"
     end
 
     desc "Start sidekiq"
-    task :start, :roles => lambda { fetch(:sidekiq_role) } do
+    task :start, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
       rails_env = fetch(:rails_env, "production")
       run "cd #{current_path} ; nohup #{fetch(:bundle_cmd, "bundle")} exec sidekiq -e #{rails_env} -C #{current_path}/config/sidekiq.yml -P #{current_path}/tmp/pids/sidekiq.pid >> #{current_path}/log/sidekiq.log 2>&1 &", :pty => false
     end
 
     desc "Restart sidekiq"
-    task :restart, :roles => lambda { fetch(:sidekiq_role) } do
+    task :restart, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
       stop
       start
     end


### PR DESCRIPTION
Capistrano has this option to prevent deploys from being halted if no servers are matched for a given role (it just prints a message and continues).

In our case, we only run sidekiq in about half of our servers, and we deploy to groups of servers at a time to reduce downtime. I had to use this option to prevent the deploy from being interrupted when no servers running sidekiq are included in a given deploy.

Is there a reason to halt the deploy when there's no need to deploy to any servers running sidekiq workers?
