### PR TITLE
Handling activerecord statement invalid exception during sidekiq shutdow...

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -64,6 +64,9 @@ module Sidekiq
           # ignore, will be pushed back onto queue during hard_shutdown
           raise
         rescue Exception => e
+          if defined?(::ActiveRecord) && e.class == ::ActiveRecord::StatementInvalid && e.message.match("Sidekiq::Shutdown")
+            raise Sidekiq::Shutdown
+          end
           raise e unless msg['retry']
           max_retry_attempts = retry_attempts_from(msg['retry'], @max_retries)
 


### PR DESCRIPTION
I am not sure If this is the cleanest way to handle the issue.

Fix https://github.com/mperham/sidekiq/issues/897
