### PR TITLE
Stop sidekiq before rails update code

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -2,8 +2,7 @@ Capistrano::Configuration.instance.load do
   before "deploy:update_code", "sidekiq:quiet"
   after "deploy:stop",    "sidekiq:stop"
   after "deploy:start",   "sidekiq:start"
-  before "deploy:restart", "sidekiq:stop"
-  after "deploy:restart", "sidekiq:start"
+  before "deploy:restart", "sidekiq:restart"
 
   _cset(:sidekiq_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" }
   _cset(:sidekiqctl_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" }


### PR DESCRIPTION
Hi,

I like sidekiq and am using it in my app.
I found a concern that there is a short time between "deploy:restart" and "sidekiq:stop". I think we need to prevent the code inconsistence.
