### PR TITLE
Redirects on delete

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -179,7 +179,7 @@ module Sidekiq
         s = score.to_f
         process_score('schedule', s, :delete)
       end
-      redirect root_path
+      redirect "#{root_path}scheduled"
     end
 
     post '/retries' do

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -81,6 +81,17 @@ class TestWeb < MiniTest::Unit::TestCase
       assert_match /HardWorker/, last_response.body
     end
 
+    it 'can delete scheduled' do
+      msg,score = add_scheduled
+      Sidekiq.redis do |conn|
+        assert_equal 1, conn.zcard('schedule')
+        post '/scheduled', 'score' => [score], 'delete' => 'Delete'
+        assert_equal 302, last_response.status
+        assert_equal 'http://example.org/scheduled', last_response.header['Location']
+        assert_equal 0, conn.zcard('schedule')
+      end
+    end
+
     it 'can display retries' do
       get '/retries'
       assert_equal 200, last_response.status


### PR DESCRIPTION
Changed redirects on pressing delete and retry buttons for scheduled and retried jobs to take you to the listing pages where the buttons where pressed.
