### PR TITLE
Fixes error "undefined method `blank?' for "":String "

### DIFF
--- a/web/views/_nav.slim
+++ b/web/views/_nav.slim
@@ -9,7 +9,7 @@
     div.nav-collapse
       ul.nav
         - tabs.each do |title, url|
-          - if url !~ /[^[:space:]]/
+          - if url != ''
             li class="#{(current_path == url) ? 'active':''}"
               a href='#{{root_path}}#{{url}}' #{title}
           - else


### PR DESCRIPTION
String.blank? is not necessarily available when using this gem (it comes from ActiveSupport).
