### PR TITLE
Recognize current tab with String#starts_with? instead of regexp

### DIFF
--- a/web/views/_nav.slim
+++ b/web/views/_nav.slim
@@ -5,13 +5,12 @@
     ul.nav
       - tabs.each do |title, url|
         - if url == ''
-          li class="#{(current_path == url) ? 'active':''}"
-            a href='#{{root_path}}#{{url}}' = t(title)
+          li class="#{current_path == url ? 'active' : ''}"
+            a href="#{{root_path}}#{{url}}" = t(title)
         - else
-          li class="#{(current_path =~ Regexp.new(url)) ? 'active':''}"
-            a href='#{{root_path}}#{{url}}' = t(title)
+          li class="#{current_path.starts_with?(url) ? 'active' : ''}"
+            a href="#{{root_path}}#{{url}}" = t(title)
 
       - custom_tabs.each do |title, url|
-          li class="#{(current_path =~ Regexp.new(url)) ? 'active':''}"
-            a href='#{{root_path}}#{{url}}' = t(title)
-
+          li class="#{current_path.starts_with?(url) ? 'active' : ''}"
+            a href="#{{root_path}}#{{url}}" = t(title)


### PR DESCRIPTION
If plugin has sub-routes same as default tab names, active tab is recognized incorrectly.

![Screenshot](http://f.cl.ly/items/3m0j3y3o1d0X033J1447/Screen%20Shot%202013-05-07%20at%206.58.25%20PM.png)

This PR fixes that behavior.
