### PR TITLE
Implement process daemonizing for JRuby

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -28,6 +28,8 @@ module Sidekiq
 
     def initialize
       @code = nil
+
+      generate_restart_data
     end
 
     def parse(args=ARGV)
@@ -139,6 +141,15 @@ module Sidekiq
       return unless options[:daemon]
 
       raise ArgumentError, "You really should set a logfile if you're going to daemonize" unless options[:logfile]
+
+      if defined?(JRUBY_VERSION)
+        daemonize_jruby
+      else
+        daemonize_process
+      end
+    end
+
+    def daemonize_process
       files_to_reopen = []
       ObjectSpace.each_object(File) do |file|
         files_to_reopen << file unless file.closed?
@@ -165,12 +176,80 @@ module Sidekiq
       initialize_logger
     end
 
+    def daemonize_jruby
+      require 'sidekiq/jruby_restart'
+      already_daemon = false
+      already_daemon = JRubyRestart.daemon_init
+      if already_daemon
+        JRubyRestart.perm_daemonize
+      else
+        pid = nil
+
+        Signal.trap "SIGUSR2" do
+          logger.info "Started new sidekiq process #{pid} as daemon..."
+
+          # Must use exit! so we don't unwind and run the ensures
+          # that will be run by the new child (such as deleting the
+          # pidfile)
+          exit!(true)
+        end
+
+        Signal.trap "SIGCHLD" do
+          logger.info "Error starting new sidekiq process as daemon, exitting"
+          exit 1
+        end
+
+        pid = JRubyRestart.daemon_start(@restart_dir, @restart_argv)
+        sleep
+      end
+    end
+
     def set_environment(cli_env)
       @environment = cli_env || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
     end
 
     def die(code)
       exit(code)
+    end
+
+    def generate_restart_data
+      # Use the same trick as unicorn, namely favor PWD because
+      # it will contain an unresolved symlink, useful for when
+      # the pwd is /data/releases/current.
+      if dir = ENV['PWD']
+        s_env = File.stat(dir)
+        s_pwd = File.stat(Dir.pwd)
+
+        if s_env.ino == s_pwd.ino and s_env.dev == s_pwd.dev
+          @restart_dir = dir
+        end
+      end
+
+      @restart_dir ||= Dir.pwd
+
+      @original_argv = ARGV.dup
+
+      if defined? Rubinius::OS_ARGV
+        @restart_argv = Rubinius::OS_ARGV
+      else
+        require 'rubygems'
+
+        # if $0 is a file in the current directory, then restart
+        # it the same, otherwise add -S on there because it was
+        # picked up in PATH.
+        #
+        if File.exists?($0)
+          arg0 = [Gem.ruby, $0]
+        else
+          arg0 = [Gem.ruby, "-S", $0]
+        end
+
+        # Detect and reinject -Ilib from the command line
+        lib = File.expand_path "lib"
+        arg0[1,0] = ["-I", lib] if $:[0] == lib
+
+        @restart_argv = arg0 + ARGV
+      end
     end
 
     def setup_options(args)

--- a/lib/sidekiq/jruby_restart.rb
+++ b/lib/sidekiq/jruby_restart.rb
@@ -1,0 +1,82 @@
+require 'ffi'
+
+module Sidekiq
+  module JRubyRestart
+    extend FFI::Library
+    ffi_lib 'c'
+
+    attach_function :execlp, [:string, :varargs], :int
+    attach_function :chdir, [:string], :int
+    attach_function :fork, [], :int
+    attach_function :exit, [:int], :void
+    attach_function :setsid, [], :int
+
+    def self.chdir_exec(dir, argv)
+      chdir(dir)
+      cmd = argv.first
+      argv = ([:string] * argv.size).zip(argv).flatten
+      argv << :string
+      argv << nil
+      execlp(cmd, *argv)
+      raise SystemCallError.new(FFI.errno)
+    end
+
+    PermKey = 'SIDEKIQ_DAEMON_PERM'
+    RestartKey = 'SIDEKIQ_DAEMON_RESTART'
+
+    # Called to tell things "Your now always in daemon mode,
+    # don't try to reenter it."
+    #
+    def self.perm_daemonize
+      ENV[PermKey] = "1"
+    end
+
+    def self.daemon?
+      ENV.key?(PermKey) || ENV.key?(RestartKey)
+    end
+
+    def self.daemon_init
+      return true if ENV.key?(PermKey)
+
+      return false unless ENV.key? RestartKey
+
+      master = ENV[RestartKey]
+
+      # In case the master disappears early
+      begin
+        Process.kill "SIGUSR2", master.to_i
+      rescue SystemCallError => e
+      end
+
+      ENV[RestartKey] = ""
+
+      setsid
+
+      null = File.open "/dev/null", "w+"
+      STDIN.reopen null
+      STDOUT.reopen null
+      STDERR.reopen null
+
+      true
+    end
+
+    def self.daemon_start(dir, argv)
+      ENV['SIDEKIQ_DAEMON_RESTART'] = Process.pid.to_s
+
+      if k = ENV['SIDEKIQ_JRUBY_DAEMON_OPTS']
+        ENV['JRUBY_OPTS'] = k
+      end
+
+      cmd = argv.first
+      argv = ([:string] * argv.size).zip(argv).flatten
+      argv << :string
+      argv << nil
+
+      chdir(dir)
+      ret = fork
+      return ret if ret != 0
+      execlp(cmd, *argv)
+      raise SystemCallError.new(FFI.errno)
+    end
+  end
+end


### PR DESCRIPTION
This code originates in large parts from the Puma webserver.
See https://github.com/puma/puma. It has been slightly adapted
to fit the sidekiq code but is in and by itself mostly unchanged.

Daemonizing has been tested to work on the following platforms:
MRI 1.9.3p0 on Ubuntu Linux 12.04
MRI 1.9.3p448 on MacOS X
JRuby 1.7.4 / JDK 6 on MacOS X
JRuby 1.7.4 / JDK 7 on SmartOS

Testsuite seems „good“ - the failures on JRuby didn't change between commits and MRI is green except for a randomly failing test as reported in #1056
