### PR TITLE
extract index logic into method

### DIFF
--- a/lib/sidekiq/middleware/chain.rb
+++ b/lib/sidekiq/middleware/chain.rb
@@ -83,16 +83,16 @@ module Sidekiq
       end
 
       def insert_before(oldklass, newklass, *args)
-        i = entries.index { |entry| entry.klass == newklass }
+        i = get_index(newklass)
         new_entry = i.nil? ? Entry.new(newklass, *args) : entries.delete_at(i)
-        i = entries.find_index { |entry| entry.klass == oldklass } || 0
+        i = get_index(oldklass) || 0
         entries.insert(i, new_entry)
       end
 
       def insert_after(oldklass, newklass, *args)
-        i = entries.index { |entry| entry.klass == newklass }
+        i = get_index(newklass)
         new_entry = i.nil? ? Entry.new(newklass, *args) : entries.delete_at(i)
-        i = entries.find_index { |entry| entry.klass == oldklass } || entries.count - 1
+        i = get_index(oldklass) || entries.count - 1
         entries.insert(i+1, new_entry)
       end
 
@@ -118,6 +118,10 @@ module Sidekiq
           end
         end
         traverse_chain.call
+      end
+    private
+      def get_index(klass)
+        entries.find_index {|entry| entry.klass == klass }
       end
     end
 


### PR DESCRIPTION
Before this was repeating the same logic over and over to get the index of an entry (if one exists).
This just extracts that similar logic into it's own method.
