### PR TITLE
Use pessimistic version operator for dependencies

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |gem|
   gem.name          = "sidekiq"
   gem.require_paths = ["lib"]
   gem.version       = Sidekiq::VERSION
-  gem.add_dependency                  'redis', '>= 3.0.4'
-  gem.add_dependency                  'redis-namespace', '>= 1.3.1'
-  gem.add_dependency                  'connection_pool', '>= 1.0.0'
-  gem.add_dependency                  'celluloid', '>= 0.15.2'
+  gem.add_dependency                  'redis', '~> 3.0.4'
+  gem.add_dependency                  'redis-namespace', '~> 1.3.1'
+  gem.add_dependency                  'connection_pool', '~> 1.0.0'
+  gem.add_dependency                  'celluloid', '~> 0.15.2'
   gem.add_dependency                  'json'
   gem.add_development_dependency      'sinatra'
   gem.add_development_dependency      'minitest', '~> 4.2'


### PR DESCRIPTION
Instead of allowing any future version of dependencies, be pessimistic.
