### PR TITLE
Handle Redis#zadd return value correctly when Scheduling

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -49,7 +49,7 @@ module Sidekiq
         payload = Sidekiq.dump_json(item)
         Sidekiq.redis do |conn|
           if item['at']
-            pushed = (conn.zadd('schedule', item['at'].to_s, payload) == 1)
+            pushed = conn.zadd('schedule', item['at'].to_s, payload)
           else
             _, pushed = conn.multi do
               conn.sadd('queues', queue)

--- a/test/test_scheduling.rb
+++ b/test/test_scheduling.rb
@@ -18,13 +18,13 @@ class TestScheduling < MiniTest::Unit::TestCase
     end
 
     it 'schedules a job via interval' do
-      @redis.expect :zadd, 1, ['schedule', String, String]
+      @redis.expect :zadd, true, ['schedule', String, String]
       assert_equal true, ScheduledWorker.perform_in(600, 'mike')
       @redis.verify
     end
 
     it 'schedules a job via timestamp' do
-      @redis.expect :zadd, 1, ['schedule', String, String]
+      @redis.expect :zadd, true, ['schedule', String, String]
       assert_equal true, ScheduledWorker.perform_in(5.days.from_now, 'mike')
       @redis.verify
     end


### PR DESCRIPTION
[Redis#zadd](http://rdoc.info/gems/redis/3.0.0/Redis#zadd-instance_method) will return a boolean value when only one item is added. This
was failing to be equal to 1, and caused any `Sidekiq::Client::push`
invocations with an 'at' value to return false, even if they
successfully were stored into redis.
