### PR TITLE
Adding functionality to find a job by job id and delete a job by job id from a SortedSet

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -279,6 +279,10 @@ module Sidekiq
       end
     end
 
+    def find_job(jid)
+      self.find{ |j| j.jid == jid }
+    end
+
     def delete(score, jid = nil)
       if jid
         elements = Sidekiq.redis do |conn|

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -179,6 +179,13 @@ class TestApi < MiniTest::Unit::TestCase
       assert_equal 0, q.size
     end
 
+    it 'can find job by id' do
+      q      = Sidekiq::Queue.new
+      job_id = ApiWorker.perform_in(100, 1, 'jason')
+      job    = Sidekiq::ScheduledSet.new.find_job(job_id)
+      assert job
+    end
+
     it 'can clear a queue' do
       q = Sidekiq::Queue.new
       2.times { ApiWorker.perform_async(1, 'mike') }


### PR DESCRIPTION
Functionality to find and delete Sidekiq jobs by the job id.  @mperham, I think this is more in line with what you were thinking.

Example usage:

**Finding and Deleting Job by ID**

```
Sidekiq::SortedSet.new('schedule').find_job_by_id('2eef6b752dab8a4c89a7aa19')
=> #<Sidekiq::SortedEntry:0x007fd5a910e858 @value=".....> 

Sidekiq::SortedSet.new('schedule').delete_job_by_id('2eef6b752dab8a4c89a7aa19')
=> true 
```

**Finding and Deleting Invalid Job ID**

```
Sidekiq::SortedSet.new('schedule').find_job_by_id('2eef6b752dab8a4c89a7aa19')
=> nil 

Sidekiq::SortedSet.new('schedule').delete_job_by_id('2eef6b752dab8a4c89a7aa19')
=> nil 
```

**Or you can use it on ScheduledSet to access the scheduled queue directly** 

```
Sidekiq::ScheduledSet.new.find_job_by_id('719a82379213ccab7551bc7e')
=> #<Sidekiq::SortedEntry:0x007fd5a928f6a0 @value=".....>

Sidekiq::ScheduledSet.new.delete_job_by_id('719a82379213ccab7551bc7e')
=> true

Sidekiq::ScheduledSet.new.find_job_by_id('719a82379213ccab7551bc7e')
=> nil 

Sidekiq::ScheduledSet.new.delete_job_by_id('719a82379213ccab7551bc7e')
=> nil
```
