### PR TITLE
Fix #621 fix job re-queueing on hard shutdown (e.g. SIGTERM).

### DIFF
--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -124,8 +124,8 @@ module Sidekiq
               # that would go to the actor (since it's busy).  Instead
               # we'll use the object_id to track the worker's data here.
               processor.terminate if processor.alive?
-              msg, queue = @in_progress[processor.object_id]
-              conn.lpush("queue:#{queue}", msg)
+              unit_of_work = @in_progress[processor.object_id]
+              conn.lpush(unit_of_work.queue, unit_of_work.message)
             end
           end
           logger.info("Pushed #{@busy.size} messages back to Redis")


### PR DESCRIPTION
Jobs in process during a hard shutdown were not properly sent back to redis resulting in the jobs being permanently lost.

Steps to reproduce:
1) enqueue an infinitely running job, see "busy" workers go to 1
2) `killall -TERM -m sidekiq`
3) expect "enqueued" to be 1, but it is actually 0

This is particularly noticeable when scaling down workers on Heroku.
