### PR TITLE
Issue with pagination and scheduled jobs in web UI

### DIFF
--- a/lib/sidekiq/paginator.rb
+++ b/lib/sidekiq/paginator.rb
@@ -14,7 +14,7 @@ module Sidekiq
         case type
         when 'zset'
           total_size = conn.zcard(key)
-          items = conn.zrange(key, starting, ending, :with_scores => true)
+          items = Hash[*conn.zrange(key, starting, ending, :with_scores => true)]
         when 'list'
           total_size = conn.llen(key)
           items = conn.lrange(key, starting, ending)

--- a/web/views/scheduled.slim
+++ b/web/views/scheduled.slim
@@ -16,7 +16,7 @@ h1 Scheduled Jobs
         tr
           td
             input type='checkbox' name='score[]' value='#{score}'
-          td== relative_time(Time.at(score))
+          td== relative_time(Time.at(msg['at']))
           td
             a href="#{root_path}queues/#{msg['queue']}" #{msg['queue']}
           td= msg['class']


### PR DESCRIPTION
I've fixed an issue with pagination and scheduled jobs in the web UI.  Since schedules are stored as ZSETs, and are fetched :with_scores => true, the resulting items are in the form [item.0, score.0, item.1, score.1, etc..].

The GET '/scheduled' Web UI action assumes @scheduled is a hash keyed off the item's score, but it's actually an array of item + score data interleaved.  This breaks the web UI, since web/views/scheduled.slim requires @schedules to be items only.

My change results in paginated items as {:score.0 => item.0, :score.1 => item.1, etc..}.  This fixes the scheduled tab on the Web UI.  AFAIK this is good to go with no side effects.
