### PR TITLE
thread.backtrace is sometimes nil

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -18,7 +18,11 @@ end
 trap 'TTIN' do
   Thread.list.each do |thread|
     Sidekiq.logger.info "Thread TID-#{thread.object_id.to_s(36)} #{thread['label']}"
-    Sidekiq.logger.info thread.backtrace.join("\n")
+    if thread.backtrace
+      Sidekiq.logger.info thread.backtrace.join("\n")
+    else
+      Sidekiq.logger.info "<no backtrace available>"
+    end
   end
 end
 


### PR DESCRIPTION
Seen on production after sending TTIN to sidekiq:

```
2012-09-24T17:23:22Z 11643 TID-4ttyo INFO: Thread TID-oqy30x3i4 
undefined method `join' for nil:NilClass
/mnt/app/verba_compete_production/shared/bundle/ruby/1.9.1/gems/sidekiq-2.3.2/lib/sidekiq/cli.rb:21:in `block (2 levels) in <top (required)>'
/mnt/app/verba_compete_production/shared/bundle/ruby/1.9.1/gems/sidekiq-2.3.2/lib/sidekiq/cli.rb:19:in `each'
/mnt/app/verba_compete_production/shared/bundle/ruby/1.9.1/gems/sidekiq-2.3.2/lib/sidekiq/cli.rb:19:in `block in <top (required)>'
/mnt/app/verba_compete_production/shared/bundle/ruby/1.9.1/gems/sidekiq-2.3.2/lib/sidekiq/cli.rb:79:in `call'
/mnt/app/verba_compete_production/shared/bundle/ruby/1.9.1/gems/sidekiq-2.3.2/lib/sidekiq/cli.rb:79:in `sleep'
/mnt/app/verba_compete_production/shared/bundle/ruby/1.9.1/gems/sidekiq-2.3.2/lib/sidekiq/cli.rb:79:in `run'
/mnt/app/verba_compete_production/shared/bundle/ruby/1.9.1/gems/sidekiq-2.3.2/bin/sidekiq:8:in `<top (required)>'
/mnt/app/verba_compete_production/shared/bundle/ruby/1.9.1/bin/sidekiq:19:in `load'
/mnt/app/verba_compete_production/shared/bundle/ruby/1.9.1/bin/sidekiq:19:in `<main>'
```

After which sidekiq exited.
