### PR TITLE
Add button to reset processed/failed stats to sidekiq web

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -40,6 +40,13 @@ module Sidekiq
 
     helpers do
 
+      def reset_stats
+        Sidekiq.redis do |conn|
+          conn.set("stat:failed", 0)
+          conn.set("stat:processed", 0)
+        end
+      end
+      
       def reset_worker_list
         Sidekiq.redis do |conn|
           workers = conn.smembers('workers')
@@ -137,6 +144,11 @@ module Sidekiq
 
     post "/reset" do
       reset_worker_list
+      redirect root_path
+    end
+    
+    post "/reset_stats" do
+      reset_stats
       redirect root_path
     end
 

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -147,6 +147,16 @@ class TestWeb < MiniTest::Unit::TestCase
       assert_equal 200, last_response.status
       assert_match /#{msg['args'][2]}/, last_response.body
     end
+    
+    it 'can reset stats' do
+      Sidekiq.redis do |conn|
+        conn.set('stat:processed', 5)
+        conn.set('stat:failed', 10)
+        post '/reset_stats'
+        assert_equal '0', conn.get('stat:processed')
+        assert_equal '0', conn.get('stat:failed')
+      end
+    end
 
     def add_scheduled
       msg = { 'class' => 'HardWorker',

--- a/web/views/_summary.slim
+++ b/web/views/_summary.slim
@@ -1,5 +1,7 @@
 .hero-unit
   h1 Sidekiq is #{current_status}
+  form action="#{root_path}reset_stats" method="post"
+    button.btn.pull-right type="submit" title="Reset the processed and failed stat counts." Reset Stats
   p Processed: #{processed}
   p Failed: #{failed}
   p Busy Workers: #{workers.size}


### PR DESCRIPTION
This just adds a button to the summary area of the sidekiq sinatra app that allows users to clear the processed and failed stats.

This addresses #196.
