### PR TITLE
Capistrano integration: Make sidekiq command configurable

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -4,6 +4,8 @@ Capistrano::Configuration.instance.load do
   after "deploy:start",   "sidekiq:start"
   after "deploy:restart", "sidekiq:restart"
 
+  _cset(:sidekiq_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" }
+  _cset(:sidekiqctl_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" }
   _cset(:sidekiq_timeout)   { 10 }
   _cset(:sidekiq_role)      { :app }
   _cset(:sidekiq_pid)       { "#{current_path}/tmp/pids/sidekiq.pid" }
@@ -19,14 +21,14 @@ Capistrano::Configuration.instance.load do
     desc "Quiet sidekiq (stop accepting new work)"
     task :quiet, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
       for_each_process do |pid_file|
-        run "if [ -d #{current_path} ] && [ -f #{pid_file} ]; then cd #{current_path} && #{fetch(:bundle_cmd, "bundle")} exec sidekiqctl quiet #{pid_file} ; fi"
+        run "if [ -d #{current_path} ] && [ -f #{pid_file} ]; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} quiet #{pid_file} ; fi"
       end
     end
 
     desc "Stop sidekiq"
     task :stop, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
       for_each_process do |pid_file|
-        run "if [ -d #{current_path} ] && [ -f #{pid_file} ]; then cd #{current_path} && #{fetch(:bundle_cmd, "bundle")} exec sidekiqctl stop #{pid_file} #{fetch :sidekiq_timeout} ; fi"
+        run "if [ -d #{current_path} ] && [ -f #{pid_file} ]; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} stop #{pid_file} #{fetch :sidekiq_timeout} ; fi"
       end
     end
 
@@ -34,7 +36,7 @@ Capistrano::Configuration.instance.load do
     task :start, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
       rails_env = fetch(:rails_env, "production")
       for_each_process do |pid_file|
-        run "cd #{current_path} ; nohup #{fetch(:bundle_cmd, "bundle")} exec sidekiq -e #{rails_env} -C #{current_path}/config/sidekiq.yml -P #{pid_file} >> #{current_path}/log/sidekiq.log 2>&1 &", :pty => false
+        run "cd #{current_path} ; nohup #{fetch(:sidekiq_cmd)} -e #{rails_env} -C #{current_path}/config/sidekiq.yml -P #{pid_file} >> #{current_path}/log/sidekiq.log 2>&1 &", :pty => false
       end
     end
 


### PR DESCRIPTION
This patch allows users to configure which sidekiq executable to use during Capistrano deployments.

This is useful if you want to use some other executable than `bundle exec sidekiq`, e.g. when using Bundler's binstubs.
#### Usage:

``` ruby
# in config/deploy.rb
set :sidekiq_cmd, './bin/sidekiq'
set :sidekiqcli_cmd, './bin/sidekiqcli'
```
