### PR TITLE
Allow retrying a job even when rescuing an exception

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -65,6 +65,11 @@ module Sidekiq
           raise
         rescue Exception => e
           raise e unless msg['retry']
+          process_retry_exception(worker, msg, queue, e)
+          raise e
+        end
+
+        def process_retry_exception(worker, msg, queue, e)
           max_retry_attempts = retry_attempts_from(msg['retry'], @max_retries)
 
           msg['queue'] = if msg['retry_queue']
@@ -102,8 +107,6 @@ module Sidekiq
             # Goodbye dear message, you (re)tried your best I'm sure.
             retries_exhausted(worker, msg)
           end
-
-          raise e
         end
 
         def retries_exhausted(worker, msg)


### PR DESCRIPTION
One of our Sidekiq workers often encounters various "transient" errors (timeouts, IO errors, etc). Since the processing usually succeeds after the 2nd or 3rd attempt, we'd like to suppress those exceptions so that they don't hit our exception notification service (BugSnag) until they've been retried a certain number of times. However, we still need Sidekiq to register the job as a failure and schedule it to be retried. We couldn't think of a way to do this with the current Sidekiq::Middleware::Server::RetryJobs instrumentation.

With this PR, our custom middleware accomplishes what we're trying to do:

``` ruby
module SidekiqTransientExceptions

  class Middleware

    def call worker, job, queue
      begin
        yield
      rescue Exception => ex
        retries = job['retry_count'] || 0
        raise_exception = ex.is_a?(TransientException) ? retries >= TransientException.retry_limit : true

        if raise_exception
          # exception re-raised by SidekiqTransientExceptions
          raise ex
        else
          # exception silenced by SidekiqTransientExceptions, but job scheduled to be retried
          Sidekiq::Middleware::Server::RetryJobs.new.process_retry_exception worker, job, queue, ex
        end
      end

    end

  end

end
```

Where the exception originates:

``` ruby
class MyWorker

  include Sidekiq::Worker
  sidekiq_options :retry => 5

  class TransientException < Exception
    def self.retry_limit ; 3 ; end
  end

  def perform
    begin
      some_function! # sometimes raises an IOError, SocketError, Timeout::Error
    rescue IOError, SocketError, Timeout::Error => ex
      raise TransientException.new(message: ex.message)
    end
  end
end
```

Of course, if there's a better way to accomplish this then we're all ears :)
