### PR TITLE
don't fail when handling an exception with a nil backtrace

### DIFF
--- a/lib/sidekiq/exception_handler.rb
+++ b/lib/sidekiq/exception_handler.rb
@@ -4,7 +4,7 @@ module Sidekiq
     def handle_exception(ex, ctxHash={})
       Sidekiq.logger.warn(ctxHash) if !ctxHash.empty?
       Sidekiq.logger.warn ex
-      Sidekiq.logger.warn ex.backtrace.join("\n")
+      Sidekiq.logger.warn ex.backtrace.join("\n") unless ex.backtrace.nil?
       # This list of services is getting a bit ridiculous.
       # For future error services, please add your own
       # middleware like BugSnag does:

--- a/test/test_exception_handler.rb
+++ b/test/test_exception_handler.rb
@@ -37,6 +37,20 @@ class TestExceptionHandler < Sidekiq::Test
       assert_match /Something didn't work!/, log[1], "didn't include the exception message"
       assert_match /test\/test_exception_handler.rb/, log[2], "didn't include the backtrace"
     end
+
+    describe "when the exception does not have a backtrace" do
+      it "does not fail" do
+        exception = ExceptionHandlerTestException.new
+        assert_nil exception.backtrace
+
+        begin
+          Component.new.handle_exception exception
+          pass
+        rescue => e
+          flunk "failed handling a nil backtrace"
+        end
+      end
+    end
   end
 
   describe "with fake Airbrake" do


### PR DESCRIPTION
Hey there!

If you pass an exception to Sidekiq's `handle_exception` which is "sans backtrace", it asplodes because it tries to `join` it to print to `Sidekiq.logger`. I've ignored that step in that case, and added a spec to cover it.

Kapow!
