### PR TITLE
Support queue-names-with-dashes

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -141,7 +141,7 @@ module Sidekiq
 
       @parser = OptionParser.new do |o|
         o.on "-q", "--queue QUEUE[,WEIGHT]...", "Queues to process with optional weights" do |arg|
-          queues_and_weights = arg.scan(/(\w+),?(\d*)/)
+          queues_and_weights = arg.scan(/([\w-]+),?(\d*)/)
           queues_and_weights.each {|queue_and_weight| parse_queues(opts, *queue_and_weight)}
           opts[:strict] = queues_and_weights.collect(&:last).none? {|weight| weight != ''}
         end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -65,6 +65,11 @@ class TestCli < MiniTest::Unit::TestCase
       assert_equal %w(bar foo foo foo), Sidekiq.options[:queues]
     end
 
+    it 'handles queues with multi-word names' do
+      @cli.parse(['sidekiq', '-q', 'queue_one,queue-two', '-r', './test/fake_env.rb'])
+      assert_equal %w(queue_one queue-two), Sidekiq.options[:queues]
+    end
+
     it 'sets verbose' do
       old = Sidekiq.logger.level
       @cli.parse(['sidekiq', '-v', '-r', './test/fake_env.rb'])


### PR DESCRIPTION
I was trying to figure out why sidekiq wasn't processing any
workers in my 'user-requested-refreshes' queue. I finally figured
out it was processing the 'user', 'requested', and 'refreshes'
queues instead.
