### PR TITLE
Fix for uninitialized constant Capistrano::VERSION (NameError)

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -1,4 +1,4 @@
-if defined?(Capistrano::Version) && Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
+if defined?(Capistrano::Version) && Gem::Version.new(Capistrano::Version).release >= Gem::Version.new('3.0.0')
   load File.expand_path("../tasks/sidekiq.rake", __FILE__)
 else
   require_relative 'capistrano2'


### PR DESCRIPTION
Hi

This is a fix for the **uninitialized constant Capistrano::VERSION (NameError)** error I was getting.

Thanks.
