### PR TITLE
Moved Queues to it's own section

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -128,6 +128,11 @@ module Sidekiq
       slim :index
     end
 
+    get "/queues" do
+      @queues = queues
+      slim :queues
+    end
+
     get "/queues/:name" do
       halt 404 unless params[:name]
       count = (params[:count] || 10).to_i
@@ -146,7 +151,7 @@ module Sidekiq
         conn.del("queue:#{params[:name]}")
         conn.srem("queues", params[:name])
       end
-      redirect root_path
+      redirect "#{root_path}queues"
     end
 
     get "/retries/:score" do

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -24,33 +24,20 @@ class TestWeb < MiniTest::Unit::TestCase
       end
     end
 
-    it 'shows active queues' do
+    it 'can display home' do
       get '/'
       assert_equal 200, last_response.status
       assert_match /Sidekiq is idle/, last_response.body
       refute_match /default/, last_response.body
-
-      assert WebWorker.perform_async(1, 2)
-
-      get '/'
-      assert_equal 200, last_response.status
-      assert_match /Sidekiq is idle/, last_response.body
-      assert_match /default/, last_response.body
-      refute_match /foo/, last_response.body
-
-      assert Sidekiq::Client.push('queue' => :foo, 'class' => WebWorker, 'args' => [1, 3])
-
-      get '/'
-      assert_equal 200, last_response.status
-      assert_match /Sidekiq is idle/, last_response.body
-      assert_match /default/, last_response.body
-      assert_match /foo/, last_response.body
-      assert_match /Backlog: 2/, last_response.body
     end
 
-    it 'handles queues with no name' do
+    it 'can display queues' do
+      assert Sidekiq::Client.push('queue' => :foo, 'class' => WebWorker, 'args' => [1, 3])
+
       get '/queues'
-      assert_equal 404, last_response.status
+      assert_equal 200, last_response.status
+      assert_match /foo/, last_response.body
+      refute_match /HardWorker/, last_response.body
     end
 
     it 'handles missing retry' do

--- a/web/views/index.slim
+++ b/web/views/index.slim
@@ -1,4 +1,3 @@
-
 .hero-unit
   h1 Sidekiq is #{current_status}
   p Processed: #{processed}
@@ -8,44 +7,19 @@
   p Retries Pending: #{zcard('retry')}
   p Queue Backlog: #{backlog}
 
-.tabbable
-  ul.nav.nav-tabs
-    li.active
-      a href="#workers" data-toggle="tab" Busy Workers
-    li
-      a href="#queues" data-toggle="tab" Queues
-  .tab-content
-    #workers.tab-pane.active
-      table class="table table-striped table-bordered"
-        tr
-          th Worker
-          th Queue
-          th Class
-          th Arguments
-          th Started
-        - workers.each do |(worker, msg)|
-          tr
-            td= worker
-            td= msg['queue']
-            td= msg['payload']['class']
-            td= msg['payload']['args'].inspect[0..100]
-            td== relative_time(Time.parse(msg['run_at']))
-      form action="#{root_path}reset" method="post"
-         button.btn type="submit" title="If you kill -9 Sidekiq, this table can fill up with old data." Clear worker list
-
-    #queues.tab-pane
-      table class="table table-striped table-bordered"
-        tr
-          th Queue
-          th Size
-          th
-        - queues.each do |(queue, size)|
-          tr
-            td
-              a href="#{root_path}queues/#{queue}" #{queue}
-            td= size
-            td
-              form action="#{root_path}queues/#{queue}" method="post"
-                input.btn.btn-danger type="submit" name="delete" value="Delete"
-
-
+table class="table table-striped table-bordered"
+  tr
+    th Worker
+    th Queue
+    th Class
+    th Arguments
+    th Started
+  - workers.each do |(worker, msg)|
+    tr
+      td= worker
+      td= msg['queue']
+      td= msg['payload']['class']
+      td= msg['payload']['args'].inspect[0..100]
+      td== relative_time(Time.parse(msg['run_at']))
+form action="#{root_path}reset" method="post"
+   button.btn type="submit" title="If you kill -9 Sidekiq, this table can fill up with old data." Clear worker list

--- a/web/views/layout.slim
+++ b/web/views/layout.slim
@@ -13,6 +13,8 @@ html
             li
               a href='#{{root_path}}' Home
             li
+              a href='#{{root_path}}queues' Queues
+            li
               a href='#{{root_path}}retries' Retries
             li
               a href='#{{root_path}}scheduled' Scheduled


### PR DESCRIPTION
Note that the following test was broken on master already:

``` ruby
  1) Error:
test_0001_should_poll_like_a_bad_mother_shut_yo_mouth(poller):
MockExpectationError: expected rpush, {:retval=>1, :args=>["queue:someq", "{\"class\":\"Bob\",\"args\":[1,2],\"queue\":\"someq\"}"]}, got []
    /Users/fredrik/sidekiq/test/test_retry.rb:121:in `block (2 levels) in <class:TestRetry>'
```
