### PR TITLE
USR2 Signal

### DIFF
--- a/bin/sidekiqctl
+++ b/bin/sidekiqctl
@@ -43,6 +43,10 @@ class Sidekiqctl
     `kill -USR1 #{pid}`
   end
 
+  def sleep
+    `kill -USR2 #{pid}`
+  end
+
   def stop
     `kill -TERM #{pid}`
     timeout.times do

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -15,6 +15,12 @@ trap 'USR1' do
   mgr.stop! if mgr
 end
 
+trap 'USR2' do
+  Sidekiq.logger.info "Received USR2. Only stopping Fetcher. Current workers will show up in the UI until finished."
+  mgr = Sidekiq::CLI.instance.manager
+  mgr.sleep if mgr
+end
+
 trap 'TTIN' do
   Thread.list.each do |thread|
     Sidekiq.logger.info "Thread TID-#{thread.object_id.to_s(36)} #{thread['label']}"


### PR DESCRIPTION
Currently, when a USR1 signal is sent, the current jobs are allowed finish but there is no indication in the UI as to when those jobs are actually finished.  The workers in the UI disappear.

I am introducing a USR2 signal call that will only stop the Fetcher, but not the workers.  The workers will finish their current jobs and not get any new jobs.  

It would be up to the end user to properly send another signal (or use capistrano after they have verified that all of the jobs have finished) 
