### PR TITLE
ActiveRecord::StatementInvalid: Mysql2::Error: This connection is still waiting for a result, try again once you have the result

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'http://rubygems.org'
 gemspec
 
+gem 'celluloid', :github => 'celluloid/celluloid', :branch => 'revert-actor-locals'
 gem 'slim'
 gem 'sqlite3', :platform => :mri
 


### PR DESCRIPTION
We're seeing this error a fair amount in Sidekiq since upgrading to 2.12.0.  I suspect the new task threading in Celluloid 0.14.  Create a branch which reverts back to fiber tasks and run it in production to see if problems disappear.

```
[GEM_ROOT]/gems/peek-mysql2-1.1.0/lib/peek/views/mysql2.rb:14:in `query`
[GEM_ROOT]/gems/peek-mysql2-1.1.0/lib/peek/views/mysql2.rb:14:in `query_with_timing`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:243:in `block in execute`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in log`
[GEM_ROOT]/gems/activesupport-3.2.12/lib/active_support/notifications/instrumenter.rb:20:in `instrument`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log`
[GEM_ROOT]/gems/newrelic_rpm-3.6.2.96/lib/new_relic/agent/instrumentation/active_record.rb:46:in `block in log_with_newrelic_instrumentation`
[GEM_ROOT]/gems/newrelic_rpm-3.6.2.96/lib/new_relic/agent/method_tracer.rb:273:in `trace_execution_scoped`
[GEM_ROOT]/gems/newrelic_rpm-3.6.2.96/lib/new_relic/agent/instrumentation/active_record.rb:43:in `log_with_newrelic_instrumentation`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:243:in `execute`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/connection_adapters/mysql2_adapter.rb:211:in `execute`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/connection_adapters/mysql2_adapter.rb:215:in `exec_query`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/connection_adapters/mysql2_adapter.rb:224:in `select`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract/database_statements.rb:18:in `select_all`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract/query_cache.rb:63:in `select_all`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/querying.rb:38:in `block in find_by_sql`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/explain.rb:40:in `logging_query_plan`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/querying.rb:37:in `find_by_sql`
[GEM_ROOT]/gems/newrelic_rpm-3.6.2.96/lib/new_relic/agent/method_tracer.rb:523:in `block in find_by_sql_with_trace_ActiveRecord_self_name_find_by_sql`
[GEM_ROOT]/gems/newrelic_rpm-3.6.2.96/lib/new_relic/agent/method_tracer.rb:273:in `trace_execution_scoped`
[GEM_ROOT]/gems/newrelic_rpm-3.6.2.96/lib/new_relic/agent/method_tracer.rb:518:in `find_by_sql_with_trace_ActiveRecord_self_name_find_by_sql`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/relation.rb:171:in `exec_queries`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/relation.rb:160:in `block in to_a`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/explain.rb:40:in `logging_query_plan`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/relation.rb:159:in `to_a`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/relation/finder_methods.rb:378:in `find_first`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/relation/finder_methods.rb:122:in `first`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/relation/finder_methods.rb:336:in `find_one`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/relation/finder_methods.rb:312:in `find_with_ids`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/relation/finder_methods.rb:107:in `find`
[GEM_ROOT]/gems/activerecord-3.2.12/lib/active_record/querying.rb:5:in `find`
[PROJECT_ROOT]/app/workers/shipping/manifest_importer.rb:105:in `shipment_notification`
```
