### PR TITLE
add  capistrano option sidekiq_default_hooks with compatibility

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -1,15 +1,19 @@
 Capistrano::Configuration.instance.load do
-  before "deploy:update_code", "sidekiq:quiet"
-  after "deploy:stop",    "sidekiq:stop"
-  after "deploy:start",   "sidekiq:start"
-  before "deploy:restart", "sidekiq:restart"
 
+  _cset(:sidekiq_default_hooks) { true }
   _cset(:sidekiq_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" }
   _cset(:sidekiqctl_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" }
   _cset(:sidekiq_timeout)   { 10 }
   _cset(:sidekiq_role)      { :app }
   _cset(:sidekiq_pid)       { "#{current_path}/tmp/pids/sidekiq.pid" }
   _cset(:sidekiq_processes) { 1 }
+
+  if fetch(:sidekiq_default_hooks)
+    before "deploy:update_code", "sidekiq:quiet"
+    after "deploy:stop",    "sidekiq:stop"
+    after "deploy:start",   "sidekiq:start"
+    before "deploy:restart", "sidekiq:restart"
+  end
 
   namespace :sidekiq do
     def for_each_process(&block)


### PR DESCRIPTION
I start sidekiq by runit. So, i want to stop my sidekiq service (and runit will up it) during deploy. But require 'sidekiq/capistrano' in my deploy.rb add hooks that started sidekiq after deploy. I want to do this optional. 
