### PR TITLE
Dry up push_bulk

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -57,6 +57,10 @@ module Sidekiq
     # Returns the number of jobs pushed or nil if the pushed failed.  The number of jobs
     # pushed can be less than the number given if the middleware stopped processing for one
     # or more jobs.
+    #
+    # Example:
+    #   Sidekiq::Client.push_bulk('queue' => 'my_queue', 'class' => MyWorker, 'args' => [['foo', 1, :bat => 'bar'],['bar', 2, :bat => 'foo']])
+    #
     def self.push_bulk(items)
       normed = normalize_item(items)
 


### PR DESCRIPTION
Just a small change to de-dupe the `raw_push` functionality.
#### Reasoning

RPUSH will accept multiple, so why not have both use `raw_push`
#### Side-effects of `push_bulk` and `push` using the same `raw_push`
-  `normed['at']` when using `push_bulk` would schedule all of the jobs at the same time,  is this a desired functionality to allow?
