### PR TITLE
Minimize font in summary section to not line break on 9 digits in FF.

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -216,12 +216,12 @@ header.row .pagination {
   padding: 4px 0 2px 0;
 }
 .summary_bar ul .desc {
-  font-size: 1.1em;
+  font-size: 1em;
   font-weight: normal;
 }
 .summary_bar ul .count {
   color: #b1003e;
-  font-size: 1.1em;
+  font-size: 1em;
   font-weight: bold;
   float: right;
 }


### PR DESCRIPTION
Fixes #544.

![dl](http://f.cl.ly/items/013a2R2c392y1U0p3L1h/Screen%20Shot%202012-11-26%20at%204.03.51%20PM.png)
