### PR TITLE
Add system view

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -219,12 +219,23 @@ module Sidekiq
       redirect "#{root_path}scheduled"
     end
 
+    get '/system' do
+      @redis_keys, @redis_info =  Sidekiq.redis do |conn|
+                        conn.pipelined do
+                          conn.keys
+                          conn.info
+                        end
+                      end
+      slim :system
+    end
+
     def self.tabs
       @tabs ||= {
         "Workers"   =>'',
         "Queues"    =>'queues',
         "Retries"   =>'retries',
-        "Scheduled" =>'scheduled'
+        "Scheduled" =>'scheduled',
+        "System"    =>'system'
       }
     end
 

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -203,6 +203,18 @@ class TestWeb < MiniTest::Unit::TestCase
       end
     end
 
+    describe "system view" do
+      it 'loads successfully' do
+        get '/system'
+        assert_equal 200, last_response.status
+      end
+
+      it  'displays redis version' do
+        get '/system'
+        assert_match /redis_version/, last_response.body
+      end
+    end
+
     def add_scheduled
       score = Time.now.to_f
       msg = { 'class' => 'HardWorker',

--- a/web/views/system.slim
+++ b/web/views/system.slim
@@ -1,0 +1,19 @@
+h3 System
+
+h4 Redis Info
+table class="queues table table-hover table-bordered table-striped table-white"
+  thead
+    th Key
+    th Value
+  - @redis_info.each do |key, value|
+    tr
+      td= key
+      td= value
+
+h4 Redis Keys
+table class="queues table table-hover table-bordered table-striped table-white"
+  thead
+    th Key
+  - @redis_keys.each do |key|
+    tr
+      td= key


### PR DESCRIPTION
System view showing Redis keys, along with the dump from `Redis.info`

![system](http://f.cl.ly/items/1T2m2G0n3X3N2I1v1x0y/Screen%20Shot%202012-12-04%20at%202.31.24%20PM.png)

It loads fine in the browser, however the related tests like the following:

``` Ruby
    describe "system view" do
      it 'loads successfully' do
        get '/system'
        assert_equal 200, last_response.status
      end
```

throw this error:

```
  1) Error:
test_0001_loads successfully(sidekiq web::system view):
NoMethodError: undefined method `to_s' for <Redis::Future [:keys, "testy:*"]>:Redis::Future
    /Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/redis-namespace-1.2.1/lib/redis/namespace.rb:293:in `rem_namespace'
    /Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/redis-namespace-1.2.1/lib/redis/namespace.rb:262:in `method_missing'
    /Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/redis-namespace-1.2.1/lib/redis/namespace.rb:210:in `keys'
    /Users/bhilkert/Dropbox/code/sidekiq/lib/sidekiq/web.rb:225:in `block (3 levels) in <class:Web>'
    /Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/redis-3.0.2/lib/redis.rb:1973:in `block in pipelined'
    /Users/bhilkert/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/redis-3.0.2/lib/redis.rb:36:in `block in synchronize'
```

Any idea what this is about?
