### PR TITLE
Allow polling and paging parameters to work together in Sidekiq web ui

### DIFF
--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -76,7 +76,7 @@ module Sidekiq
     def location
       Sidekiq.redis { |conn| conn.client.location }
     end
-    
+
     def redis_connection
       Sidekiq.redis { |conn| conn.client.id }
     end
@@ -108,6 +108,16 @@ module Sidekiq
     def parse_params(params)
       score, jid = params.split("-")
       [score.to_f, jid]
+    end
+
+    SAFE_QPARAMS = %w(page poll)
+
+    # Merge options with current params, filter safe params, and stringify to query string
+    def qparams(options)
+      options = options.stringify_keys
+      params.merge(options).map { |key, value|
+        SAFE_QPARAMS.include?(key) ? "#{key}=#{value}" : next
+      }.join("&")
     end
 
     def truncate(text, truncate_after_chars = 2000)

--- a/web/views/_paging.erb
+++ b/web/views/_paging.erb
@@ -1,23 +1,23 @@
 <% if @total_size > @count %>
   <ul class="pagination pull-right">
     <li class="<%= 'disabled' if @current_page == 1 %>">
-      <a href="<%= url %>?page=1">«</a>
+      <a href="<%= url %>?page=1">&laquo;</a>
     </li>
     <% if @current_page > 1 %>
       <li>
-        <a href="<%= url %>?page=<%= @current_page - 1 %>"><%= @current_page - 1 %></a>
+        <a href="<%= url %>?<%= qparams(page: @current_page - 1) %>"><%= @current_page - 1 %></a>
       </li>
     <% end %>
     <li class="disabled">
-      <a href="<%= url %>?page=<%= @current_page %>"><%= @current_page %></a>
+      <a href="<%= url %>?<%= qparams(page: @current_page) %>"><%= @current_page %></a>
     </li>
     <% if @total_size > @current_page * @count %>
       <li>
-        <a href="<%= url %>?page=<%= @current_page + 1 %>"><%= @current_page + 1 %></a>
+        <a href="<%= url %>?<%= qparams(page: @current_page + 1) %>"><%= @current_page + 1 %></a>
       </li>
     <% end %>
     <li class="<%= 'disabled' if @total_size <= @current_page * @count %>">
-      <a href="<%= url %>?page=<%= (@total_size.to_f / @count).ceil %>">»</a>
+      <a href="<%= url %>?<%= qparams(page: (@total_size.to_f / @count).ceil) %>">&raquo;</a>
     </li>
   </ul>
 <% end %>

--- a/web/views/_poll.erb
+++ b/web/views/_poll.erb
@@ -7,6 +7,6 @@
   <% if params[:poll] %>
     <a id="live-poll" class="btn btn-primary active" href="<%= root_path %><%= current_path %>"><%= t('StopPolling') %></a>
   <% else %>
-    <a id="live-poll" class="btn btn-primary" href="<%= root_path %><%= current_path %>?poll=true"><%= t('LivePoll') %></a>
+    <a id="live-poll" class="btn btn-primary" href="<%= root_path %><%= current_path %>?<%= qparams(poll: true) %>"><%= t('LivePoll') %></a>
   <% end %>
 <% end %>


### PR DESCRIPTION
This should address #1185. I can change the braces block syntax in the `qparams` method if the `do`/`end` is more acceptable.
