### PR TITLE
Added option in views to expand the description past the limit

### DIFF
--- a/web/views/_workers.slim
+++ b/web/views/_workers.slim
@@ -5,10 +5,16 @@ table class="table table-striped table-bordered workers"
     th Class
     th Arguments
     th Started
-  - workers.each do |(worker, msg)|
+  - workers.each_with_index do |(worker, msg), index|
     tr
       td= worker
       td= msg['queue']
       td= msg['payload']['class']
-      td= msg['payload']['args'].inspect[0..100]
+      td
+        - if msg['payload']['args'].to_s.size > 100
+          = msg['payload']['args'].inspect[0..100] + "... "
+          button data-toggle="collapse" data-target="#worker_#{index}" class="btn btn-mini" Show All
+          .collapse[id="worker_#{index}" style="max-width: 750px;"]= msg['payload']['args']
+        - else
+          = msg['payload']['args']
       td== relative_time(msg['run_at'].is_a?(Numeric) ? Time.at(msg['run_at']) : Time.parse(msg['run_at']))

--- a/web/views/queue.slim
+++ b/web/views/queue.slim
@@ -7,9 +7,15 @@ table class="table table-striped table-bordered"
   tr
     th Class
     th Arguments
-  - @messages.each do |msg|
+  - @messages.each_with_index do |msg, index|
     tr
       td= msg['class']
-      td= msg['args'].inspect[0..100]
+      td
+        - if msg['args'] and msg['args'].to_s.size > 100
+          = msg['args'].inspect[0..100] + "... "
+          button data-toggle="collapse" data-target="#worker_#{index}" class="btn btn-mini" Show All
+          .collapse[id="worker_#{index}"]= msg['args']
+        - else
+          = msg['args']
 
 == slim :_paging, :locals => { :url => "#{root_path}queues/#{@name}" }


### PR DESCRIPTION
Currently the description in the worker summary and queue page is truncated at 100 chars. This looks good but limits the usefulness of the interface. Allow the description of a job to be expanded with a click.  This uses javascript in bootstrap, so no extra js is needed.
