### PR TITLE
Accept queue names containing dots through the CLI

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -149,7 +149,7 @@ module Sidekiq
 
       @parser = OptionParser.new do |o|
         o.on "-q", "--queue QUEUE[,WEIGHT]...", "Queues to process with optional weights" do |arg|
-          queues_and_weights = arg.scan(/([\w-]+),?(\d*)/)
+          queues_and_weights = arg.scan(/([\w\.-]+),?(\d*)/)
           queues_and_weights.each {|queue_and_weight| parse_queues(opts, *queue_and_weight)}
           opts[:strict] = queues_and_weights.collect(&:last).none? {|weight| weight != ''}
         end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -70,6 +70,11 @@ class TestCli < MiniTest::Unit::TestCase
       assert_equal %w(queue_one queue-two), Sidekiq.options[:queues]
     end
 
+    it 'handles queues with dots in the name' do
+      @cli.parse(['sidekiq', '-q', 'foo.bar', '-r', './test/fake_env.rb'])
+      assert_equal ['foo.bar'], Sidekiq.options[:queues]
+    end
+
     it 'sets verbose' do
       old = Sidekiq.logger.level
       @cli.parse(['sidekiq', '-v', '-r', './test/fake_env.rb'])


### PR DESCRIPTION
I have a bunch of resque queues with dots in their names, like `foo.bar`, that I would like to start processing with sidekiq instead. Currently, the CLI parses this as two queues, `foo` and `bar`, which is not what I would expect. This commit updates the CLI to allow dot names in the queues.

Here is an example of what happens when I attempt to run sidekiq on an existing resque queue:

```
$ bx sidekiq -q 'photo.processing.imports' -v
2012-10-25T19:42:28Z 21567 TID-ox6784ijg INFO: Booting Sidekiq 2.3.3 with Redis at redis://127.0.0.1:6379/0
2012-10-25T19:42:28Z 21567 TID-ox6784ijg INFO: Running in ruby 1.9.3p194 (2012-04-20 revision 35410) [x86_64-darwin12.0.0]
2012-10-25T19:42:28Z 21567 TID-ox6784ijg INFO: See LICENSE and the LGPL-3.0 for licensing details.
2012-10-25T19:42:29Z 21567 TID-ox67rv250 DEBUG: {:queues=>["photo", "processing", "imports"], :concurrency=>25, :require=>".", :environment=>"development", :timeout=>8, :strict=>true}

[no jobs processed]
```

Here is what I would prefer to happen:

```
$ bx sidekiq -q 'photo.processing.imports' -v
2012-10-25T19:45:30Z 21692 TID-owik184ps INFO: Booting Sidekiq 2.4.0 with Redis at redis://127.0.0.1:6379/0
2012-10-25T19:45:30Z 21692 TID-owik184ps INFO: Running in ruby 1.9.3p194 (2012-04-20 revision 35410) [x86_64-darwin12.0.0]
2012-10-25T19:45:30Z 21692 TID-owik184ps INFO: See LICENSE and the LGPL-3.0 for licensing details.
2012-10-25T19:45:30Z 21692 TID-owikgy934 DEBUG: {:queues=>["photo.processing.imports"], :concurrency=>25, :require=>".", :environment=>"development", :timeout=>8, :strict=>true}

[many jobs processed]
```
