### PR TITLE
Makes retry time calculation easier to monkey-patch

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -43,7 +43,6 @@ module Sidekiq
 
         # delayed_job uses the same basic formula
         DEFAULT_MAX_RETRY_ATTEMPTS = 25
-        DELAY = proc { |count| (count ** 4) + 15 + (rand(30)*(count+1)) }
 
         def call(worker, msg, queue)
           yield
@@ -73,7 +72,7 @@ module Sidekiq
           end
 
           if count < max_retry_attempts
-            delay = DELAY.call(count)
+            delay = seconds_to_delay(count)
             logger.debug { "Failure! Retry #{count} in #{delay} seconds" }
             retry_at = Time.now.to_f + delay
             payload = Sidekiq.dump_json(msg)
@@ -93,6 +92,10 @@ module Sidekiq
           else
             default
           end
+        end
+
+        def seconds_to_delay(count)
+          (count ** 4) + 15 + (rand(30)*(count+1))
         end
 
       end


### PR DESCRIPTION
Makes retry time calculation easier to monkey-patch by changing it from a constant proc to a method.

I have a need to replace the delayed retry calculation method, and this makes it easier to change.
