### PR TITLE
Add Bignum to the list of classes which cannot be duped.

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -95,7 +95,7 @@ module Sidekiq
     end
 
     # Singleton classes are not clonable.
-    SINGLETON_CLASSES = [ NilClass, TrueClass, FalseClass, Symbol, Fixnum, Float ].freeze
+    SINGLETON_CLASSES = [ NilClass, TrueClass, FalseClass, Symbol, Fixnum, Float, Bignum ].freeze
 
     # Clone the arguments passed to the worker so that if
     # the message fails, what is pushed back onto Redis hasn't


### PR DESCRIPTION
When trying to process an argument that's a Bignum, you can get a "TypeError: allocator undefined for Bignum" exception.

Perhaps it would be better to map over the arguments and just capture the exception if the arg can't be duped?
