### PR TITLE
Error in Previous Commit fixing queue backlog computation

### DIFF
--- a/web/views/index.slim
+++ b/web/views/index.slim
@@ -5,7 +5,7 @@
   p Failed: #{failed}
   p Busy Workers: #{workers.size}
   p Retries Pending: #{retry_count}
-  p Queue Backlog: #{queues.values.inject(0){|memo, val| memo + val}}
+  p Queue Backlog: #{queues.inject(0){|memo, val| memo + val.last}}
 
 .tabbable
   ul.nav.nav-tabs


### PR DESCRIPTION
I just realized that the I submitted the incorrect patch

The queues variable is a two element array, not a hash.
