### PR TITLE
Don't daemonize in Capistrano recipe in order to accommodate JRuby

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -36,7 +36,7 @@ Capistrano::Configuration.instance.load do
     task :start, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
       rails_env = fetch(:rails_env, "production")
       for_each_process do |pid_file, idx|
-        run "cd #{current_path} ; #{fetch(:sidekiq_cmd)} -d -e #{rails_env} -C #{current_path}/config/sidekiq.yml -i #{idx} -P #{pid_file} -L #{current_path}/log/sidekiq.log", :pty => false
+        run "cd #{current_path} ; nohup #{fetch(:sidekiq_cmd)} -e #{rails_env} -C #{current_path}/config/sidekiq.yml -i #{idx} -P #{pid_file} >> #{current_path}/log/sidekiq.log 2>&1 &", :pty => false
       end
     end
 


### PR DESCRIPTION
Daemonization is cool, but unfortunately JRuby doesn't support `Process.daemon`, and thus doesn't work with the `-d` flag. I'd like to be able to still use the Capistrano recipes shipped with Sidekiq, but they're not usable on JRuby, since the -d flag is hard-coded into the options.

This change makes use of -d when starting Sidekiq conditional on a Capistrano variable called `:sidekiq_daemonize`, which defaults to true. So, by default, everyone will get the current behavior (daemonization), but users running on JRuby will have the option of doing a `set :sidekiq_daemonize, false` in their deploy.rb in order to fall back to the old nohup approach.

I realize having the two quite long command strings side-by-side is a little ew, if you find it objectionable I'm happy to pull out some of the commonalities. Let me know what you think!

Edit: per Mike's suggestion, this now just reverts to not using daemonization at all in the recipe, which keeps things simpler.
