### PR TITLE
Stop Airbrake notifications of ignored exceptions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 - Upgrade Twitter Bootstrap to 2.1.0
 - Rescue more Exceptions
 - Change Job ID to be Hex, rather than Base64, for HTTP safety
+- Use `Airbrake#notify_or_ignore`
 
 2.2.1
 -----------

--- a/lib/sidekiq/exception_handler.rb
+++ b/lib/sidekiq/exception_handler.rb
@@ -13,7 +13,7 @@ module Sidekiq
     private
 
     def send_to_airbrake(msg, ex)
-      ::Airbrake.notify(ex, :parameters => msg)
+      ::Airbrake.notify_or_ignore(ex, :parameters => msg)
     end
 
     def send_to_exceptional(msg, ex)

--- a/test/test_exception_handler.rb
+++ b/test/test_exception_handler.rb
@@ -49,7 +49,7 @@ class TestExceptionHandler < MiniTest::Unit::TestCase
     end
 
     it "notifies Airbrake" do
-      ::Airbrake.expect(:notify,nil,[TEST_EXCEPTION,:parameters => { :a => 1 }])
+      ::Airbrake.expect(:notify_or_ignore,nil,[TEST_EXCEPTION,:parameters => { :a => 1 }])
       Component.new.invoke_exception(:a => 1)
       ::Airbrake.verify
     end


### PR DESCRIPTION
Fixes [this Airbrake issue](https://github.com/airbrake/airbrake/issues/117) wherein exceptions ignored in Airbrake configuration still generate notifications.
