### PR TITLE
Capistrano: deploy:finalize_update for sidekiq:quiet

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -9,7 +9,7 @@ Capistrano::Configuration.instance.load do
   _cset(:sidekiq_processes) { 1 }
 
   if fetch(:sidekiq_default_hooks)
-    before "deploy:update_code", "sidekiq:quiet"
+    before "deploy:finalize_update", "sidekiq:quiet"
     after "deploy:stop",    "sidekiq:stop"
     after "deploy:start",   "sidekiq:start"
     before "deploy:restart", "sidekiq:restart"


### PR DESCRIPTION
Use deploy:finalize_update because the bundle:install is triggered
on this hooks.
