### PR TITLE
Add a "latency" stat in the dashboard

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -327,7 +327,7 @@ module Sidekiq
           enqueued:   sidekiq_stats.enqueued,
           scheduled:  sidekiq_stats.scheduled_size,
           retries:    sidekiq_stats.retry_size,
-          latency:    queue.latency,
+          default_latency: queue.latency,
         },
         redis: redis_stats
       })

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -326,7 +326,7 @@ class TestWeb < Sidekiq::Test
         end
 
         it 'reports latency' do
-          assert_equal 0, @response["sidekiq"]["latency"]
+          assert_equal 0, @response["sidekiq"]["default_latency"]
         end
       end
 


### PR DESCRIPTION
I've added the latency metric in the `/dashboard/stats` response.

It is useful to collect metrics (for Munin or else) without using Ruby and Sidekiq's DSL at all.
