### PR TITLE
Configurable redis url in tests

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -25,4 +25,9 @@ require 'sidekiq/util'
 Sidekiq.logger.level = Logger::ERROR
 
 require 'sidekiq/redis_connection'
-REDIS = Sidekiq::RedisConnection.create(:url => "redis://localhost/15", :namespace => 'testy')
+redis_url = ENV['REDIS_URL'] || 'redis://localhost/15'
+REDIS = Sidekiq::RedisConnection.create(:url => redis_url, :namespace => 'testy')
+
+Sidekiq.configure_client do |config|
+  config.redis = { :url => redis_url, :namespace => 'testy' }
+end


### PR DESCRIPTION
This allows for a custom redis url (i.e. when having redis run on a non-default port) in tests. To use this, run the tests with `REDIS_URL=redis://localhost:16379/15 rake`
