### PR TITLE
unused, undocumented method causing errors on rubydoc.info

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -22,10 +22,6 @@ module Sidekiq
     :profile => false,
   }
 
-  def self.❨╯°□°❩╯︵┻━┻
-    puts "Calm down, bro"
-  end
-
   def self.options
     @options ||= DEFAULTS.dup
   end

--- a/test/test_sidekiq.rb
+++ b/test/test_sidekiq.rb
@@ -24,14 +24,4 @@ class TestSidekiq < Sidekiq::Test
       end
   	end
   end
-
-  describe "❨╯°□°❩╯︵┻━┻" do
-    before { $stdout = StringIO.new }
-    after  { $stdout = STDOUT }
-
-    it "allows angry developers to express their emotional constitution and remedies it" do
-      Sidekiq.❨╯°□°❩╯︵┻━┻
-      assert_equal "Calm down, bro\n", $stdout.string
-    end
-  end
 end


### PR DESCRIPTION
Sidekiq's documentation is [not available on rubydoc.info](http://rubydoc.info/gems/sidekiq/Sidekiq) due to a method in `::Sidekiq` which does not appear to be part of the public interface, and is not called from anywhere inside the gem.

This pull request removes the dead code, which restores the functionality of the documentation server. Tested against `yard server` v0.8.7.2 and ruby 2.0.0-p247.
