### PR TITLE
Catch more Exceptions to avoid scheduling poller thread death

### DIFF
--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -43,7 +43,7 @@ module Sidekiq
                 end
               end
             end
-          rescue SystemCallError => ex
+          rescue SystemCallError, Redis::TimeoutError, Redis::ConnectionError => ex
             # ECONNREFUSED, etc.  Most likely a problem with
             # redis networking.  Punt and try again at the next interval
             logger.warn ex.message


### PR DESCRIPTION
Catch Redis::TimeoutError, Redis::ConnectionError thrown by Redis client on networking errors.

See: https://github.com/redis/redis-rb/blob/master/lib/redis/client.rb#L200
