### PR TITLE
Output synchronously

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -22,6 +22,8 @@ trap 'TTIN' do
   end
 end
 
+$stdout.sync = true
+
 require 'yaml'
 require 'singleton'
 require 'optparse'


### PR DESCRIPTION
I guess this is an opinionated change but if you're routing stdout to syslog or similar you'll want it to be unbuffered.
