### PR TITLE
Fixes Issue #637 "cap sidekiq:stop fails if it's already stoped"

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -19,14 +19,14 @@ Capistrano::Configuration.instance.load do
     end
 
     desc "Quiet sidekiq (stop accepting new work)"
-    task :quiet, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
+    task :quiet, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue, :on_error => :continue do
       for_each_process do |pid_file, idx|
         run "if [ -d #{current_path} ] && [ -f #{pid_file} ]; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} quiet #{pid_file} ; fi"
       end
     end
 
     desc "Stop sidekiq"
-    task :stop, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
+    task :stop, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue, :on_error => :continue do
       for_each_process do |pid_file, idx|
         run "if [ -d #{current_path} ] && [ -f #{pid_file} ]; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} stop #{pid_file} #{fetch :sidekiq_timeout} ; fi"
       end


### PR DESCRIPTION
Adds ":on_error => :continue" setting to the stop and quiet tasks in the capistrano recipe. Now instead of failing the tasks show the error message and continue, when sidekiq is already stopped. fixes #637
