### PR TITLE
Make the history graph more readable

### DIFF
--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -97,7 +97,7 @@ var historyGraph = function() {
 
   var hoverDetail = new Rickshaw.Graph.HoverDetail({
     graph: graph,
-    yFormatter: function(y) { return Math.floor(y) },
+    yFormatter: function(y) { return Math.floor(y).numberWithDelimiter() },
   });
 }
 


### PR DESCRIPTION
Hovering in the history graph now has formatted number, really useful
when you have a lot of jobs processed daily.

![History Graph](https://f.cloud.github.com/assets/79502/110532/96c1cbe6-6ac4-11e2-8c43-24a7298f8437.png)
