### PR TITLE
Prompt before deleting a queue

### DIFF
--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -49,3 +49,9 @@ $(function() {
     pollLink.data('polling', !pollLink.data('polling'));
   })
 });
+
+$(function() {
+  $('[data-confirm]').click(function() {
+    return confirm($(this).attr('data-confirm'));
+  });
+});

--- a/web/views/queues.slim
+++ b/web/views/queues.slim
@@ -13,7 +13,7 @@ h1 Queues
         td= size
         td
           form action="#{root_path}queues/#{queue}" method="post"
-            input.btn.btn-danger type="submit" name="delete" value="Delete"
+            input.btn.btn-danger type="submit" name="delete" value="Delete" data-confirm="Are you sure you want to delete the #{queue} queue?"
 - else
   p No queues found.
   a href="#{root_path}" Back


### PR DESCRIPTION
I have really large fingers and I was using my iPad and accidentally clicked the delete button when viewing the queues. It would be nice to have a prompt to ensure this doesn't happen by accident.

I had a look through the test suite for the web component, it wouldn't be possible to test this without adding the extra complexity of a javascript driver. Let me know if you'd like this, I can add as well.

Cheers
