### PR TITLE
examples/sinkiq.rb: uninitialized constant Sidekiq::Stats

### DIFF
--- a/examples/sinkiq.rb
+++ b/examples/sinkiq.rb
@@ -19,8 +19,8 @@ class SinatraWorker
 end
 
 get '/' do
-  @failed = Sidekiq::Stats.failed
-  @processed = Sidekiq::Stats.processed
+  @failed = Sidekiq.info[:failed]
+  @processed = Sidekiq.info[:processed]
   @messages = $redis.lrange('sinkiq-example-messages', 0, -1)
   erb :index
 end


### PR DESCRIPTION
I tried to run the sinkiq.rb example and noticed that it was failing when trying to retrieve stats. This is a small patch to update the example. Thanks!
