### PR TITLE
Fix Capistrano::Version name error.

### DIFF
--- a/lib/sidekiq/capistrano.rb
+++ b/lib/sidekiq/capistrano.rb
@@ -1,4 +1,4 @@
-if defined?(Capistrano::Version) && Gem::Version.new(Capistrano::Version).release >= Gem::Version.new('3.0.0')
+if defined?(Capistrano::VERSION) && Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
   load File.expand_path("../tasks/sidekiq.rake", __FILE__)
 else
   require_relative 'capistrano2'


### PR DESCRIPTION
This fixes Capistrano::Version back to Capistrano::VERSION, based on this file: https://github.com/capistrano/capistrano/blob/master/lib/capistrano/version.rb
