### PR TITLE
clear_jobs method for testing, which removes jobs without actually performing them

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -34,6 +34,10 @@ module Sidekiq
         @pushed ||= []
       end
 
+      def clear_jobs
+        @pushed = []
+      end
+
       def drain
         while job = jobs.shift do
           new.perform(*job['args'])

--- a/test/test_testing.rb
+++ b/test/test_testing.rb
@@ -83,6 +83,12 @@ class TestTesting < MiniTest::Unit::TestCase
       assert_equal 1, EnqueuedWorker.jobs.size
     end
 
+    it 'clears jobs' do
+      Sidekiq::Client.enqueue(EnqueuedWorker, 1, 2)
+      EnqueuedWorker.clear_jobs
+      assert_equal 0, EnqueuedWorker.jobs.size
+    end
+
     it 'executes all stored jobs' do
       assert StoredWorker.perform_async(false)
       assert StoredWorker.perform_async(true)


### PR DESCRIPTION
Might be handy for testing cleanup, if you want to see if a job was queued but don't actually want to process the job.
