### PR TITLE
Use pessimistic version constraint for all runtime dependencies

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -14,15 +14,15 @@ Gem::Specification.new do |gem|
   gem.name          = "sidekiq"
   gem.require_paths = ["lib"]
   gem.version       = Sidekiq::VERSION
-  gem.add_dependency                  'redis', '>= 3.0.4'
-  gem.add_dependency                  'redis-namespace', '>= 1.3.1'
-  gem.add_dependency                  'connection_pool', '>= 1.0.0'
-  gem.add_dependency                  'celluloid', '>= 0.15.2'
-  gem.add_dependency                  'json'
-  gem.add_development_dependency      'sinatra'
-  gem.add_development_dependency      'minitest', '~> 4.2'
-  gem.add_development_dependency      'rake'
-  gem.add_development_dependency      'actionmailer', '>= 4.0.0'
-  gem.add_development_dependency      'activerecord', '>= 4.0.0'
-  gem.add_development_dependency      'coveralls'
+  gem.add_dependency             'celluloid', '~> 0.15.2'
+  gem.add_dependency             'connection_pool', '~> 1.0'
+  gem.add_dependency             'json', '~> 1.0'
+  gem.add_dependency             'redis', ['~> 3.0', '>= 3.0.4']
+  gem.add_dependency             'redis-namespace', ['~> 1.3', '>= 1.3.1']
+  gem.add_development_dependency 'actionmailer', '>= 4'
+  gem.add_development_dependency 'activerecord', '>= 4'
+  gem.add_development_dependency 'coveralls'
+  gem.add_development_dependency 'minitest', '~> 4.2'
+  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'sinatra'
 end


### PR DESCRIPTION
Please read [**Using `>=` Considered Harmful (or, What’s Wrong With `>=`)**](http://yehudakatz.com/2010/08/21/using-considered-harmful-or-whats-wrong-with/). If anyone understandings Ruby versioning best practices, it’s @wycats, and he specifically advises against using `>=` without a corresponding `<`:

> One thing for certain though: you cannot be sure that your gem works with every future version of your dependencies. Sanely versioned gems take the opportunity of a major release to break things, and until you have actually tested against the new versions, it’s madness to claim compatibility. One example: a number of gems have dependencies on activesupport >= 2.3. In a large number of cases, these gems do not work correctly with ActiveSuport 3.0, since we changed how components of ActiveSupport get loaded to make it easier to cherry-pick.
> 
> Now, instead of receiving a version conflict, users of these gems will get cryptic runtime error messages. Even worse, everything might appear to work, until some weird edge-case is exercised in production, and which your tests would have caught.
