### PR TITLE
Add an example config for Upstart on Ubuntu 12.04.

### DIFF
--- a/examples/upstart.conf
+++ b/examples/upstart.conf
@@ -3,6 +3,14 @@
 # This example config should work with Ubuntu 12.04+ but will need changes for
 # older versions of upstart.
 
+# Save this config as /etc/init/sidekiq.conf then mange sidekiq with:
+#   sudo start sidekiq
+#   sudo stop sidekiq
+#   sudo status sidekiq
+#
+# or use the service command:
+#   sudo service sidekiq {start,stop,restart,status}
+
 description "Sidekiq Background Worker System"
 
 start on runlevel [2345]
@@ -17,5 +25,5 @@ respawn limit 10 5
 script
   cd /app/[application]/current
 
-  bundle exec sidekiq -e production
+  bundle exec sidekiq -e production -L /app/[applicaiton]/shared/log/sidekiq.log
 end script


### PR DESCRIPTION
We use Ubuntu for all over our deployments and we use upstart for managing all of our custom jobs / services. This example should be enough to get an upstart task written for running sidekiq for an app.
