### PR TITLE
Added rescue from NameError to the require ActiveSupport Inflections to provide (unofficial) support for the sidekiq process for Rails 2.3

### DIFF
--- a/lib/sidekiq/core_ext.rb
+++ b/lib/sidekiq/core_ext.rb
@@ -90,7 +90,7 @@ end
 
 begin
   require 'active_support/core_ext/string/inflections'
-rescue LoadError, NameError
+rescue LoadError, NameError # NameError is necessary to run Sidekiq unofficially on Rails 2.3
   class String
     def constantize
       names = self.split('::')


### PR DESCRIPTION
I've heard through your project description and saw that you mentioned that sidekiq only officially supports Rails 3.2 and 4. This tiny patch is a fix for the sidekiq worker process for a Rails 2.3 application.

I am currently pinned to a Rails 2.3 application that is still awaiting upgrade. I was able to get sidekiq up and running (including 'mounting' the sinatra app for the web UI at the rack level) with fairly little friction. The only problem that I encountered was in the core_ext.rb file in the line that calls require 'active_support/core_ext/string/inflections'.

When I ran this command in the terminal:
sidekiq -r ./config/environment.rb

I would get the following error:
.../gems/activesupport-2.3.18/lib/active_support/inflector.rb:40 uninitialized constant ActiveSupport::CoreExtensions::String
...

I spent some time trying to track down the class loading issue, and could not find anything conclusive. My pull request fixes this issue and the sidekiq worker process starts up and runs successfully. 

I know that you don't support Rails 2.3 officially, but I hope that you will accept my pull request because it is very small and should be harmless to developers using Rails 3 and 4.

If you are interested in accepting this pull request, I would also be happy to create an unofficial "Using Sidekiq with Rails 2.3" page for those unfortunately souls in my position :). 

Thanks for reading this!
