### PR TITLE
Explicitly require active_support/inflector in core_ext for unofficial compatibility with Rails 2.3.

### DIFF
--- a/lib/sidekiq/core_ext.rb
+++ b/lib/sidekiq/core_ext.rb
@@ -89,8 +89,9 @@ rescue LoadError
 end
 
 begin
+  require 'active_support/inflector' # inflector must be explicitly required to run Sidekiq unofficially on Rails 2.3
   require 'active_support/core_ext/string/inflections'
-rescue LoadError, NameError # NameError is necessary to run Sidekiq unofficially on Rails 2.3
+rescue LoadError, NameError
   class String
     def constantize
       names = self.split('::')


### PR DESCRIPTION
This is a follow-up from pull request: https://github.com/mperham/sidekiq/pull/1336

I awfully sorry, but I realized that I ended up masking the issue that I was facing with the ActiveSupport Inflectors relating to ActiveSupport 2.3. Rescuing from the NameError, did indeed the Sidekiq worker process to run correctly, however once I started adding jobs that had dependencies on ActiveSupport Inflectors, I (unsurprisingly) started seeing failures. When I started looking up ActiveRecord models in my Jobs, ActiveRecord was generating bad queries because the #tableize method did not exist, etc. 

Requiring the 'active_support/inflector' explicitly will correctly load the active_support inflectors when the sidekiq worker process is started. With this change, the sidekiq worker process still starts up and runs correctly on a Rails 3 application. I have not yet tested it with Rails 4, but don't foresee any issues (I'd be happy to verify tomorrow if you like).

I did not remove the rescuing from NameError, but it is not useless for my purposes so I could definitely yank it out of the code base if you feel that it should go.
