### PR TITLE
Use Inject instead of Sum to compute queue backlog size

### DIFF
--- a/web/views/index.slim
+++ b/web/views/index.slim
@@ -5,7 +5,7 @@
   p Failed: #{failed}
   p Busy Workers: #{workers.size}
   p Retries Pending: #{retry_count}
-  p Queue Backlog: #{queues.map{|q,size| size}.sum}
+  p Queue Backlog: #{queues.values.inject(0){|memo, val| memo + val}}
 
 .tabbable
   ul.nav.nav-tabs


### PR DESCRIPTION
Fix for #203.

Sum is not a built in method on Enumerable, it is an extension defined
in ActiveSupport. This allows a more generic and universal use of the
web ui.
