### PR TITLE
Added missed translation for button

### DIFF
--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -12,6 +12,7 @@ en:
   Scheduled: Scheduled
   Retries: Retries
   Enqueued: Enqueued
+  ClearWorkerList: Clear workers list
   Worker: Worker
   Workers: Workers
   LivePoll: Live Poll

--- a/web/locales/ru.yml
+++ b/web/locales/ru.yml
@@ -11,6 +11,7 @@ ru:
   Scheduled: Запланировано
   Retries: Попыток
   Enqueued: В очереди
+  ClearWorkerList: Очистить список обработчиков
   Worker: Обработчик
   Workers: Обработчики
   LivePoll: Постоянный опрос


### PR DESCRIPTION
Testing master branch for fixed this issue - https://github.com/mperham/sidekiq/issues/720#issuecomment-16108396. Added missed translation for button on workers page:

http://monosnap.com/image/337cI7HuYvYUBuAAQKmVFdBUL
