### PR TITLE
Fix inline testing argument handling to match server mode

### DIFF
--- a/lib/sidekiq/testing/inline.rb
+++ b/lib/sidekiq/testing/inline.rb
@@ -29,7 +29,7 @@ module Sidekiq
     module ClassMethods
       alias_method :perform_async_old, :perform_async
       def perform_async(*args)
-        new.perform(*args)
+        new.perform(*Sidekiq.load_json(Sidekiq.dump_json(args)))
         true
       end
     end

--- a/test/test_testing_inline.rb
+++ b/test/test_testing_inline.rb
@@ -12,11 +12,19 @@ Sidekiq.hook_rails!
 class TestInline < MiniTest::Unit::TestCase
   describe 'sidekiq inline testing' do
     class InlineError < RuntimeError; end
+    class ParameterIsNotString < RuntimeError; end
 
     class InlineWorker
       include Sidekiq::Worker
       def perform(pass)
         raise InlineError unless pass
+      end
+    end
+
+    class InlineWorkerWithTimeParam
+      include Sidekiq::Worker
+      def perform(time)
+        raise ParameterIsNotString unless time.is_a?(String)
       end
     end
 
@@ -70,6 +78,10 @@ class TestInline < MiniTest::Unit::TestCase
       assert_raises InlineError do
         Sidekiq::Client.enqueue(InlineWorker, false)
       end
+    end
+
+    it 'should relay parameters through json' do
+      assert Sidekiq::Client.enqueue(InlineWorkerWithTimeParam, Time.now)
     end
   end
 end


### PR DESCRIPTION
If you are passing arguments like time objects that serialize to strings
but don't deserialize back automatically, inline testing was passing the
objects through raw meaning different behavior in tests vs. production.
Now the inline wrapper does a round trip through json.
