### PR TITLE
Fixes Live Pool button on web UI for smartphone devices, see #1218

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -82,16 +82,8 @@ h3 {
   padding: 60px 0;
 }
 
-.row.header .actions {
-  padding-top: 0.9em;
-}
-
 header.row .pagination {
   margin: 12px 0;
-}
-
-.summary_bar .actions {
-  padding: 10px 0px;
 }
 
 .summary_bar .status {
@@ -114,7 +106,7 @@ header.row .pagination {
   border-width: 0px;
 }
 .poll-wrapper {
-  padding: 9px 0 0 0;
+  margin: 9px 0px;
 }
 .nav #live-poll {
   height: 25px;
@@ -551,8 +543,7 @@ img.smallogo {
   }
 
   .poll-wrapper {
-    padding: 0px 20px 5px 0px;
-    width: 20%;
+    margin: 0px 9px 9px;
   }
 
   .navbar.navbar-fixed-bottom ul {

--- a/web/views/_nav.erb
+++ b/web/views/_nav.erb
@@ -23,7 +23,7 @@
       <% end %>
     </ul>
 
-    <div class="col-sm-2 pull-right poll-wrapper">
+    <div class="poll-wrapper pull-right">
       <%= erb :_poll %>
     </div>
   </div>

--- a/web/views/_poll.erb
+++ b/web/views/_poll.erb
@@ -4,11 +4,9 @@
   </script>
 <% end %>
 <% unless current_path == '' %>
-  <div class="actions">
-    <% if params[:poll] %>
-      <a id="live-poll" class="btn btn-block btn-primary active" href="<%= root_path %><%= current_path %>"><%= t('StopPolling') %></a>
-    <% else %>
-      <a id="live-poll" class="btn btn-block btn-primary" href="<%= root_path %><%= current_path %>?poll=true"><%= t('LivePoll') %></a>
-    <% end %>
-  </div>
+  <% if params[:poll] %>
+    <a id="live-poll" class="btn btn-primary active" href="<%= root_path %><%= current_path %>"><%= t('StopPolling') %></a>
+  <% else %>
+    <a id="live-poll" class="btn btn-primary" href="<%= root_path %><%= current_path %>?poll=true"><%= t('LivePoll') %></a>
+  <% end %>
 <% end %>


### PR DESCRIPTION
Removes constraints so the text fits the button regardless of length (i18n) or screen width. See #1218.

![after before](http://f.cl.ly/items/17412g1S3542453H1F1e/beforeafter.png)

Note: this removes the padding the button used to have on the regular version (no media queries).
