### PR TITLE
Fix issue with #insert_before and #insert_after

### DIFF
--- a/lib/sidekiq/middleware/chain.rb
+++ b/lib/sidekiq/middleware/chain.rb
@@ -77,13 +77,15 @@ module Sidekiq
       end
 
       def insert_before(oldklass, newklass, *args)
-        new_entry = entries.delete_if { |entry| entry.klass == newklass } || Entry.new(newklass, *args)
+        i = entries.index { |entry| entry.klass == newklass }
+        new_entry = i.nil? ? Entry.new(newklass, *args) : entries.delete_at(i)
         i = entries.find_index { |entry| entry.klass == oldklass } || 0
         entries.insert(i, new_entry)
       end
 
       def insert_after(oldklass, newklass, *args)
-        new_entry = entries.delete_if { |entry| entry.klass == newklass } || Entry.new(newklass, *args)
+        i = entries.index { |entry| entry.klass == newklass }
+        new_entry = i.nil? ? Entry.new(newklass, *args) : entries.delete_at(i)
         i = entries.find_index { |entry| entry.klass == oldklass } || entries.count - 1
         entries.insert(i+1, new_entry)
       end


### PR DESCRIPTION
Middleware chain corrupt results from using #insert_before or #insert_after.  #delete_if returns the chain, not the entry deleted.  Changed to use #index followed by #delete_at instead.
