### PR TITLE
bump the 'redis-namespace' gem

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Sidekiq::VERSION
   gem.add_dependency                  'redis', '>= 3.0.4'
-  gem.add_dependency                  'redis-namespace'
+  gem.add_dependency                  'redis-namespace', '>= 1.3.1'
   gem.add_dependency                  'connection_pool', '>= 1.0.0'
   gem.add_dependency                  'celluloid', '>= 0.14.1'
   gem.add_dependency                  'json'


### PR DESCRIPTION
pin the `redis-namespace` gem in order to pick up [a security fix](http://blog.steveklabnik.com/posts/2013-08-03-redis-namespace-1-3-1--security-release).
