### PR TITLE
require 'json' for standalone rack app

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -16,6 +16,7 @@ module Sidekiq
 
     helpers do
       def strings
+        require 'json'
         @strings ||= begin
           Dir["#{settings.locales}/*.yml"].inject({}) do |memo, file|
             memo.merge(YAML.load(File.read(file)))


### PR DESCRIPTION
Running Sidekiq:Web as a standalone rack-app gives error 'NameError - uninitialized constant Sidekiq::Web::YAML'.
