### PR TITLE
Fix retry on normalize_item method

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -126,7 +126,7 @@ module Sidekiq
 
       normalized_item = item['class'].get_sidekiq_options.merge(item.dup)
       normalized_item['class'] = normalized_item['class'].to_s
-      normalized_item['retry'] = !!normalized_item['retry']
+      normalized_item['retry'] = !!normalized_item['retry'] unless normalized_item['retry'].is_a?(Fixnum)
       normalized_item['jid'] = SecureRandom.hex(12)
 
       normalized_item

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -116,6 +116,9 @@ class TestClient < MiniTest::Unit::TestCase
   class BWorker < BaseWorker
     sidekiq_options 'retry' => 'b'
   end
+  class CWorker < BaseWorker
+    sidekiq_options 'retry' => 2
+  end
 
   describe 'client middleware' do
 
@@ -147,6 +150,10 @@ class TestClient < MiniTest::Unit::TestCase
   describe 'item normalization' do
     it 'defaults retry to true' do
       assert_equal true, Sidekiq::Client.normalize_item('class' => QueuedWorker, 'args' => [])['retry']
+    end
+
+    it 'should not normalize numeric retry\'s' do
+      assert_equal 2, Sidekiq::Client.normalize_item('class' => CWorker, 'args' => [])['retry']
     end
   end
 end


### PR DESCRIPTION
Allow numeric values on retry option
