### PR TITLE
Constantize a class before invoking middleware

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -111,6 +111,7 @@ module Sidekiq
       end
 
       def process_single(worker_class, item)
+        worker_class = worker_class.constantize if worker_class.is_a?(String)
         queue = item['queue']
 
         Sidekiq.client_middleware.invoke(worker_class, item, queue) do


### PR DESCRIPTION
Middleware does not expect class to be a string or a real class. Here we constantize strings before invoking the middleware chain.

 See:
https://github.com/mperham/sidekiq/issues/988
https://github.com/krasnoukhov/sidekiq-middleware/issues/12
