### PR TITLE
Log job args

### DIFF
--- a/lib/sidekiq/middleware/server/logging.rb
+++ b/lib/sidekiq/middleware/server/logging.rb
@@ -7,6 +7,7 @@ module Sidekiq
           Sidekiq::Logging.with_context("#{worker.class.to_s} JID-#{item['jid']}") do
             begin
               start = Time.now
+              logger.info { "args: #{item['args']}" }
               logger.info { "start" }
               yield
               logger.info { "done: #{elapsed(start)} sec" }


### PR DESCRIPTION
I found it a big help to see the arguments of a job in the log file, because when a large number of jobs run simultaneously, and one of them fails, it's often impossible to find out which one it was without this info.
