### PR TITLE
Switches to using File#open when loading web locale YAMLs due to error using #read

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -22,7 +22,7 @@ module Sidekiq
       def strings
         @strings ||= begin
           Dir["#{settings.locales}/*.yml"].inject({}) do |memo, file|
-            memo.merge(YAML.load(File.read(file)))
+            memo.merge(YAML.load(File.open(file)))
           end
         end
       end


### PR DESCRIPTION
My JRuby setup...
`jruby 1.7.4 (1.9.3p392) 2013-05-16 2390d3b on Java HotSpot(TM) 64-Bit Server VM 1.7.0_07-b11 +indy [Windows 7-amd64]`

I have `Sidekiq::Web` mounted to in my rackup file and get the following error when I attempt to hit the UI in the browser:

```
Psych::SyntaxError - (<unknown>): 'reader' unacceptable character '?' (0x86) special characters are not allowed in "'reader'", position 1213 at line 0 column 0:
        org/jruby/ext/psych/PsychParser.java:216:in `parse'
        C:/Ruby/jruby-1.7.4/lib/ruby/shared/psych.rb:205:in `parse_stream'
        C:/Ruby/jruby-1.7.4/lib/ruby/shared/psych.rb:153:in `parse'
        C:/Ruby/jruby-1.7.4/lib/ruby/shared/psych.rb:129:in `load'
        C:/Projects/sidekiq/lib/sidekiq/web.rb:25:in `strings'
        org/jruby/RubyArray.java:1617:in `each'
        org/jruby/RubyEnumerable.java:815:in `inject'
        C:/Projects/sidekiq/lib/sidekiq/web.rb:24:in `strings'
        C:/Projects/sidekiq/lib/sidekiq/web.rb:36:in `get_locale'
        C:/Projects/sidekiq/lib/sidekiq/web.rb:40:in `t'
        C:/Projects/sidekiq/web/views/dashboard.slim:4:in `__singleton__'
        org/jruby/RubyBasicObject.java:1735:in `instance_eval'
        C:/Projects/sidekiq/web/views/dashboard.slim:-1:in `__singleton__'
        C:/Projects/sidekiq/web/views/dashboard.slim:-3:in `__tilt_4348'
        org/jruby/RubyMethod.java:122:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/tilt-1.4.1/lib/tilt/template.rb:170:in `evaluate'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/tilt-1.4.1/lib/tilt/template.rb:103:in `render'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:798:in `render'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:730:in `slim'
        C:/Projects/sidekiq/lib/sidekiq/web.rb:293:in `HEAD /'
        org/jruby/RubyMethod.java:118:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:1541:in `compile!'
        org/jruby/RubyProc.java:255:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:950:in `route!'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:966:in `route_eval'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:950:in `route!'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:987:in `process_route'
        org/jruby/RubyKernel.java:1254:in `catch'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:985:in `process_route'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:948:in `route!'
        org/jruby/RubyArray.java:1617:in `each'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:947:in `route!'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:1059:in `dispatch!'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:1041:in `invoke'
        org/jruby/RubyKernel.java:1254:in `catch'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:1041:in `invoke'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:1056:in `dispatch!'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:882:in `call!'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:1041:in `invoke'
        org/jruby/RubyKernel.java:1254:in `catch'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:1041:in `invoke'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:882:in `call!'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:870:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-protection-1.5.0/lib/rack/protection/xss_header.rb:18:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-protection-1.5.0/lib/rack/protection/path_traversal.rb:16:in`call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-protection-1.5.0/lib/rack/protection/json_csrf.rb:18:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-protection-1.5.0/lib/rack/protection/base.rb:49:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-protection-1.5.0/lib/rack/protection/base.rb:49:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-protection-1.5.0/lib/rack/protection/frame_options.rb:31:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/nulllogger.rb:9:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/head.rb:11:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/showexceptions.rb:21:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:175:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:1949:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:1449:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:1726:in `synchronize'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:1449:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/urlmap.rb:65:in `call'
        org/jruby/RubyArray.java:1617:in `each'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/lint.rb:49:in `_call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/lint.rb:37:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/showexceptions.rb:24:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/puma-2.4.1-java/lib/puma/rack_patch.rb:13:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/sinatra-1.4.3/lib/sinatra/base.rb:212:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/chunked.rb:43:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/rack-1.5.2/lib/rack/content_length.rb:14:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/puma-2.4.1-java/lib/puma/server.rb:472:in `handle_request'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/puma-2.4.1-java/lib/puma/server.rb:343:in `process_client'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/puma-2.4.1-java/lib/puma/server.rb:242:in `run'
        org/jruby/RubyProc.java:255:in `call'
        C:/Ruby/jruby-1.7.4/lib/ruby/gems/shared/gems/puma-2.4.1-java/lib/puma/thread_pool.rb:92:in `spawn_thread'
```

Tracked this back to the `File#read` causing YAML read issues, switching to `File#open` fixes this up a treat.

Looks to be related to this issue jruby/jruby#483
