### PR TITLE
remove preference to REDISTOGO_URL environment variable

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -49,8 +49,6 @@ module Sidekiq
       end
 
       def determine_redis_provider
-        # REDISTOGO_URL is only support for legacy reasons
-        return ENV['REDISTOGO_URL'] if ENV['REDISTOGO_URL']
         provider = ENV['REDIS_PROVIDER'] || 'REDIS_URL'
         ENV[provider]
       end


### PR DESCRIPTION
Having this piece of code makes it difficult to switch providers, as the presence of the `REDISTOGO_URL` environment variable takes precedence over any user-set configuration.
