### PR TITLE
Compare gem versions by their version number, not a lexicographic sort o...

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -2,7 +2,7 @@ require 'yaml'
 require 'sinatra/base'
 require 'slim'
 
-raise "The Sidekiq Web UI requires slim 1.3.8 or greater.  You have slim v#{Slim::VERSION}" if Slim::VERSION < '1.3.8'
+raise "The Sidekiq Web UI requires slim 1.3.8 or greater.  You have slim v#{Slim::VERSION}" if Gem::Version.new(Slim::VERSION) < Gem::Version.new('1.3.8')
 
 require 'sidekiq'
 require 'sidekiq/api'


### PR DESCRIPTION
...f a String representation.

Slim is currently at 1.3.9.  If 1.3.10 gets released, the current check will fail because '1.3.10' is less than '1.3.8' lexicographically.
