### PR TITLE
Changed return of client_push method on testing

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -60,7 +60,7 @@ module Sidekiq
 
       def client_push(opts)
         jobs << opts
-        jobs.size-1
+        opts.object_id
       end
 
       # Jobs queued for this worker


### PR DESCRIPTION
It's now possible to have a `:jid` in testing environment.
