### PR TITLE
Fix retry default

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -118,12 +118,12 @@ module Sidekiq
       raise(ArgumentError, "Message must include a class and set of arguments: #{item.inspect}") if !item['class'] || !item['args']
       raise(ArgumentError, "Message must include a Sidekiq::Worker class, not class name: #{item['class'].ancestors.inspect}") if !item['class'].is_a?(Class) || !item['class'].respond_to?('get_sidekiq_options')
 
-      normalized_item = item.dup
+      normalized_item = item['class'].get_sidekiq_options.merge(item.dup)
       normalized_item['class'] = normalized_item['class'].to_s
       normalized_item['retry'] = !!normalized_item['retry']
       normalized_item['jid'] = SecureRandom.hex(12)
 
-      item['class'].get_sidekiq_options.merge normalized_item
+      normalized_item
     end
 
   end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -144,4 +144,9 @@ class TestClient < MiniTest::Unit::TestCase
     end
   end
 
+  describe 'item normalization' do
+    it 'defaults retry to true' do
+      assert_equal true, Sidekiq::Client.normalize_item('class' => QueuedWorker, 'args' => [])['retry']
+    end
+  end
 end


### PR DESCRIPTION
92bec164beeb05aa3530e4ef2a337436a00fbda6 changed the item normalization behavior to overwrite the `retry` default of `true` with `!!nil`. This patch fixes the regression.
