### PR TITLE
Not properly requeuing jobs when using a namespace

### DIFF
--- a/test/test_fetch_with_namespace.rb
+++ b/test/test_fetch_with_namespace.rb
@@ -1,0 +1,43 @@
+require 'helper'
+require 'sidekiq/fetch'
+
+class TestFetcher < MiniTest::Unit::TestCase
+
+  def setup
+    Sidekiq.options = Sidekiq.options.merge(namespace: 'snuffy')
+    Sidekiq.redis do |conn|
+      conn.flushdb
+      conn.rpush('queue:basic', 'msg')
+    end
+  end
+
+  def test_basic_fetch_retrieve
+    fetch = Sidekiq::BasicFetch.new(:queues => ['basic', 'bar'])
+    uow = fetch.retrieve_work
+    refute_nil uow
+    assert_equal 'basic', uow.queue_name
+    assert_equal 'msg', uow.message
+    q = Sidekiq::Queue.new('basic')
+    assert_equal 0, q.size
+    uow.requeue
+    assert_equal 1, q.size
+    assert_nil uow.acknowledge
+  end
+
+  def test_basic_fetch_strict_retrieve
+    fetch = Sidekiq::BasicFetch.new(:queues => ['basic', 'bar', 'bar'], :strict => true)
+    cmd = fetch.queues_cmd
+    assert_equal cmd, ['queue:basic', 'queue:bar', 1]
+  end
+
+  def test_basic_fetch_bulk_requeue
+    q1 = Sidekiq::Queue.new('foo')
+    q2 = Sidekiq::Queue.new('bar')
+    assert_equal 0, q1.size
+    assert_equal 0, q2.size
+    uow = Sidekiq::BasicFetch::UnitOfWork
+    Sidekiq::BasicFetch.bulk_requeue([uow.new('queue:foo', 'bob'), uow.new('queue:foo', 'bar'), uow.new('queue:bar', 'widget')])
+    assert_equal 2, q1.size
+    assert_equal 1, q2.size
+  end
+end


### PR DESCRIPTION
When I am using a namespace and I have jobs that are stopped via the command line, the jobs are not properly rpushed back to the correct queue.

When I am not using a namespace, the jobs are properly pushed to the correct queue.

When I use a namespace, 'snuffy' and investigate the key names in redis (using redis = Redis.new) before I send the stop command, I can see a list named "snuffy:default" as well as the current jobs running ("snuffy:default:blahblah:started")

When I send a stop command and investigate the key names I see a list named "snuffy:snuffy:queue:default", as well as a "snuffy:queue:default" list. The "snuffy:queue:default" contained all the jobs that were not processed yet, and the "snuffy:snuffy:queue:default" list contained the jobs that should have been pushed to the proper queue list.

When I do not use a namespace, I only see a "queue:default" list after I send the stop command.  This list contains the jobs that were not processed as well as the jobs that were in flight.

I investigated the Sidekiq library and found the fetch.rb file that has the bulk_requeue method and the UnitOfWork Struct.  When I logged the queue that was being put into the conn.rpush command, it was 'snuffy:queue:default'.  When not using a namespace, it was "queue:default"

In this pull request there is a new test file called test_fetch_with_namespace that has the namespace being added to the Sidekiq.options hash.

There is also the code in lib/sidekiq/fetch that helps the new tests pass.
