### PR TITLE
Sidekiq Web: If text contains invalid byte sequence, replace them instead of raising an exception

### DIFF
--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -160,6 +160,10 @@ module Sidekiq
 
     def h(text)
       ::Rack::Utils.escape_html(text)
+    rescue ArgumentError => e
+      raise unless e.message.eql?('invalid byte sequence in UTF-8')
+      text.encode!('UTF-16', 'UTF-8', invalid: :replace, replace: '').encode!('UTF-8', 'UTF-16')
+      retry
     end
 
     # Any paginated list that performs an action needs to redirect


### PR DESCRIPTION
In my project, we encountered situations where many of our job hashes are encoded differently from UTF-8.  We still want the web UI to render in these cases though.
