### PR TITLE
Add "Delete All" button to Retries in Web UI

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ HEAD
   Sidekiq client does not have to load your worker classes at all.  [#524]
 - `Sidekiq::Client.push_bulk` now works with inline testing.
 - **Really** fix status icon in Web UI this time.
+- Add "Delete All" and "Retry All" buttons to Retries in Web UI
 
 
 2.5.3

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -43,6 +43,15 @@ module Sidekiq
         end
       end
     end
+
+    def clear
+      Sidekiq.redis do |conn|
+        conn.multi do
+          conn.del("queue:#{name}")
+          conn.srem("queues", name)
+        end
+      end
+    end
   end
 
   ##
@@ -142,6 +151,12 @@ module Sidekiq
         conn.zremrangebyscore(@zset, score, score)
       end
       count != 0
+    end
+
+    def clear
+      Sidekiq.redis do |conn|
+        conn.del(@zset)
+      end
     end
   end
 

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -72,9 +72,10 @@ class TestWeb < MiniTest::Unit::TestCase
 
       Sidekiq.redis do |conn|
         refute conn.smembers('queues').include?('foo')
+        refute conn.exists('queues:foo')
       end
     end
-    
+
     it 'can delete a job' do
       Sidekiq.redis do |conn|
         conn.rpush('queue:foo', "{}")
@@ -154,12 +155,35 @@ class TestWeb < MiniTest::Unit::TestCase
       refute_match /#{score}/, last_response.body
     end
 
+    it 'can delete all retries' do
+      3.times { add_retry }
+
+      post "/retries/all/delete", 'delete' => 'Delete'
+      assert_equal 0, Sidekiq::RetrySet.new.size
+      assert_equal 302, last_response.status
+      assert_equal 'http://example.org/retries', last_response.header['Location']
+    end
+
     it 'can retry a single retry now' do
       msg, score = add_retry
 
       post "/retries/#{score}", 'retry' => 'Retry'
       assert_equal 302, last_response.status
       assert_equal 'http://example.org/retries', last_response.header['Location']
+
+      get '/queues/default'
+      assert_equal 200, last_response.status
+      assert_match /#{msg['args'][2]}/, last_response.body
+    end
+
+    it 'can retry all retries' do
+      msg, score = add_retry
+      add_retry
+
+      post "/retries/all/retry", 'retry' => 'Retry'
+      assert_equal 302, last_response.status
+      assert_equal 'http://example.org/retries', last_response.header['Location']
+      assert_equal 2, Sidekiq::Queue.new("default").size
 
       get '/queues/default'
       assert_equal 200, last_response.status

--- a/web/views/retries.slim
+++ b/web/views/retries.slim
@@ -28,7 +28,13 @@ header.row
             a href="#{root_path}queues/#{msg['queue']}" #{msg['queue']}
           td= msg['class']
           td= display_args(msg['args'])
-    input.btn.btn-danger.btn-small.pull-right type="submit" name="delete" value="Delete"
-    input.btn.btn-primary.btn-small.pull-right type="submit" name="retry" value="Retry Now" 
+    input.btn.btn-primary.btn-small.pull-left type="submit" name="retry" value="Retry Now"
+    input.btn.btn-danger.btn-small.pull-left type="submit" name="delete" value="Delete"
+
+  form action="#{root_path}retries/all/delete" method="post"
+    input.btn.btn-danger.btn-small.pull-right type="submit" name="delete" value="Delete All" data-confirm="Are you sure?"
+  form action="#{root_path}retries/all/retry" method="post"
+    input.btn.btn-danger.btn-small.pull-right type="submit" name="retry" value="Retry All" data-confirm="Are you sure?"
+
 - else
   .alert.alert-success No retries were found


### PR DESCRIPTION
Added "Delete All" button that leverages the API to clear jobs.

![dl](http://f.cl.ly/items/3R163Y410k2s2q1p0q3e/Screen%20Shot%202012-11-25%20at%209.36.53%20PM.png)

![dl](http://f.cl.ly/items/472i2j1Q2x0M1o20253Y/Screen%20Shot%202012-11-25%20at%209.37.06%20PM.png)

![dl](http://f.cl.ly/items/2T0r3y0d3w1B0j2y0W3r/Screen%20Shot%202012-11-25%20at%209.37.13%20PM.png)
