### PR TITLE
Update Travis config for bundle issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+bundler_args: --without development
 rvm:
   - 1.9.3
   - jruby-19mode


### PR DESCRIPTION
Update Travis config to not rely on dev env to try and resolve the bundle install issues.

Closes #656 
