### PR TITLE
logging controls for level and threshold of printing duration

### DIFF
--- a/lib/sidekiq/logging.rb
+++ b/lib/sidekiq/logging.rb
@@ -1,11 +1,6 @@
 require 'time'
 require 'logger'
 
-# open up a new attribute for logger
-class Logger
-  attr_accessor :threshold
-end
-
 module Sidekiq
   module Logging
 
@@ -35,7 +30,6 @@ module Sidekiq
       @logger = Logger.new(log_target)
       @logger.level = Logger::INFO
       @logger.formatter = Pretty.new
-      @logger.threshold = 0
       oldlogger.close if oldlogger && !$TESTING # don't want to close testing's STDOUT logging
       @logger
     end

--- a/lib/sidekiq/middleware/server/logging.rb
+++ b/lib/sidekiq/middleware/server/logging.rb
@@ -7,19 +7,17 @@ module Sidekiq
           Sidekiq::Logging.with_context("#{worker.class.to_s} JID-#{item['jid']}") do
             begin
               start = Time.now
-              logger.info { "start" } if logger.level <= Logger::INFO
+              logger.info { "start" } if log_level(worker) <= Logger::INFO
               yield
 
               # only output the finish if we're in INFO or lower, or there is a threshold and this is a long job
               t = elapsed(start)
 
-              if logger.threshold > 0 && t > logger.threshold
-                logger.warn { "done: #{t} sec" }
-              elsif logger.level <= Logger::INFO
+              if t > log_threshold(worker) || log_level(worker) <= Logger::INFO
                 logger.info { "done: #{t} sec" }
               end
             rescue Exception
-              logger.warn { "fail: #{elapsed(start)} sec" }
+              logger.info { "fail: #{elapsed(start)} sec" }
               raise
             end
           end
@@ -31,6 +29,14 @@ module Sidekiq
 
         def logger
           Sidekiq.logger
+        end
+
+        def log_level(worker)
+          worker.class.get_sidekiq_options['log_level'] || Logger::INFO
+        end
+
+        def log_threshold(worker)
+          worker.class.get_sidekiq_options['log_threshold'] || 0
         end
       end
     end

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -75,7 +75,7 @@ module Sidekiq
         self.sidekiq_retries_exhausted_block = block
       end
 
-      DEFAULT_OPTIONS = { 'retry' => true, 'queue' => 'default' }
+      DEFAULT_OPTIONS = { 'retry' => true, 'queue' => 'default', 'log_level' => nil, 'log_threshold' => nil }
 
       def get_sidekiq_options # :nodoc:
         self.sidekiq_options_hash ||= DEFAULT_OPTIONS


### PR DESCRIPTION
code is attached, usage for both would look like the following.

``` ruby
Sidekiq.configure_server do |config|
  # only output failed jobs
  config.logger.level = Logger::WARN

  # anything over 2.5 seconds needs attention
  # log them even though success
  config.logger.threshold = 2.5
end
```
