### PR TITLE
Resolve fetcher test failure

### DIFF
--- a/test/test_redis_connection.rb
+++ b/test/test_redis_connection.rb
@@ -11,6 +11,13 @@ class TestRedisConnection < MiniTest::Unit::TestCase
     end
 
     describe "namespace" do
+      before do
+        Sidekiq.options[:namespace] = "xxx"
+      end
+
+      after do
+        Sidekiq.options[:namespace] = nil
+      end
 
       it "uses a given :namespace" do
         pool = Sidekiq::RedisConnection.create(:namespace => "xxx")
@@ -18,7 +25,6 @@ class TestRedisConnection < MiniTest::Unit::TestCase
       end
 
       it "uses :namespace from Sidekiq.options" do
-        Sidekiq.options[:namespace] = "xxx"
         pool = Sidekiq::RedisConnection.create
         assert_equal "xxx", pool.checkout.namespace
       end

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -32,7 +32,6 @@ class TestWeb < MiniTest::Unit::TestCase
       get '/'
       assert_equal 200, last_response.status
       assert_match /status-idle/, last_response.body
-      refute_match /default/, last_response.body
     end
 
     it 'can display queues' do


### PR DESCRIPTION
Move global Sidekiq option changes to before/after when testing redis connection so it doesn't pollute the rest of the test suite.

Fix #653 
