### PR TITLE
Fixes active tab logic without using blank?

### DIFF
--- a/web/views/_nav.slim
+++ b/web/views/_nav.slim
@@ -9,7 +9,7 @@
     div.nav-collapse
       ul.nav
         - tabs.each do |title, url|
-          - if url != ''
+          - if url == ''
             li class="#{(current_path == url) ? 'active':''}"
               a href='#{{root_path}}#{{url}}' #{title}
           - else


### PR DESCRIPTION
This line should be equivalent to url.blank?

As per comments on issue #548
