### PR TITLE
Adding functionality to return a scheduled job given a job id

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -20,6 +20,17 @@ module Sidekiq
       end
 
       ##
+      # Return details of a scheduled job given a job id
+      #
+      # Example Usage: 
+      #   Sidekiq::Client.get_scheduled_job('1ae396f79e1507541bfe953asdc') 
+      #
+      def get_scheduled_job(job_id)
+        job = Sidekiq.redis { |x| x.zrange('schedule', 0, -1).select{|job| job.include? "\"jid\":\"#{job_id}\""}[0] }
+        job ? Sidekiq.load_json(job) : nil
+      end
+
+      ##
       # The main method used to push a job to Redis.  Accepts a number of options:
       #
       #   queue - the named queue to use, default 'default'

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -69,6 +69,13 @@ class TestClient < MiniTest::Unit::TestCase
       assert_equal Sidekiq::Worker::ClassMethods::DEFAULT_OPTIONS, MyWorker.get_sidekiq_options
     end
 
+    it 'returns details of a scheduled job' do
+      pushed = Sidekiq::Client.push('queue' => 'foo', 'class' => MyWorker, 'args' => [1, 2])
+      job_id = MyWorker.perform_in(100)
+      job    = Sidekiq::Client.get_scheduled_job(job_id)
+      assert job
+    end
+
     it 'handles perform_async' do
       @redis.expect :lpush, 1, ['queue:default', Array]
       pushed = MyWorker.perform_async(1, 2)


### PR DESCRIPTION
Had a similar issue as @jmazzi (https://github.com/mperham/sidekiq/issues/536#issuecomment-10604878) where I needed information on a scheduled Sidekiq job.   

Example usage:

Sidekiq::Client.get_scheduled_job('b0e879cbe7fcf3460acc2b67')
 => {"retry"=>true, "queue"=>"default", "class"=>"Sidekiq::Extensions::DelayedClass", "args"=>["---\n- !ruby/class 'MyClass'\n- :test\n- []\n"], "at"=>1366142912.6503942, "jid"=>"b0e879cbe7fcf3460acc2b67"} 

Please let me know if I've totally overlooked a better way to do this.

Cheers!
