### PR TITLE
Correct slim version dependency

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency                  'celluloid', '>= 0.14.1'
   gem.add_dependency                  'json'
   gem.add_development_dependency      'sinatra'
-  gem.add_development_dependency      'slim'
+  gem.add_development_dependency      'slim', '>= 1.3.8'
   gem.add_development_dependency      'minitest', '~> 5'
   gem.add_development_dependency      'rake'
   gem.add_development_dependency      'actionmailer'


### PR DESCRIPTION
The Sidekiq Web UI requires slim 1.3.8 or greater.
