### PR TITLE
Standalone Sidekiq::Launcher

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -91,6 +91,7 @@ module Sidekiq
       end
 
       @launcher = Sidekiq::Launcher.new(options)
+      launcher.procline(options[:tag] ? "#{options[:tag]} " : '')
 
       begin
         if options[:profile]

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -22,5 +22,10 @@ module Sidekiq
       manager.async.stop(:shutdown => true, :timeout => options[:timeout])
       manager.wait(:shutdown)
     end
+
+    def procline(tag)
+      $0 = manager.procline(tag)
+      manager.after(5) { procline(tag) }
+    end
   end
 end

--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -27,7 +27,6 @@ module Sidekiq
       @busy = []
       @fetcher = Fetcher.new(current_actor, options)
       @ready = @count.times.map { Processor.new_link(current_actor) }
-      procline(options[:tag] ? "#{options[:tag]} " : '')
     end
 
     def stop(options={})
@@ -103,6 +102,10 @@ module Sidekiq
       end
     end
 
+    def procline(tag)
+      "sidekiq #{Sidekiq::VERSION} #{tag}[#{@busy.size} of #{@count} busy]#{stopped? ? ' stopping' : ''}"
+    end
+
     private
 
     def hard_shutdown_in(delay)
@@ -155,11 +158,6 @@ module Sidekiq
 
     def stopped?
       @done
-    end
-
-    def procline(tag)
-      $0 = "sidekiq #{Sidekiq::VERSION} #{tag}[#{@busy.size} of #{@count} busy]#{stopped? ? ' stopping' : ''}"
-      after(5) { procline(tag) }
     end
   end
 end


### PR DESCRIPTION
- Add Sidekiq::Launcher, extracted from Sidekiq::CLI.
  
  This is a step forward to run Sidekiq inside a process,
  making it more easily to integrate into existing process.
- Extract procline feature from Manager to Launcher.
  
  We don't want to touch the process name if we're integrating
  Sidekiq into existing process, so better not to put procline
  assignment in Manager, but in CLI where we launch standalone
  Sidekiq process.
