### PR TITLE
Add sidekiq config variable

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -10,6 +10,7 @@ Capistrano::Configuration.instance.load do
   _cset(:sidekiq_role)      { :app }
   _cset(:sidekiq_pid)       { "#{current_path}/tmp/pids/sidekiq.pid" }
   _cset(:sidekiq_processes) { 1 }
+  _cset(:sidekiq_config) { "#{current_path}/config/sidekiq.yml" }
 
   namespace :sidekiq do
     def for_each_process(&block)
@@ -36,7 +37,7 @@ Capistrano::Configuration.instance.load do
     task :start, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
       rails_env = fetch(:rails_env, "production")
       for_each_process do |pid_file, idx|
-        run "cd #{current_path} ; #{fetch(:sidekiq_cmd)} -d -e #{rails_env} -C #{current_path}/config/sidekiq.yml -i #{idx} -P #{pid_file} -L #{current_path}/log/sidekiq.log"
+        run "cd #{current_path} ; #{fetch(:sidekiq_cmd)} -d -e #{rails_env} -C #{sidekiq_config} -i #{idx} -P #{pid_file} -L #{current_path}/log/sidekiq.log"
       end
     end
 


### PR DESCRIPTION
Simple decision for sidekiq config location customization, that (usually) depended from multi stage deployment.

For example, I can set own value for sidekiq_config:

``` ruby
set :sidekiq_config, defer { "#{current_path}/config/sidekiq/#{stage}.yml" }
```

Also, I can specify different (for example) queue for staging/production environment.
