### PR TITLE
Revert travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-bundler_args: --without development
 rvm:
   - 1.9.3
   - jruby-19mode


### PR DESCRIPTION
I think add the `--without development` flag I did before was a bad idea b/c now it can't find rake b/c it didn't install it.

Reverted.

https://travis-ci.org/mperham/sidekiq/jobs/4521615
