### PR TITLE
changed #determine_redis_provider to first check REDIS_PROVIDER

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -11,7 +11,7 @@ module Sidekiq
         if url
           options[:url] = url
         end
-        
+
         # need a connection for Fetcher and Retry
         size = options[:size] || (Sidekiq.server? ? (Sidekiq.options[:concurrency] + 2) : 5)
         pool_timeout = options[:pool_timeout] || 1
@@ -69,9 +69,8 @@ module Sidekiq
 
       def determine_redis_provider
         # REDISTOGO_URL is only support for legacy reasons
-        return ENV['REDISTOGO_URL'] if ENV['REDISTOGO_URL']
         provider = ENV['REDIS_PROVIDER'] || 'REDIS_URL'
-        ENV[provider]
+        ENV[provider] || ENV['REDISTOGO_URL']
       end
 
     end

--- a/test/test_redis_connection.rb
+++ b/test/test_redis_connection.rb
@@ -87,6 +87,20 @@ class TestRedisConnection < Sidekiq::Test
       end
     end
 
+    describe "with REDISTOGO_URL and a parallel REDIS_PROVIDER set" do
+      it "sets connection URI to the provider" do
+        uri = 'redis://sidekiq-redis-provider:6379/0'
+        provider = 'SIDEKIQ_REDIS_PROVIDER'
+
+        ENV['REDIS_PROVIDER'] = provider
+        ENV[provider] = uri
+        ENV['REDISTOGO_URL'] = 'redis://redis-to-go:6379/0'
+        with_env_var provider, uri, true
+
+        ENV[provider] = nil
+      end
+    end
+
     describe "with REDIS_PROVIDER set" do
       it "sets connection URI to the provider" do
         uri = 'redis://sidekiq-redis-provider:6379/0'


### PR DESCRIPTION
This bit us when we had two Redis providers on Heroku for a brief time to migrate to a different provider other than RedisToGo.  I think the REDIS_PROVIDER or REDIS_URL environment variables should take precedence over the specific REDISTOGO_URL for the RedisToGo provider.
