### PR TITLE
Added a splay to the delay time for retried jobs. [Fixes #480]

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -43,7 +43,7 @@ module Sidekiq
 
         # delayed_job uses the same basic formula
         DEFAULT_MAX_RETRY_ATTEMPTS = 25
-        DELAY = proc { |count| (count ** 4) + 15 }
+        DELAY = proc { |count| (count ** 4) + 15 + (rand(30)*(count+1)) }
 
         def call(worker, msg, queue)
           yield


### PR DESCRIPTION
The amount of splay increases as the number of failures increases. The maximum amount of splay is equal to 30 \* (the number of times the job has failed, plus 1). For the default max retries setting, the maximum splay would be 780 seconds.
