### PR TITLE
Require latest version of Sass to fix compilation issues

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency                  'celluloid', '~> 0.12.0'
   gem.add_dependency                  'multi_json', '~> 1'
   gem.add_dependency                  'sprockets-sass'
-  gem.add_dependency                  'sass', '~> 3.2.1'
+  gem.add_dependency                  'sass', '~> 3.2'
   gem.add_dependency                  'compass'
   gem.add_development_dependency      'minitest', '~> 3'
   gem.add_development_dependency      'sinatra'


### PR DESCRIPTION
Fixes #481 for me.

The new Sidekiq UI seems to require a modern version of the sass gem. In my case it wouldn't compile using sass 3.1.20. Bumping sass to 3.2.1 fixed the problem. 3.2.1 bundles fine with sass-rails.
