### PR TITLE
set @redis to nil when Sidekiq.redis= is called

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -68,6 +68,7 @@ module Sidekiq
   end
 
   def self.redis=(hash)
+    @redis = nil
     return @redis = hash if hash.is_a?(ConnectionPool)
 
     if hash.is_a?(Hash)


### PR DESCRIPTION
@redis needs to be unset so the @redis ||= can load from the new @hash value
