### PR TITLE
Add retry_queue to sidekiq_options

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -51,7 +51,11 @@ module Sidekiq
           raise e unless msg['retry']
           max_retry_attempts = retry_attempts_from(msg['retry'], DEFAULT_MAX_RETRY_ATTEMPTS)
 
-          msg['queue'] = queue
+          msg['queue'] = if msg['retry_queue']
+            msg['retry_queue']
+          else
+            queue
+          end
           msg['error_message'] = e.message
           msg['error_class'] = e.class.name
           count = if msg['retry_count']


### PR DESCRIPTION
``` ruby
sidekiq_options queue: 'high', retry_queue: 'low'
```

Allows failed jobs to be retried on a new queue (so their priority can be adjusted relative to new jobs of the same class)

Would be happy to implement a `retry_options` with more options or to do so in separate middleware if you think this is too specific to be included in core sidekiq

P.S. thanks for the gem, it's awesome
