### PR TITLE
Added comments in upstart sidekiq.conf files about normal exit codes to avoid unintentional respawns

### DIFF
--- a/examples/upstart/manage-many/sidekiq.conf
+++ b/examples/upstart/manage-many/sidekiq.conf
@@ -28,7 +28,7 @@ respawn
 respawn limit 3 30
 
 # TERM and USR1 are sent by sidekiqctl when stopping sidekiq.  Without declaring these as normal exit codes, it just respawns.
-#normal exit 0 TERM USR1
+normal exit 0 TERM USR1
 
 instance ${app}-${index}
 

--- a/examples/upstart/manage-one/sidekiq.conf
+++ b/examples/upstart/manage-one/sidekiq.conf
@@ -28,7 +28,7 @@ respawn
 respawn limit 3 30
 
 # TERM and USR1 are sent by sidekiqctl when stopping sidekiq.  Without declaring these as normal exit codes, it just respawns.
-#normal exit 0 TERM USR1
+normal exit 0 TERM USR1
 
 instance $index
 


### PR DESCRIPTION
I found that when I tried to use initctl to stop the sidekiq processes, they would just respawn because the exit codes of TERM / USR1 were 'normal' exits.  By default, only 0 is a normal exit code.
I put in lines for declaring 0, TERM, and USR1 as normal exit codes to avoid respawning - but I left them commented out as I'm not sure if that what you want in you examples.
I think it is still useful for other users to know what do in case they want to completely shutdown sidekiq - as I like to do before starting a deployment.

Thanks for the great example scripts.
