### PR TITLE
remove duplicate slim requirement leading to lower verserion being bundled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 gemspec
 
-gem 'slim'
 gem 'sqlite3', :platform => :mri
 
 group :test do


### PR DESCRIPTION
@mperham

Prevent this when running tests:
`/Users/mgrosser/code/tools/sidekiq/lib/sidekiq/web.rb:5:in`<top (required)>': The Sidekiq Web UI requires slim 1.3.8 or greater.`
