### PR TITLE
Only eager load when I want you to!

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -197,7 +197,7 @@ module Sidekiq
         require 'rails'
         require 'sidekiq/rails'
         require File.expand_path("#{options[:require]}/config/environment.rb")
-        ::Rails.application.eager_load!
+        ::Rails.application.eager_load! if ::Rails.application.config.eager_load
         options[:tag] ||= default_tag
       else
         require options[:require]


### PR DESCRIPTION
We are having a problem with a config class getting loaded twice in development mode (where cache_classes is set to false).  This causes the config class's configured values to be reset back to the default values - not good.

An example of our output when starting sidekiq in an environment where cache_classes is false:

```
$ RAILS_ENV=development_integration be sidekiq
!!! This should only happen once
Before eager loading
!!! This should only happen once
After eager loading
2013-10-21T22:09:46Z 83047 TID-ow3nrisws INFO: Booting Sidekiq 2.10.1 using redis://localhost:6379/0 with options {:namespace=>"myapp.development_integration"}
```

I added an `if` statement on the `eager_load!` line to check if we've configured our application to eager load or not.  I realize that this may not be the best solution, but it provides us with what we need right now.

What would be your suggested approach to this problem?
