### PR TITLE
Allow other fields that specify recipients, not just "to"

### DIFF
--- a/lib/sidekiq/extensions/action_mailer.rb
+++ b/lib/sidekiq/extensions/action_mailer.rb
@@ -19,7 +19,7 @@ module Sidekiq
         msg = target.send(method_name, *args)
         # The email method can return nil, which causes ActionMailer to return
         # an undeliverable empty message.
-        msg.deliver if msg && msg.to && msg.from
+        msg.deliver if msg && (msg.to || msg.cc || msg.bcc) && msg.from
       end
     end
 


### PR DESCRIPTION
We had some code that BCCs everyone instead of putting them in the "to:" field. The ActionMailer extension won't actually call the deliver method though unless "to" is specified. This fixes it so that any of the recipient-specifying methods should be delivered.
