### PR TITLE
Accept stringy values for -i (like -i worker.1)

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -248,7 +248,7 @@ module Sidekiq
         end
 
         o.on '-i', '--index INT', "unique process index on this machine" do |arg|
-          opts[:index] = Integer(arg)
+          opts[:index] = Integer(arg.match(/\d+/)[0])
         end
 
         o.on '-p', '--profile', "Profile all code run by Sidekiq" do |arg|

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -45,6 +45,11 @@ class TestCli < MiniTest::Unit::TestCase
       assert_equal 7, Sidekiq.options[:index]
     end
 
+    it 'accepts a stringy process index' do
+      @cli.parse(['sidekiq', '-i', 'worker.7', '-r', './test/fake_env.rb'])
+      assert_equal 7, Sidekiq.options[:index]
+    end
+
     it 'sets strictly ordered queues if weights are not present' do
       @cli.parse(['sidekiq', '-q', 'foo,bar', '-r', './test/fake_env.rb'])
       assert_equal true, !!Sidekiq.options[:strict]


### PR DESCRIPTION
A bit easier to work with than shell trickery like `${PS#worker.}`.
