### PR TITLE
Fix test failures due to Slim checks for Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'celluloid', "~> 0.12.0"
-gem 'slim'
+gem 'slim', :github => 'jroes/slim'
 gem 'sqlite3', :platform => :mri
 
 group :test do


### PR DESCRIPTION
Not sure if you're interested in this as a temporary fix until https://github.com/slim-template/slim/pull/382 gets merged in, but I thought I'd send it over just in case.

All sidekiq tests now pass with this.

I suppose another option would be to downgrade slim to an earlier version.
