### PR TITLE
Prevent capistrano from running sidekiq start twice

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -2,7 +2,6 @@ Capistrano::Configuration.instance.load do
   before "deploy:update_code", "sidekiq:quiet"
   after "deploy:stop",    "sidekiq:stop"
   after "deploy:start",   "sidekiq:start"
-  after "deploy:restart", "sidekiq:restart"
 
   _cset(:sidekiq_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" }
   _cset(:sidekiqctl_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" }


### PR DESCRIPTION
It appears that sidekiq is starting up 2 processes during deployment.
1. during the callback for deploy:start (executes sidekiq.start)
2. during the callback for deploy:restart (executes sidekiq:restart)

I believe the first sidekiq:start is still starting up when the sidekiq:restart gets called. By the time restart  command happens, there's no sidekiq.pid file available yet, so it starts up a new sidekiq process. 

```
** transaction: commit
  * executing `deploy:restart'
  * executing `deploy:stop'
    triggering after callbacks for `deploy:stop'
  * executing `sidekiq:stop'
  * executing "if [ -d /var/apps/XXX/current ] && [ -f /var/apps/XXX/current/tmp/pids/sidekiq.pid ]; then cd /var/apps/XXX/current && bundle exec sidekiqctl stop /var/apps/XXX/current/tmp/pids/sidekiq.pid 60 ; fi"
    servers: ["worker1"]
    [worker1] executing command
 ** [out :: worker1] Sidekiq shut down gracefully.
    command finished in 10660ms
  * executing `deploy:start'
    triggering after callbacks for `deploy:start'
  * executing `sidekiq:start'
  * executing "cd /var/apps/XXX/current ; nohup bundle exec sidekiq -e qa -C /var/apps/XXX/current/config/sidekiq.yml -P /var/apps/XXX/current/tmp/pids/sidekiq.pid >> /var/apps/XXX/current/log/sidekiq.log 2>&1 &"
    servers: ["worker1"]
    [worker1] executing command
    command finished in 767ms
    triggering after callbacks for `deploy:restart'
  * executing `sidekiq:restart'
  * executing `sidekiq:stop'
  * executing "if [ -d /var/apps/XXX/current ] && [ -f /var/apps/XXX/current/tmp/pids/sidekiq.pid ]; then cd /var/apps/XXX/current && bundle exec sidekiqctl stop /var/apps/XXX/current/tmp/pids/sidekiq.pid 60 ; fi"
    servers: ["worker1"]
    [worker1] executing command
    command finished in 1512ms
  * executing `sidekiq:start'
  * executing "cd /var/apps/XXX/current ; nohup bundle exec sidekiq -e qa -C /var/apps/XXX/current/config/sidekiq.yml -P /var/apps/XXX/current/tmp/pids/sidekiq.pid >> /var/apps/XXX/current/log/sidekiq.log 2>&1 &"
    servers: ["worker1"]
    [worker1] executing command
    command finished in 1514ms
  * executing `deploy:cleanup'
```

This is pretty much what I've been seeing when doing multiple deployments, leaving an orphaned worker running (see #433)

Removing the  deploy:restart callback in the capistrano config seems to have fixed this problem.

If it helps, I'm also running capistrano 2.13.5
