### PR TITLE
Add Numeric Time support

### DIFF
--- a/test/test_testing_inline.rb
+++ b/test/test_testing_inline.rb
@@ -24,7 +24,7 @@ class TestInline < MiniTest::Unit::TestCase
     class InlineWorkerWithTimeParam
       include Sidekiq::Worker
       def perform(time)
-        raise ParameterIsNotString unless time.is_a?(String)
+        raise ParameterIsNotString unless time.is_a?(String) || time.is_a?(Numeric)
       end
     end
 

--- a/web/views/_workers.slim
+++ b/web/views/_workers.slim
@@ -11,4 +11,4 @@ table class="table table-striped table-bordered workers"
       td= msg['queue']
       td= msg['payload']['class']
       td= msg['payload']['args'].inspect[0..100]
-      td== relative_time(Time.parse(msg['run_at']))
+      td== relative_time(msg['run_at'].is_a?(Numeric) ? Time.at(msg['run_at']) : Time.parse(msg['run_at']))

--- a/web/views/retry.slim
+++ b/web/views/retry.slim
@@ -22,11 +22,11 @@ header
           td= msg['retry_count']
         tr
           th Last Retry
-          td== relative_time(Time.parse(msg['retried_at']))
+          td== relative_time(msg['retried_at'].is_a?(Numeric) ? Time.at(msg['retried_at']) : Time.parse(msg['retried_at']))
       - else
         tr
           th Originally Failed
-          td== relative_time(Time.parse(msg['failed_at']))
+          td== relative_time(msg['failed_at'].is_a?(Numeric) ? Time.at(msg['failed_at']) : Time.parse(msg['failed_at']))
       tr
         th Next Retry
         td== relative_time(Time.at(@score))


### PR DESCRIPTION
This adds support for Time serialized as a Numeric (Float) in the JSON strings.
