### PR TITLE
Display the full Redis connection in Web footer

### DIFF
--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -76,6 +76,10 @@ module Sidekiq
     def location
       Sidekiq.redis { |conn| conn.client.location }
     end
+    
+    def redis_connection
+      Sidekiq.redis { |conn| conn.client.id }
+    end
 
     def namespace
       @@ns ||= Sidekiq.redis {|conn| conn.respond_to?(:namespace) ? conn.namespace : nil }

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -35,7 +35,7 @@
               <p class="navbar-text" style="color:white;">Sidekiq v<%= Sidekiq::VERSION %></p>
             </li>
             <li>
-              <p class="navbar-text">Redis: <%= location %></p>
+              <p class="navbar-text">Redis: <%= redis_connection %></p>
             </li>
             <li>
               <p class="navbar-text"><%= t('Time') %>: <%= Time.now.utc.strftime('%H:%M:%S UTC') %></p>


### PR DESCRIPTION
The web interface shows the Redis location in the footer.

Since we can connect to Redis with the full array of options, we can have a combination of socket and non-0 database, which would not be properly displayed.

The Redis client supports an `#id` method that just does what we need.

I've added a helper method `#redis_connection` that delegates to Redis' client ID method.

![sidekiq 2013-10-22 16-23-09](https://f.cloud.github.com/assets/5142/1381777/7ada7c98-3b25-11e3-87d4-8a1186638a4e.png)

Since there is no test for this, I've not added some, and I didn't delete the existing `#location` helper either.
