### PR TITLE
 fixes #928 example of using sidekiq with whenever without loading rails 

### DIFF
--- a/examples/scheduling.rb
+++ b/examples/scheduling.rb
@@ -35,3 +35,13 @@ end
 every :hour do # Many shortcuts available: :hour, :day, :month, :year, :reboot
   runner "HourlyWorker.perform_async"
 end
+
+# Using the runner command loads an extra rails instance
+# If you want to avoid this you can use the sidekiq-client-cli gem which is a commmand line sidekiq client
+# Define a new job_type
+job_type :sidekiq,  "cd :path && RAILS_ENV=:environment bundle exec sidekiq-client :task :output"
+
+# Add the worker to the queue directly
+every :hour do
+  sidekiq "push HourlyWorker"
+end


### PR DESCRIPTION
Hi

I've created a gem [sidekiq-client-cli](https://github.com/didil/sidekiq-client-cli)  which allows to push workers to the sidekiq queue from the command line and thus from a crontab via whenever without loading rails and added an example on using it to your examples section

Best

Adil
