### PR TITLE
Update changelog link to Testing section of wiki.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,7 +7,7 @@
   appear to be doing any work. [#1194]
 - Sidekiq's testing behavior is now dynamic.  You can choose between
   `inline` and `fake` behavior in your tests. See
-[Testing](wiki/Testing) for detail. [#1193]
+[Testing](https://github.com/mperham/sidekiq/wiki/Testing) for detail. [#1193]
 - The Retries table has a new column for the error message.
 - The Web UI topbar now contains the status and live poll button.
 - Orphaned worker records are now auto-vacuumed when you vist the


### PR DESCRIPTION
The link of (wiki/Testing) expands to https://github.com/mperham/sidekiq/blob/master/wiki/Testing which then 404s.
