### PR TITLE
fix pagination when @total_size is devisible by @count

### DIFF
--- a/web/views/_paging.slim
+++ b/web/views/_paging.slim
@@ -12,4 +12,4 @@
         li
           a href="#{url}?page=#{@current_page + 1}" #{@current_page + 1}
       li class="#{'disabled' if @total_size <= @current_page * @count}"
-        a href="#{url}?page=#{(@total_size / @count).ceil + 1}" »
+        a href="#{url}?page=#{(@total_size.to_f / @count).ceil}" »


### PR DESCRIPTION
Old implementation:

``` ruby
@total_size = 25
@count = 101
# last page = 25/101 + 1 = 5

@total_size = 25
@count = 100
# last page = 25/100 + 1 = 5 # should be 4
```
