### PR TITLE
Stringify Extensions::Proxy options

### DIFF
--- a/lib/sidekiq/extensions/generic_proxy.rb
+++ b/lib/sidekiq/extensions/generic_proxy.rb
@@ -4,7 +4,7 @@ module Sidekiq
       def initialize(performable, target, options={})
         @performable = performable
         @target = target
-        @opts = performable.stringify_keys(options)
+        @opts = options
       end
 
       def method_missing(name, *args)

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -68,8 +68,8 @@ module Sidekiq
         hash
       end
 
-      def client_push(*args) # :nodoc:
-        Sidekiq::Client.push(*args)
+      def client_push(item) # :nodoc:
+        Sidekiq::Client.push(stringify_keys(item))
       end
 
     end


### PR DESCRIPTION
Passing options as feels natural, using symbol keys, doesn't currently work as expected. The keys need to be stringified.
