### PR TITLE
improve usability on mobile-ui for redis stats on dashboard

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -290,7 +290,6 @@ img.smallogo {
 .poll-status {
   padding: 10px 0;
 }
-
 .stat {
   float: left;
   text-align: center;
@@ -304,7 +303,23 @@ img.smallogo {
 .stat p {
   font-size: 0.9em;
 }
-
+@media (max-width: 767px) {
+  .stat {
+    float: none;
+    margin-right: 10px;
+    width: 100%;
+    text-align: left;
+    line-height: 45px;
+  }
+  .stat h3{
+    float: right;
+    margin: 5px 10px 5px 5px;
+  }
+  .stat p{
+    font-size: normal;
+    margin: 5px 5px 5px 10px;
+  }
+}
 .beacon {
   position: relative;
   height: 20px;


### PR DESCRIPTION
i actually would migrate to bootstrap 3 since there are a lot of usability improvements right out of the box, but that implies a lot of markup refactoring... well not that much, but to be not that invasive i just add this CSS improvement which makes it look better behind 768px width screen. 

try it on vertical tablet, phone or a small window in desktop. 
