### PR TITLE
Capistrano V3 Support.

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -1,54 +1,5 @@
-Capistrano::Configuration.instance.load do
-
-  _cset(:sidekiq_default_hooks) { true }
-  _cset(:sidekiq_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" }
-  _cset(:sidekiqctl_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" }
-  _cset(:sidekiq_timeout)   { 10 }
-  _cset(:sidekiq_role)      { :app }
-  _cset(:sidekiq_pid)       { "#{current_path}/tmp/pids/sidekiq.pid" }
-  _cset(:sidekiq_processes) { 1 }
-
-  if fetch(:sidekiq_default_hooks)
-    before "deploy:update_code", "sidekiq:quiet"
-    after "deploy:stop",    "sidekiq:stop"
-    after "deploy:start",   "sidekiq:start"
-    before "deploy:restart", "sidekiq:restart"
-  end
-
-  namespace :sidekiq do
-    def for_each_process(&block)
-      fetch(:sidekiq_processes).times do |idx|
-        yield((idx == 0 ? "#{fetch(:sidekiq_pid)}" : "#{fetch(:sidekiq_pid)}-#{idx}"), idx)
-      end
-    end
-
-    desc "Quiet sidekiq (stop accepting new work)"
-    task :quiet, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
-      for_each_process do |pid_file, idx|
-        run "if [ -d #{current_path} ] && [ -f #{pid_file} ] && kill -0 `cat #{pid_file}`> /dev/null 2>&1; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} quiet #{pid_file} ; else echo 'Sidekiq is not running'; fi"
-      end
-    end
-
-    desc "Stop sidekiq"
-    task :stop, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
-      for_each_process do |pid_file, idx|
-        run "if [ -d #{current_path} ] && [ -f #{pid_file} ] && kill -0 `cat #{pid_file}`> /dev/null 2>&1; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} stop #{pid_file} #{fetch :sidekiq_timeout} ; else echo 'Sidekiq is not running'; fi"
-      end
-    end
-
-    desc "Start sidekiq"
-    task :start, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
-      rails_env = fetch(:rails_env, "production")
-      for_each_process do |pid_file, idx|
-        run "cd #{current_path} ; nohup #{fetch(:sidekiq_cmd)} -e #{rails_env} -C #{current_path}/config/sidekiq.yml -i #{idx} -P #{pid_file} >> #{current_path}/log/sidekiq.log 2>&1 &", :pty => false
-      end
-    end
-
-    desc "Restart sidekiq"
-    task :restart, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
-      stop
-      start
-    end
-
-  end
+if Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
+  load File.expand_path("../tasks/sidekiq.rake", __FILE__)
+else
+  require_relative 'capistrano2'
 end

--- a/lib/sidekiq/capistrano2.rb
+++ b/lib/sidekiq/capistrano2.rb
@@ -1,0 +1,54 @@
+Capistrano::Configuration.instance.load do
+
+  _cset(:sidekiq_default_hooks) { true }
+  _cset(:sidekiq_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiq" }
+  _cset(:sidekiqctl_cmd) { "#{fetch(:bundle_cmd, "bundle")} exec sidekiqctl" }
+  _cset(:sidekiq_timeout)   { 10 }
+  _cset(:sidekiq_role)      { :app }
+  _cset(:sidekiq_pid)       { "#{current_path}/tmp/pids/sidekiq.pid" }
+  _cset(:sidekiq_processes) { 1 }
+
+  if fetch(:sidekiq_default_hooks)
+    before "deploy:update_code", "sidekiq:quiet"
+    after "deploy:stop",    "sidekiq:stop"
+    after "deploy:start",   "sidekiq:start"
+    before "deploy:restart", "sidekiq:restart"
+  end
+
+  namespace :sidekiq do
+    def for_each_process(&block)
+      fetch(:sidekiq_processes).times do |idx|
+        yield((idx == 0 ? "#{fetch(:sidekiq_pid)}" : "#{fetch(:sidekiq_pid)}-#{idx}"), idx)
+      end
+    end
+
+    desc "Quiet sidekiq (stop accepting new work)"
+    task :quiet, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
+      for_each_process do |pid_file, idx|
+        run "if [ -d #{current_path} ] && [ -f #{pid_file} ] && kill -0 `cat #{pid_file}`> /dev/null 2>&1; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} quiet #{pid_file} ; else echo 'Sidekiq is not running'; fi"
+      end
+    end
+
+    desc "Stop sidekiq"
+    task :stop, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
+      for_each_process do |pid_file, idx|
+        run "if [ -d #{current_path} ] && [ -f #{pid_file} ] && kill -0 `cat #{pid_file}`> /dev/null 2>&1; then cd #{current_path} && #{fetch(:sidekiqctl_cmd)} stop #{pid_file} #{fetch :sidekiq_timeout} ; else echo 'Sidekiq is not running'; fi"
+      end
+    end
+
+    desc "Start sidekiq"
+    task :start, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
+      rails_env = fetch(:rails_env, "production")
+      for_each_process do |pid_file, idx|
+        run "cd #{current_path} ; nohup #{fetch(:sidekiq_cmd)} -e #{rails_env} -C #{current_path}/config/sidekiq.yml -i #{idx} -P #{pid_file} >> #{current_path}/log/sidekiq.log 2>&1 &", :pty => false
+      end
+    end
+
+    desc "Restart sidekiq"
+    task :restart, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
+      stop
+      start
+    end
+
+  end
+end

--- a/lib/sidekiq/capistrano3.rb
+++ b/lib/sidekiq/capistrano3.rb
@@ -1,1 +1,0 @@
-load File.expand_path("../tasks/sidekiq.rake", __FILE__)


### PR DESCRIPTION
This patch adds support for capistrano V3.  No existing files were modified.  Just new V3 specific files added.

To get it working (assuming bundler is being used) add the following to Capfile:

```
require 'sidekiq/capistrano3'
```

And this to config/deploy.rb:

```
SSHKit.config.command_map[:sidekiq] = "bundle exec sidekiq"
SSHKit.config.command_map[:sidekiqctl] = "bundle exec sidekiqctl"
```

The above works around an issue with SSHKit that prevents it from changing to the correct directory if the first string of the command to be executed contains spaces.  Not ideal, but it's life for now.

I can update the Wiki with links/instructions once you merge it if you'd like.
