### PR TITLE
Conditionalize loading of ActiveRecord and ActionMailer support

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -112,6 +112,6 @@ module Sidekiq
 end
 
 require 'sidekiq/extensions/class_methods'
-require 'sidekiq/extensions/action_mailer'
-require 'sidekiq/extensions/active_record'
+require 'sidekiq/extensions/action_mailer' if defined?(::ActionMailer)
+require 'sidekiq/extensions/active_record' if defined?(::ActiveRecord)
 require 'sidekiq/rails' if defined?(::Rails::Engine)

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -1,7 +1,7 @@
 require 'sidekiq/util'
 require 'sidekiq/actor'
 
-require 'sidekiq/middleware/server/active_record'
+require 'sidekiq/middleware/server/active_record' if defined?(::ActiveRecord)
 require 'sidekiq/middleware/server/retry_jobs'
 require 'sidekiq/middleware/server/logging'
 
@@ -20,7 +20,7 @@ module Sidekiq
       Middleware::Chain.new do |m|
         m.add Middleware::Server::Logging
         m.add Middleware::Server::RetryJobs
-        m.add Middleware::Server::ActiveRecord
+        m.add Middleware::Server::ActiveRecord if defined?(::ActiveRecord)
       end
     end
 


### PR DESCRIPTION
- Only load the ActiveRecord and ActionMailer support if those
  libraries are available.
