### PR TITLE
Show retries in specific queue

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -209,6 +209,10 @@ module Sidekiq
       @parent = parent
     end
 
+    def message
+      @value
+    end
+
     def at
       Time.at(score).utc
     end

--- a/lib/sidekiq/paginator.rb
+++ b/lib/sidekiq/paginator.rb
@@ -1,6 +1,14 @@
 module Sidekiq
   module Paginator
     def page(key, pageidx=1, page_size=25)
+      if key.respond_to? :each
+        page_enumerable(key, pageidx, page_size)
+      else
+        page_redis(key, pageidx, page_size)
+      end
+    end
+
+    def page_redis(key, pageidx, page_size)
       current_page = pageidx.to_i < 1 ? 1 : pageidx.to_i
       pageidx = current_page - 1
       total_size = 0
@@ -24,6 +32,14 @@ module Sidekiq
           raise "can't page a #{type}"
         end
       end
+
+      [current_page, total_size, items]
+    end
+
+    def page_enumerable(array, pageidx, page_size)
+      current_page = pageidx.to_i < 1 ? 1 : pageidx.to_i
+      total_size = array.size
+      items = array.slice((current_page - 1) * page_size, page_size)
 
       [current_page, total_size, items]
     end

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -11,6 +11,7 @@ en: # <---- change this to your locale code
   Failed: Failed
   Scheduled: Scheduled
   Retries: Retries
+  RetriesInQueue: Retries in <span class='title'>%{queue}</span>
   Enqueued: Enqueued
   ClearWorkerList: Clear workers list
   Worker: Worker

--- a/web/views/retries.erb
+++ b/web/views/retries.erb
@@ -1,10 +1,14 @@
 <header class="row">
   <div class="span5">
-    <h3><%= t('Retries') %></h3>
+    <% if @name %>
+      <h3><%= t('RetriesInQueue', :queue => @name) %></h3>
+    <% else %>
+      <h3><%= t('Retries') %></h3>
+    <% end %>
   </div>
   <div class="span4">
     <% if @retries.size > 0 %>
-      <%= erb :_paging, :locals => { :url => "#{root_path}retries" } %>
+      <%= erb :_paging, :locals => { :url => @paging_path} %>
     <% end %>
   </div>
 </header>
@@ -32,7 +36,7 @@
           </td>
           <td><%= msg['retry_count'] %></td>
           <td>
-            <a href="<%= root_path %>queues/<%= msg['queue'] %>"><%= msg['queue'] %></a>
+            <a href="<%= root_path %>retries/in/<%= msg['queue'] %>"><%= msg['queue'] %></a>
           </td>
           <td><%= msg['class'] %></td>
           <td>


### PR DESCRIPTION
I often want to see just retries in the specific queue. This patch adds support for "retries/in/#{queue}" endpoint which will filter the failures. Clicking the name of the queue in the Retries view will show only the filtered failures.

![retries-in-queue](https://f.cloud.github.com/assets/19076/1172342/531f7b5c-211e-11e3-9422-4a55edd9a803.gif)

I have only included English localization, since I don't speak any other languages that sidekiq supports.
