### PR TITLE
Prevent args being misused

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -118,6 +118,7 @@ module Sidekiq
     def self.normalize_item(item)
       raise(ArgumentError, "Message must be a Hash of the form: { 'class' => SomeWorker, 'args' => ['bob', 1, :foo => 'bar'] }") unless item.is_a?(Hash)
       raise(ArgumentError, "Message must include a class and set of arguments: #{item.inspect}") if !item['class'] || !item['args']
+      raise(ArgumentError, "Message args must be an Array") unless item['args'].is_a?(Array)
       raise(ArgumentError, "Message class must be either a Class or String representation of the class name") unless item['class'].is_a?(Class) || item['class'].is_a?(String)
 
       if item['class'].is_a?(Class)

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -39,6 +39,10 @@ class TestClient < MiniTest::Unit::TestCase
         Sidekiq::Client.push('queue' => 'foo', 'class' => 42, 'args' => [1, 2])
       end
 
+      assert_raises ArgumentError do
+        Sidekiq::Client.push('queue' => 'foo', 'class' => MyWorker, 'args' => 1)
+      end
+
     end
 
     it 'pushes messages to redis' do


### PR DESCRIPTION
Whilst playing around with Sidekiq::Client.push I accidentally didn't wrap args in an Array. This caused various `undefined method 'map' for 3:Fixnum` in a couple different places ( web, processor )

![Screen Shot 2013-01-05 at 09 32 59](https://f.cloud.github.com/assets/139095/44902/37f16d0e-571b-11e2-8bc2-09dabf58a8cb.png)

This should prevent that happening again :)
