### PR TITLE
Updated delay extension for ActiveRecord instances

### DIFF
--- a/lib/sidekiq/extensions/active_record.rb
+++ b/lib/sidekiq/extensions/active_record.rb
@@ -15,9 +15,9 @@ module Sidekiq
       include Sidekiq::Worker
 
       def perform(yml)
-        (class_name, id, method_name, args) = YAML.load(yml)
+        (class_name, primary_key, method_name, args) = YAML.load(yml)
         klass = class_name.constantize
-        target = klass.find(id)
+        target = klass.find(primary_key)
         target.send(method_name, *args)
       end
     end

--- a/lib/sidekiq/extensions/generic_proxy.rb
+++ b/lib/sidekiq/extensions/generic_proxy.rb
@@ -16,7 +16,8 @@ module Sidekiq
         # to JSON and then deserialized on the other side back into a
         # Ruby object.
         if @performable == DelayedModel
-          obj = [@target.class.name, @target.id, name, args]
+          primary_key = @target.class.primary_key
+          obj = [@target.class.name, @target.attributes[primary_key], name, args]
         else
           obj = [@target, name, args]
         end


### PR DESCRIPTION
In reference to #278.

Given the recommendation to not queue up instances, this pull request instead queues up the class name, primary key, method name, and args for the ActiveRecord delayed extension. Processing the job then does a fresh `find` and sends the along the method/args.

This is more similar to the `delayed_job` approach - allowing for the elegance of `model.delay.method` without the worry of queuing up the actual instance.
