### PR TITLE
Adding the -C option into capistrano 3 task

### DIFF
--- a/lib/sidekiq/tasks/sidekiq.rake
+++ b/lib/sidekiq/tasks/sidekiq.rake
@@ -14,7 +14,7 @@ namespace :load do
     set :sidekiq_pid,           ->{ "tmp/sidekiq.pid" }
 
                                   # "-d -i INT -P PATH" are added automatically.
-    set :sidekiq_options,       ->{ "-e #{fetch(:rails_env, 'production')} -L #{current_path}/log/sidekiq.log" }
+    set :sidekiq_options,       ->{ "-e #{fetch(:rails_env, 'production')} -C #{current_path}/config/sidekiq.yml -L #{current_path}/log/sidekiq.log" }
 
     set :sidekiq_timeout,       ->{ 10 }
     set :sidekiq_role,          ->{ :app }


### PR DESCRIPTION
Looking into the old Capistrano2 tasks I noticed the -C option was missing in the new version.
