### PR TITLE
JID not beign set on workers during tests

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -86,7 +86,9 @@ module Sidekiq
       # Drain and run all jobs for this worker
       def drain
         while job = jobs.shift do
-          new.perform(*job['args'])
+          worker = new
+          worker.jid = job['jid']
+          worker.perform(*job['args'])
         end
       end
 
@@ -94,7 +96,9 @@ module Sidekiq
       def perform_one
         raise(EmptyQueueError, "perform_one called with empty job queue") if jobs.empty?
         job = jobs.shift
-        new.perform(*job['args'])
+        worker = new
+        worker.jid = job['jid']
+        worker.perform(*job['args'])
       end
     end
 

--- a/test/test_testing.rb
+++ b/test/test_testing.rb
@@ -113,6 +113,36 @@ class TestTesting < Minitest::Test
 
     end
 
+    class SpecificJidWorker
+      include Sidekiq::Worker
+      class_attribute :count
+      self.count = 0
+      def perform(worker_jid)
+        return unless worker_jid == self.jid
+        self.class.count += 1
+      end
+    end
+
+    it 'execute only jobs with assigned JID' do
+      4.times do |i|
+        jid = SpecificJidWorker.perform_async(nil)
+        if i % 2 == 0
+          SpecificJidWorker.jobs[-1]["args"] = ["wrong_jid"]
+        else
+          SpecificJidWorker.jobs[-1]["args"] = [jid]
+        end
+      end
+
+      SpecificJidWorker.perform_one
+      assert_equal 0, SpecificJidWorker.count
+
+      SpecificJidWorker.perform_one
+      assert_equal 1, SpecificJidWorker.count
+
+      SpecificJidWorker.drain
+      assert_equal 2, SpecificJidWorker.count
+    end
+
     it 'round trip serializes the job arguments' do
       assert StoredWorker.perform_async(:mike)
       job = StoredWorker.jobs.first


### PR DESCRIPTION
In my application I normally use AR objects to hold the JID. On these tests, to avoid AR I passed the right/wrong JID as a parameter.
