### PR TITLE
Support for REDISCLOUD_URL as an ENV variable

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -26,9 +26,14 @@ module Sidekiq
 
     # Not public
     def self.determine_redis_provider
-      return ENV['REDISTOGO_URL'] if ENV['REDISTOGO_URL']
-      provider = ENV['REDIS_PROVIDER'] || 'REDIS_URL'
-      ENV[provider]
+      if redis_to_go = ENV['REDISTOGO_URL']
+        redis_to_go
+      elsif redis_cloud = ENV['REDISCLOUD_URL']
+        redis_cloud
+      else
+        provider = ENV['REDIS_PROVIDER'] || 'REDIS_URL'
+        ENV[provider]
+      end
     end
   end
 end


### PR DESCRIPTION
This is a pretty easy one. There is a new Heroku addon, that uses this ENV variable for its connection string. Because you already support REDISTOGO_URL, you might as well support this new one as well?
