### PR TITLE
fix poll interval for scheduling

### DIFF
--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -55,7 +55,7 @@ module Sidekiq
 
       def add_jitter
         begin
-          sleep(POLL_INTERVAL * rand)
+          sleep(poll_interval * rand)
         rescue Celluloid::Task::TerminatedError
           # Hit Ctrl-C when Sidekiq is finished booting and we have a chance
           # to get here.


### PR DESCRIPTION
Scheduling was only using the default polling frequency. Also, I've changed the wiki section to reflect setting the option for poll_interval:

``` ruby
Sidekiq.options[:poll_interval] = 1
```

It can probably get rolled back into the block config, but the example that was there wasn't working. My testing confirmed this one works.

It works really well too.. awesome stuff! Killed a dependency for us.
