### PR TITLE
Update redis version to fix issue using redis namespaces

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "sidekiq"
   gem.require_paths = ["lib"]
   gem.version       = Sidekiq::VERSION
-  gem.add_dependency                  'redis', '>= 3.0'
+  gem.add_dependency                  'redis', '>= 3.0.4'
   gem.add_dependency                  'redis-namespace'
   gem.add_dependency                  'connection_pool', '>= 1.0.0'
   gem.add_dependency                  'celluloid', '>= 0.14.1'


### PR DESCRIPTION
When a namespace is specified in the initializer, enqueuing jobs encounters an error:

```
2013-08-20T14:55:16Z 34503 TID-ox3zgd90c INFO: Sidekiq client using redis://localhost:6379/0 with options {:namespace=>"postal_service"}
NoMethodError: undefined method `is_a?' for <Redis::Future [:sadd, "postal_service:queues", :postback]>:Redis::Future
```

[ [full stack trace](http://gist.io/6284596) ]
