### PR TITLE
Allow scheduling Workers only once for a given interval and set of arguments

### DIFF
--- a/test/test_scheduling.rb
+++ b/test/test_scheduling.rb
@@ -34,6 +34,17 @@ class TestScheduling < Sidekiq::Test
       assert Sidekiq::Client.push_bulk('class' => ScheduledWorker, 'args' => [['mike'], ['mike']], 'at' => 600)
       @redis.verify
     end
+
+    it 'schedules a job only once' do
+      job = Minitest::Mock.new
+      def job.klass; 'TestScheduling::ScheduledWorker'; end
+      def job.score; Time.utc(2013, 9, 25, 5).to_f end
+      def job.args; ['vlad']; end
+      Sidekiq::ScheduledSet.stub :new, [job] do
+        ScheduledWorker.perform_once_in(Time.utc(2013, 9, 25, 5), 'vlad')
+      end
+      @redis.verify
+    end
   end
 
 end


### PR DESCRIPTION
We needed to be able to schedule a Worker only once for a given combination of timestamp and arguments, so we built it as a part of our application.

This code is extracted from the application and made generic, in hopes that it may be useful to other users of sidekiq. I did not open a discussion about it first, since it did not take a lot of time to extract this from our application, so I hope you find it acceptable to include in sidekiq.
