### PR TITLE
Allow configuring worker defaults

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -89,6 +89,14 @@ module Sidekiq
     @server_chain
   end
 
+  def self.default_worker_options=(hash)
+    @default_worker_options = default_worker_options.merge(hash)
+  end
+
+  def self.default_worker_options
+    @default_worker_options || { 'retry' => true, 'queue' => 'default' }
+  end
+
   def self.load_json(string)
     JSON.parse(string)
   end

--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -129,7 +129,7 @@ module Sidekiq
           normalized_item = item['class'].get_sidekiq_options.merge(item)
           normalized_item['class'] = normalized_item['class'].to_s
         else
-          normalized_item = Sidekiq::Worker::ClassMethods::DEFAULT_OPTIONS.merge(item)
+          normalized_item = Sidekiq.default_worker_options.merge(item)
         end
 
         normalized_item['jid'] ||= SecureRandom.hex(12)

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -75,10 +75,8 @@ module Sidekiq
         self.sidekiq_retries_exhausted_block = block
       end
 
-      DEFAULT_OPTIONS = { 'retry' => true, 'queue' => 'default' }
-
       def get_sidekiq_options # :nodoc:
-        self.sidekiq_options_hash ||= DEFAULT_OPTIONS
+        self.sidekiq_options_hash ||= Sidekiq.default_worker_options
       end
 
       def client_push(item) # :nodoc:

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -70,7 +70,7 @@ class TestClient < Minitest::Test
     end
 
     it 'has default options' do
-      assert_equal Sidekiq::Worker::ClassMethods::DEFAULT_OPTIONS, MyWorker.get_sidekiq_options
+      assert_equal Sidekiq.default_worker_options, MyWorker.get_sidekiq_options
     end
 
     it 'handles perform_async' do


### PR DESCRIPTION
Configuring worker defaults is very useful in cases where you want to turn on `backtrace: true` on all workers, or disabling `retry` capabilities.
