### PR TITLE
Allow setting sidekiq's redis to an existing Redis or Redis::Namespace object

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -71,8 +71,10 @@ module Sidekiq
       @redis = RedisConnection.create(hash)
     elsif hash.is_a?(ConnectionPool)
       @redis = hash
+    elsif hash.is_a?(Redis) || hash.is_a?(Redis::Namespace)
+      @redis = hash
     else
-      raise ArgumentError, "redis= requires a Hash or ConnectionPool"
+      raise ArgumentError, "redis= requires a Hash, ConnectionPool, Redis or Redis::Namespace object"
     end
   end
 


### PR DESCRIPTION
Sometimes you already have a constructed, configured instance of `Redis` or `Redis::Namespace` around in your app. It would be great to be able to set Sidekiq's redis to use your existing object.

This pull request allows you to do just this.

Eg:

```
my_redis = Redis.connect(...)

Sidekiq.configure_server do |config|
  config.redis = my_redis
end
```
