### PR TITLE
Run .push_bulk calls inline in inline testing mode

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -65,13 +65,7 @@ module Sidekiq
       end.compact
 
       pushed = false
-      Sidekiq.redis do |conn|
-        _, pushed = conn.multi do
-          conn.sadd('queues', normed['queue'])
-          conn.rpush("queue:#{normed['queue']}", payloads)
-        end
-      end
-
+      pushed = raw_push(normed, payloads)
       pushed ? payloads.size : nil
     end
 

--- a/lib/sidekiq/testing/inline.rb
+++ b/lib/sidekiq/testing/inline.rb
@@ -28,8 +28,11 @@ module Sidekiq
     #
     singleton_class.class_eval do
       alias_method :raw_push_old, :raw_push
-      def raw_push(hash, _)
-        hash['class'].constantize.new.perform(*Sidekiq.load_json(Sidekiq.dump_json(hash['args'])))
+      def raw_push(normed, payload)
+        Array.wrap(payload).each do |hash|
+          normed['class'].constantize.new.perform(*Sidekiq.load_json(hash)['args'])
+        end
+
         true
       end
     end

--- a/test/test_testing_inline.rb
+++ b/test/test_testing_inline.rb
@@ -80,6 +80,14 @@ class TestInline < MiniTest::Unit::TestCase
       end
     end
 
+    it 'stubs the push_bulk call when in testing mode' do
+      assert Sidekiq::Client.push_bulk({'class' => InlineWorker, 'args' => [true, true]})
+
+      assert_raises InlineError do
+        Sidekiq::Client.push_bulk({'class' => InlineWorker, 'args' => [true, false]})
+      end
+    end
+
     it 'should relay parameters through json' do
       assert Sidekiq::Client.enqueue(InlineWorkerWithTimeParam, Time.now)
     end


### PR DESCRIPTION
`.push_bulk` uses essentially the same process as `.raw_push` to push jobs onto the queue, so we can have it call `.raw_push`, which makes it easy to handle `.push_bulk` calls in inline testing mode.
