### PR TITLE
Support Pushing in Batches

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -32,33 +32,28 @@ module Sidekiq
     # Example:
     #   Sidekiq::Client.push('queue' => 'my_queue', 'class' => MyWorker, 'args' => ['foo', 1, :bat => 'bar'])
     #
-    def self.push(item)
-      raise(ArgumentError, "Message must be a Hash of the form: { 'class' => SomeWorker, 'args' => ['bob', 1, :foo => 'bar'] }") unless item.is_a?(Hash)
-      raise(ArgumentError, "Message must include a class and set of arguments: #{item.inspect}") if !item['class'] || !item['args']
-      raise(ArgumentError, "Message must include a Sidekiq::Worker class, not class name: #{item['class'].ancestors.inspect}") if !item['class'].is_a?(Class) || !item['class'].respond_to?('get_sidekiq_options')
+    def self.push(item)   
+      push_to_queue(item, false)
+    end
 
-      worker_class = item['class']
-      item['class'] = item['class'].to_s
-
-      item = worker_class.get_sidekiq_options.merge(item)
-      item['retry'] = !!item['retry']
-      queue = item['queue']
-
-      pushed = false
-      Sidekiq.client_middleware.invoke(worker_class, item, queue) do
-        payload = Sidekiq.dump_json(item)
-        Sidekiq.redis do |conn|
-          if item['at']
-            pushed = (conn.zadd('schedule', item['at'].to_s, payload) == 1)
-          else
-            _, pushed = conn.multi do
-              conn.sadd('queues', queue)
-              conn.rpush("queue:#{queue}", payload)
-            end
-          end
-        end
-      end
-      !! pushed
+    ##
+    # Sibling of the push method, push_batch implies multiple messages should be delivered, in batch, to
+    # the specified worker.  
+    #   queue - the named queue to use, default 'default'
+    #   class - the worker class to call, required
+    #   args - an array of arrays of simple arguments to the perform method.  The arrays within the base array must be JSON serializable
+    #   retry - whether to retry this job if it fails, true or false, default true
+    #   backtrace - whether to save any error backtrace, default false
+    #
+    # All options must be strings, not symbols.  NB: because we are serializing to JSON, all
+    # symbols in 'args' will be converted to strings.
+    # Example:
+    #   Sidekiq::Client.push_batch('queue' => 'my_queue', 'class' => MyWorker, 'args' => [['bar', 2, :bat => 'foo'], ['foo', 1, :bat => 'bar']])
+    #
+    def self.push_batch(item)
+      #TODO: Actually support scheduled batches      
+      raise(ArgumentError, "Batches cannot be scheduled at this time.") if item['at']
+      self.push_to_queue(item, true)
     end
 
     # Redis compatibility helper.  Example usage:
@@ -70,5 +65,44 @@ module Sidekiq
     def self.enqueue(klass, *args)
       klass.perform_async(*args)
     end
+
+    private 
+      def self.get_payload(item)
+        payload = []
+        args = item.delete('args')
+        args.each do |arguments|
+          payload << Sidekiq.dump_json(item.merge({'args' => arguments}))
+        end
+        payload
+      end    
+
+      #Push the message to redis
+      def self.push_to_queue(item, batch)
+        raise(ArgumentError, "Message must be a Hash of the form: { 'class' => SomeWorker, 'args' => ['bob', 1, :foo => 'bar'] }") unless item.is_a?(Hash)
+        raise(ArgumentError, "Message must include a class and set of arguments: #{item.inspect}") if !item['class'] || !item['args']
+        raise(ArgumentError, "Message must include a Sidekiq::Worker class, not class name: #{item['class'].ancestors.inspect}") if !item['class'].is_a?(Class) || !item['class'].respond_to?('get_sidekiq_options')
+        worker_class = item['class']
+        item['class'] = item['class'].to_s
+
+        item = worker_class.get_sidekiq_options.merge(item)
+        item['retry'] = !!item['retry']
+        queue = item['queue']
+
+        pushed = false
+        payload = batch ? self.get_payload(item) : Sidekiq.dump_json(item)
+        Sidekiq.client_middleware.invoke(worker_class, payload, queue) do        
+          Sidekiq.redis do |conn|
+            if item['at']
+              pushed = (conn.zadd('schedule', item['at'].to_s, payload) == 1)
+            else
+              _, pushed = conn.multi do              
+                conn.sadd('queues', queue)
+                conn.rpush("queue:#{queue}", payload)
+              end
+            end
+          end
+        end
+        !! pushed
+      end  
   end
 end

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -35,6 +35,10 @@ module Sidekiq
         Sidekiq::Client.push('class' => self, 'args' => args)
       end
 
+      def perform_batch_async(*args)
+        Sidekiq::Client.push_batch('class' => self, 'args' => args)
+      end
+
       def perform_in(interval, *args)
         int = interval.to_f
         ts = (int < 1_000_000_000 ? Time.now.to_f + int : int)


### PR DESCRIPTION
Hi Mike,
In an effort to make sidekiq a bit faster on the push side, I've added the ability for coders to pass in a bulk array of arguments which leverages the fact that rpush can take a list of values and place them on the tail of the list (or queue, in this instance).  

An example use case would be a user wanting to send a message to 100 of their friends.  Rather than calling perform_async 100 times with only slightly different messages (in this case, just the target user would change), we can call perform_bulk_async once with an array of messages, and save ourselves a bunch of round trips over the wire.

Some issues I already see and would like your feedback on how you'd like me to proceed.
1)  Scheduling won't work with this model, because zadd doesn't take a list of values.  We can call zadd multiple times; however, that causes issues with validating that all jobs were properly enqueued.
2)  It's unclear to me whether UniqueJobs should be updated.  If we're trying to prevent identical bulk-requests from processing, then it's fine in its current state.  If we'd like each individual job within that bulk message to be unique, then it'll need to be tweaked.

Thanks for all your hard work on Sidekiq.  It's an awesome tool that I'm already using all over the place.

-Wes
