### PR TITLE
Changelog updates for next release

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,13 @@
+Upcoming
+-----------
+
+- Provides ability to hook onto failure after max retries failed. [jkassemi, #780]
+- Delay on retry moved from constant proc to method call [lulalala, #784]
+- DSM V compatible symptom definition of developer frustration [colszowka, #782]
+- Fix bug in pagination link to last page [pitr, #774]
+- Upstart scripts for multiple Sidekiq instances [dariocravero, #763]
+- Use select via pipes instead of poll to catch signals [mrnugget, #761]
+
 2.8.0
 -----------
 


### PR DESCRIPTION
Think I caught all changes since 2.8.0 build - threw into an "Upcoming" header. Version bump is up to you when the timing is right. 
