### PR TITLE
Added polling to the index page to monitor jobs and workers more easily

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -117,6 +117,10 @@ module Sidekiq
       slim :index
     end
 
+    get "/poll" do
+      slim :poll, layout: false
+    end
+
     get "/queues" do
       @queues = queues
       slim :queues

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -31,6 +31,14 @@ class TestWeb < MiniTest::Unit::TestCase
       refute_match /default/, last_response.body
     end
 
+    it 'can display poll' do
+      get '/poll'
+      assert_equal 200, last_response.status
+      assert_match /hero-unit/, last_response.body
+      assert_match /workers/, last_response.body
+      refute_match /navbar/, last_response.body
+    end
+
     it 'can display queues' do
       assert Sidekiq::Client.push('queue' => :foo, 'class' => WebWorker, 'args' => [1, 3])
 
@@ -115,26 +123,26 @@ class TestWeb < MiniTest::Unit::TestCase
       assert_equal 200, last_response.status
       assert_match /HardWorker/, last_response.body
     end
-    
+
     it 'can delete a single retry' do
       _, score = add_retry
 
       post "/retries/#{score}", 'delete' => 'Delete'
       assert_equal 302, last_response.status
       assert_equal 'http://example.org/retries', last_response.header['Location']
-      
+
       get "/retries"
       assert_equal 200, last_response.status
       refute_match /#{score}/, last_response.body
     end
-    
+
     it 'can retry a single retry now' do
       msg, score = add_retry
 
       post "/retries/#{score}", 'retry' => 'Retry'
       assert_equal 302, last_response.status
       assert_equal 'http://example.org/retries', last_response.header['Location']
-      
+
       get '/queues/default'
       assert_equal 200, last_response.status
       assert_match /#{msg['args'][2]}/, last_response.body

--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -18,3 +18,32 @@ $(function() {
     }
   });
 });
+
+$(function() {
+  $('a[name=poll]').data('polling', false);
+
+  $('a[name=poll]').on('click', function(e) {
+    e.preventDefault();
+    var pollLink = $(this);
+    if (pollLink.data('polling')) {
+      clearInterval(pollLink.data('interval'));
+      pollLink.text('Live Poll');
+      $('.poll-status').text('');
+    }
+    else {
+      var href = pollLink.attr('href');
+      pollLink.data('interval', setInterval(function() {
+        $.get(href, function(data) {
+          var responseHtml = $(data);
+          $('.hero-unit').replaceWith(responseHtml.find('.hero-unit'));
+          $('.workers').replaceWith(responseHtml.find('.workers'));
+        });
+        var currentTime = new Date();
+        $('.poll-status').text('Last polled at: ' + currentTime.getHours() + ':' + currentTime.getMinutes() + ':' + currentTime.getSeconds());
+      }, 2000));
+      $('.poll-status').text('Starting to poll...');
+      pollLink.text('Stop Polling');
+    }
+    pollLink.data('polling', !pollLink.data('polling'));
+  })
+});

--- a/web/assets/stylesheets/layout.css
+++ b/web/assets/stylesheets/layout.css
@@ -20,3 +20,7 @@ code {
 .hero-unit {
   padding: 30px;
 }
+
+.poll-status {
+  padding-left: 10px;
+}

--- a/web/views/_summary.slim
+++ b/web/views/_summary.slim
@@ -1,0 +1,8 @@
+.hero-unit
+  h1 Sidekiq is #{current_status}
+  p Processed: #{processed}
+  p Failed: #{failed}
+  p Busy Workers: #{workers.size}
+  p Scheduled: #{zcard('schedule')}
+  p Retries Pending: #{zcard('retry')}
+  p Queue Backlog: #{backlog}

--- a/web/views/_workers.slim
+++ b/web/views/_workers.slim
@@ -1,0 +1,14 @@
+table class="table table-striped table-bordered workers"
+  tr
+    th Worker
+    th Queue
+    th Class
+    th Arguments
+    th Started
+  - workers.each do |(worker, msg)|
+    tr
+      td= worker
+      td= msg['queue']
+      td= msg['payload']['class']
+      td= msg['payload']['args'].inspect[0..100]
+      td== relative_time(Time.parse(msg['run_at']))

--- a/web/views/index.slim
+++ b/web/views/index.slim
@@ -1,25 +1,10 @@
-.hero-unit
-  h1 Sidekiq is #{current_status}
-  p Processed: #{processed}
-  p Failed: #{failed}
-  p Busy Workers: #{workers.size}
-  p Scheduled: #{zcard('schedule')}
-  p Retries Pending: #{zcard('retry')}
-  p Queue Backlog: #{backlog}
+== slim :_summary
 
-table class="table table-striped table-bordered"
-  tr
-    th Worker
-    th Queue
-    th Class
-    th Arguments
-    th Started
-  - workers.each do |(worker, msg)|
-    tr
-      td= worker
-      td= msg['queue']
-      td= msg['payload']['class']
-      td= msg['payload']['args'].inspect[0..100]
-      td== relative_time(Time.parse(msg['run_at']))
+.poll
+  a*{name: 'poll'} href='#{{root_path}}poll' Live Poll
+  span class="poll-status"
+
+== slim :_workers
+
 form action="#{root_path}reset" method="post"
-   button.btn type="submit" title="If you kill -9 Sidekiq, this table can fill up with old data." Clear worker list
+  button.btn type="submit" title="If you kill -9 Sidekiq, this table can fill up with old data." Clear worker list

--- a/web/views/layout.slim
+++ b/web/views/layout.slim
@@ -13,7 +13,7 @@ html
             span.icon-bar
           a.brand href='#{{root_path}}'
             | Sidekiq
-          div.nav-collapse  
+          div.nav-collapse
             ul.nav
               li
                 a href='#{{root_path}}' Home

--- a/web/views/poll.slim
+++ b/web/views/poll.slim
@@ -1,0 +1,3 @@
+div
+  == slim :_summary
+  == slim :_workers


### PR DESCRIPTION
As discussed, I've added polling similar to Resque's web front-end. I added a small test for the new action (/poll) as that was the only real logic added except for Javascript logic. We could potentially add in a JS testing framework to test the JS polling logic, but I'm totally unfamiliar with JS testing so I've left it as is for now.
