### PR TITLE
Use regular object for exception data

### DIFF
--- a/test/test_exception_handler.rb
+++ b/test/test_exception_handler.rb
@@ -115,7 +115,7 @@ class TestExceptionHandler < MiniTest::Unit::TestCase
 
     it "notifies Exceptional" do
       ::Exceptional::Config.expect(:should_send_to_api?,true)
-      exception_data = MiniTest::Mock.new
+      exception_data = Object.new
       ::Exceptional::Remote.expect(:error,nil,[exception_data])
       ::Exceptional::ExceptionData.expect(:new,exception_data,[TEST_EXCEPTION])
       Component.new.invoke_exception(:c => 3)


### PR DESCRIPTION
This test doesn't assert anything about the test data itself. Therefore
using a regular object is fine.

This also fixes the build for Rubinius. The problem is that a minitest
mock object removes all kinds of methods that should be there. Since
exception_data is for example used in an array later on, it should
respond to methods like equal? and == in order to be able to behave
properly in an array.

In MRI you can get away with this, because once you go into C land, you
don't go back to Ruby until you're done. This means you can remove
methods that data structures normally depend on without MRI breaking.
