### PR TITLE
Added method in testing for running only due jobs

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -39,6 +39,18 @@ module Sidekiq
           new.perform(*job['args'])
         end
       end
+
+      def drain_due_jobs
+        scheduled = []
+        while job = jobs.shift do
+          if (at = job['at']) && at > Time.now.to_f
+            scheduled << job
+          else
+            new.perform(*job['args'])
+          end
+        end
+        jobs.concat(scheduled)
+      end
     end
   end
 end

--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency      'rake'
   gem.add_development_dependency      'actionmailer', '~> 3'
   gem.add_development_dependency      'activerecord', '~> 3'
+  gem.add_development_dependency      'timecop'
 end


### PR DESCRIPTION
I've added the method drain_due_jobs in testing infrastructure to allow running only due jobs. Jobs not due will be kept in jobs list so they could be drained later.

Tests need to "travel" in time, so I've added the timecop gem as a development dependency.
