### PR TITLE
Added a comment why REDISTOGO_URL is supported

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -26,6 +26,7 @@ module Sidekiq
 
     # Not public
     def self.determine_redis_provider
+      # REDISTOGO_URL is only support for legacy reasons
       return ENV['REDISTOGO_URL'] if ENV['REDISTOGO_URL']
       provider = ENV['REDIS_PROVIDER'] || 'REDIS_URL'
       ENV[provider]


### PR DESCRIPTION
I wasn't aware that REDISTOGO_URL was legacy only. I've added a comment so someone doesn't make the same mistake again.
