### PR TITLE
It seems appropriate to use UUID (RFC4122) as the unique job ID

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -62,7 +62,7 @@ module Sidekiq
         normed = normalize_item(items)
         payloads = items['args'].map do |args|
           raise ArgumentError, "Bulk arguments must be an Array of Arrays: [[1], [2]]" if !args.is_a?(Array)
-          process_single(items['class'], normed.merge('args' => args, 'jid' => SecureRandom.hex(12)))
+          process_single(items['class'], normed.merge('args' => args, 'jid' => SecureRandom.uuid()))
         end.compact
 
         pushed = false
@@ -129,7 +129,7 @@ module Sidekiq
           normalized_item = Sidekiq::Worker::ClassMethods::DEFAULT_OPTIONS.merge(item)
         end
 
-        normalized_item['jid'] = SecureRandom.hex(12)
+        normalized_item['jid'] = SecureRandom.uuid()
         normalized_item
       end
 


### PR DESCRIPTION
Since SecureRandom.uuid() will likely continue to use newer versions of RFC4122 as they are released, this will ensure that the globally-unique job ID generation technique in sidekiq will stay current with the latest accepted methods..
