### PR TITLE
Support scheduled jobs in bulk push

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -92,7 +92,9 @@ module Sidekiq
     def self.raw_push(normed, payload) # :nodoc:
       pushed = false
       Sidekiq.redis do |conn|
-        if normed['at']
+        if normed['at'] && payload.is_a?(Array)
+          pushed = conn.zadd('schedule', payload.map {|hash| [normed['at'].to_s, hash]})
+        elsif normed['at']
           pushed = conn.zadd('schedule', normed['at'].to_s, payload)
         else
           _, pushed = conn.multi do

--- a/test/test_scheduling.rb
+++ b/test/test_scheduling.rb
@@ -28,6 +28,12 @@ class TestScheduling < MiniTest::Unit::TestCase
       assert ScheduledWorker.perform_in(5.days.from_now, 'mike')
       @redis.verify
     end
+
+    it 'schedules multiple jobs at once' do
+      @redis.expect :zadd, true, ['schedule', Array]
+      assert Sidekiq::Client.push_bulk('class' => ScheduledWorker, 'args' => ['mike', 'mike'], 'at' => 600)
+      @redis.verify
+    end
   end
 
 end


### PR DESCRIPTION
`ZADD` supports adding multiple elements at once so we can schedule jobs via the bulk push mechanism
