### PR TITLE
Force MultiJson to NOT symbolize keys

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -96,7 +96,7 @@ module Sidekiq
   end
 
   def self.load_json(string)
-    MultiJson.decode(string)
+    MultiJson.decode(string, :symbolize_keys => false)
   end
 
   def self.dump_json(object)


### PR DESCRIPTION
Your load_json method must use your explicit MultiJson decoder options, in your case :symbolize_keys => false (you're using string keys)

Point is, that if you don't do it, then your gem will not work as expected. For example in your sinatra monitoring app, your slim templates are using msg['class'], msg['args] etc... but if in project where sidekiq is required will be global MultiJson configuration or global configuration for particular JSON gem, like:

```
Oj.default_options = {
  :symbol_keys      => true,
  :mode             => :compat,
  :time_format      => :xmlschema,
  :second_precision => 0
}
```

Your gem will not work at all. So you'll see empty queues http://cl.ly/image/0X2q1S232q1B and workers will not work at all as well, simply they are expecting 'string' keys...
