### PR TITLE
Add reset stats to Web UI summary box and method to API

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -16,6 +16,13 @@ module Sidekiq
       count.nil? ? 0 : count.to_i
     end
 
+    def reset
+      Sidekiq.redis do |conn|
+        conn.set("stat:failed", 0)
+        conn.set("stat:processed", 0)
+      end
+    end
+
     def queues
       Sidekiq.redis do |conn|
         queues = conn.smembers('queues')

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -32,6 +32,18 @@ class TestApi < MiniTest::Unit::TestCase
       end
     end
 
+    describe "reset" do
+      it 'can reset stats' do
+        Sidekiq.redis do |conn|
+          conn.set('stat:processed', 5)
+          conn.set('stat:failed', 10)
+          Sidekiq::Stats.new.reset
+          assert_equal '0', conn.get('stat:processed')
+          assert_equal '0', conn.get('stat:failed')
+        end
+      end
+    end
+
     describe "queues" do
       it "is initially empty" do
         s = Sidekiq::Stats.new


### PR DESCRIPTION
![screen shot 2013-04-30 at 6 16 32 pm](https://f.cloud.github.com/assets/744212/446908/bfa29386-b1e3-11e2-9893-bdc55b49fb1b.png)
