### PR TITLE
Travis CI change to get MRI specs green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
+services:
+  - redis-server
 rvm:
   - 1.9.3
   - jruby-19mode
-  - rbx-19mode
+  - rbx-2.1.1
   - 2.0.0
 branches:
   only:
@@ -15,5 +17,4 @@ notifications:
 matrix:
   allow_failures:
     - rvm: jruby-19mode
-    - rvm: rbx-19mode
-    - rvm: 2.0.0
+    - rvm: rbx-2.1.1


### PR DESCRIPTION
1. Add Redis to .travis.yml
2. Update configuration to use a valid Rubinius config
3. Make failures of Ruby 2.0.0 fail the spec run (as Ruby 2.0 is a standard config)

There are still some spec failure on the JRuby and Rubinius runs, but currently those failures are allowed.
