### PR TITLE
Ensure that all jobs are drained

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -93,8 +93,9 @@ module Sidekiq
 
       # Drain all queued jobs across all workers
       def drain_all
-        jobs.keys.each(&:drain)
-        clear_all
+        until jobs.values.all?(&:empty?) do
+          jobs.keys.each(&:drain)
+        end
       end
     end
   end


### PR DESCRIPTION
Hi Mike,

When a job create new worker new created jobs aren't drained.

This PR fixes that, i hope you'll find it useful.

Thanks for this gem!
