### PR TITLE
Add timeout option to RedisConnection 

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -10,8 +10,9 @@ module Sidekiq
       # need a connection for Fetcher and Retry
       size = options[:size] || (Sidekiq.server? ? (Sidekiq.options[:concurrency] + 2) : 5)
       namespace = options[:namespace] || Sidekiq.options[:namespace]
+      timeout = options[:timeout] || 1
 
-      ConnectionPool.new(:timeout => 1, :size => size) do
+      ConnectionPool.new(:timeout => timeout, :size => size) do
         build_client(url, namespace, driver)
       end
     end


### PR DESCRIPTION
Hi,

In my dev environment sidekiq very ofhen throw timeout exception when try to connect to Redis:

```
2013-02-22T13:53:38Z 34285 TID-7qi WARN: {"retry"=>true, "queue"=>"report_worker", "class"=>"ReportWorker", "args"=>["1aedd550b0beb4170ae3a9c180eb62363544febefd103a53739382b7616e4951"], "jid"=>"644374396d0f2d8e3bc42d43"}
2013-02-22T13:53:38Z 34285 TID-7qi WARN: Waited 1 sec
2013-02-22T13:53:38Z 34285 TID-7qi WARN: /Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool/timed_stack.rb:25:in `pop'
org/jruby/RubyKernel.java:1392:in `loop'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool/timed_stack.rb:22:in `pop'
org/jruby/ext/thread/Mutex.java:149:in `synchronize'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool/timed_stack.rb:21:in `pop'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool.rb:58:in `checkout'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool.rb:46:in `with'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq.rb:72:in `redis'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq/util.rb:25:in `redis'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq/processor.rb:70:in `stats'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq/processor.rb:43:in `process'
org/jruby/RubyProc.java:249:in `call'
org/jruby/RubyKernel.java:1809:in `public_send'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/celluloid-0.12.4/lib/celluloid/calls.rb:23:in `dispatch'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/celluloid-0.12.4/lib/celluloid/future.rb:18:in `initialize'
org/jruby/RubyProc.java:249:in `call'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/celluloid-0.12.4/lib/celluloid/internal_pool.rb:48:in `create'
2013-02-22T13:53:38Z 34285 TID-7qk ERROR: Sidekiq::Processor crashed!
Timeout::Error: Waited 1 sec
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool/timed_stack.rb:25:in `pop'
org/jruby/RubyKernel.java:1392:in `loop'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool/timed_stack.rb:22:in `pop'
org/jruby/ext/thread/Mutex.java:149:in `synchronize'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool/timed_stack.rb:21:in `pop'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool.rb:58:in `checkout'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool.rb:46:in `with'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq.rb:72:in `redis'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq/util.rb:25:in `redis'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq/processor.rb:70:in `stats'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq/processor.rb:43:in `process'
org/jruby/RubyProc.java:249:in `call'
org/jruby/RubyKernel.java:1809:in `public_send'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/celluloid-0.12.4/lib/celluloid/calls.rb:23:in `dispatch'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/celluloid-0.12.4/lib/celluloid/future.rb:18:in `initialize'
org/jruby/RubyProc.java:249:in `call'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/celluloid-0.12.4/lib/celluloid/internal_pool.rb:48:in `create'
2013-02-22T13:53:40Z 34285 TID-7q8 WARN: {:context=>"scheduling poller thread died!"}
2013-02-22T13:53:40Z 34285 TID-7q8 WARN: Waited 1 sec
2013-02-22T13:53:40Z 34285 TID-7q8 WARN: /Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool/timed_stack.rb:25:in `pop'
org/jruby/RubyKernel.java:1392:in `loop'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool/timed_stack.rb:22:in `pop'
org/jruby/ext/thread/Mutex.java:149:in `synchronize'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool/timed_stack.rb:21:in `pop'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool.rb:58:in `checkout'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/connection_pool-1.0.0/lib/connection_pool.rb:46:in `with'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq.rb:72:in `redis'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq/scheduled.rb:29:in `poll'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq/util.rb:15:in `watchdog'
/Users/mdobryakov/Projects/sidekiq/lib/sidekiq/scheduled.rb:22:in `poll'
org/jruby/RubyKernel.java:1809:in `public_send'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/celluloid-0.12.4/lib/celluloid/calls.rb:53:in `dispatch'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/celluloid-0.12.4/lib/celluloid/actor.rb:327:in `handle_message'
/Users/mdobryakov/Projects/stat_builder/vendor/bundle/jruby/1.9/gems/celluloid-0.12.4/lib/celluloid/tasks/task_fiber.rb:24:in `initialize'
```

My dev box doesn't have a lot of memory and swap always filled to 80%, therefore Redis is very slowly. So, I added option for configure RedisConnection timeout.
