### PR TITLE
Change the deprecated way for instantiate Redis

### DIFF
--- a/examples/sinkiq.rb
+++ b/examples/sinkiq.rb
@@ -8,7 +8,7 @@ require 'sinatra'
 require 'sidekiq'
 require 'redis'
 
-$redis = Redis.connect
+$redis = Redis.new
 
 class SinatraWorker
   include Sidekiq::Worker

--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -21,7 +21,7 @@ module Sidekiq
       private
 
       def build_client(url, namespace, driver, network_timeout)
-        client = Redis.connect client_opts(url, driver, network_timeout)
+        client = Redis.new client_opts(url, driver, network_timeout)
         if namespace
           require 'redis/namespace'
           Redis::Namespace.new(namespace, :redis => client)


### PR DESCRIPTION
Change to use method `new` to instantiate Redis.

Ref.: https://github.com/redis/redis-rb/blob/master/lib/redis.rb#L12-L17
