### PR TITLE
Logging: severity before all?

### DIFF
--- a/lib/sidekiq/logging.rb
+++ b/lib/sidekiq/logging.rb
@@ -7,7 +7,7 @@ module Sidekiq
     class Pretty < Logger::Formatter
       # Provide a call() method that returns the formatted message.
       def call(severity, time, program_name, message)
-        "#{time.utc.iso8601} #{Process.pid} TID-#{Thread.current.object_id.to_s(36)}#{context} #{severity}: #{message}\n"
+        "#{severity} #{time.utc.iso8601} #{Process.pid} TID-#{Thread.current.object_id.to_s(36)}#{context} #{message}\n"
       end
 
       def context


### PR DESCRIPTION
Afaik, no RFC says where the LOGLEVEL (or severity) should go, but analyzing some logs (doing a lot of it this week) you may say severity first is a convention. (Out of ~30 different 'things' from unix stuff, to dbs and servers, only sidekiq and haproxy use loglevel in the end). Also, maybe we could suppress process id and time, as it'll be handled by the log library (log4r/syslog-ng...), which leads me to:

Ideally, we could customize the Formatter#call method? Think logstash and alikes: lots of ppl going the json_event way, for instance, instead of plain logs.

I would be happy to try a customize for the call method, if you think it's a good feat.
For now a lil change in the name of convention over configuration ;)
