### PR TITLE
Class level logging

### DIFF
--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -25,13 +25,17 @@ module Sidekiq
 
     def self.included(base)
       base.extend(ClassMethods)
+      base.extend(Logging)
+      base.send :include, Logging
       base.class_attribute :sidekiq_options_hash
       base.class_attribute :sidekiq_retry_in_block
       base.class_attribute :sidekiq_retries_exhausted_block
     end
 
-    def logger
-      Sidekiq.logger
+    module Logging
+      def logger
+        Sidekiq.logger
+      end
     end
 
     module ClassMethods


### PR DESCRIPTION
Based on the [error handling article](https://github.com/mperham/sidekiq/wiki/Error-Handling) in the Sidekiq wiki. I should be able to use the Sidekiq logger in class methods such as `sidekiq_retries_exhausted`. I found this not to be true earlier today. Definitely open to feedback on the implementation. I didn't want to just copy the logger method into the `ClassMethods` module.
