### PR TITLE
New PermanentError does not get retried

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -5,6 +5,7 @@ require 'sidekiq/worker'
 require 'sidekiq/redis_connection'
 require 'sidekiq/util'
 require 'sidekiq/stats'
+require 'sidekiq/permanent_error'
 
 require 'sidekiq/extensions/class_methods'
 require 'sidekiq/extensions/action_mailer'

--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -60,7 +60,9 @@ module Sidekiq
             msg['error_backtrace'] = e.backtrace[0..msg['backtrace'].to_i]
           end
 
-          if count <= MAX_COUNT
+          if e.is_a?(Sidekiq::PermanentError)
+            logger.debug { "Dropping message because of an error that will not go away" }
+          elsif count <= MAX_COUNT
             delay = DELAY.call(count)
             logger.debug { "Failure! Retry #{count} in #{delay} seconds" }
             retry_at = Time.now.to_f + delay

--- a/lib/sidekiq/permanent_error.rb
+++ b/lib/sidekiq/permanent_error.rb
@@ -1,0 +1,3 @@
+class Sidekiq::PermanentError < RuntimeError
+  
+end


### PR DESCRIPTION
Sometime a worker might encounter a condition where it is always going to fail because it received bad parameters or similar in the first place.
For example, when interacting with an external API, a token might be invalid. Generally, the developer still wants an exception to be logged versus a silent failure via a return so now they can raise PermanentError when they encounter OAuth::Unauthorized or similar.
This fixes two problems:
1. A waste of limited API calls
2. My airbrake etc from getting filled with repetitive errors that are not going to fix themselves.
