### PR TITLE
Log thread stacktraces via Sidekiq.logger

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -17,8 +17,8 @@ end
 
 trap 'TTIN' do
   Thread.list.each do |thread|
-    puts "Thread TID-#{thread.object_id.to_s(36)} #{thread['label']}"
-    puts thread.backtrace.join("\n")
+    Sidekiq.logger.info "Thread TID-#{thread.object_id.to_s(36)} #{thread['label']}"
+    Sidekiq.logger.info thread.backtrace.join("\n")
   end
 end
 


### PR DESCRIPTION
If you have started the daemon in a way that stdout is not going
anywhere, this is needed to get the output. With default settings
nothing changes as the logger is directed to standard out.
