### PR TITLE
make 'redis=' work the same way for Hash and ConnectionPool

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -69,12 +69,8 @@ module Sidekiq
 
   def self.redis=(hash)
     return @redis = hash if hash.is_a?(ConnectionPool)
-
-    if hash.is_a?(Hash)
-      @hash = hash
-    else
-      raise ArgumentError, "redis= requires a Hash or ConnectionPool"
-    end
+    return @redis = Sidekiq::RedisConnection.create(@hash = hash) if hash.is_a?(Hash)
+    raise ArgumentError, "redis= requires a Hash or ConnectionPool"
   end
 
   def self.client_middleware


### PR DESCRIPTION
I've simplified this method and made processing consistent for ConnectionPool and Hash parameters passed in.

The following block of code allows `@redis` to be changed when passing a `ConnectionPool`:

```
  def self.redis=(hash)
    return @redis = hash if hash.is_a?(ConnectionPool)

    if hash.is_a?(Hash)
      @hash = hash
    else
      raise ArgumentError, "redis= requires a Hash or ConnectionPool"
    end
  end
```

If a hash is passed, `@redis` is not changed and the hash is saved. So calling `self.redis=(hash)` has different behavior depending on if it's called with a `Hash` or a `ConnectionPool`.

The new code in this pull request simplified the methods and ensures processing is the same for both Hash and ConnectionPool:

```
  def self.redis=(hash)
    return @redis = hash if hash.is_a?(ConnectionPool)
    return @redis = Sidekiq::RedisConnection.create(@hash = hash) if hash.is_a?(Hash)
    raise ArgumentError, "redis= requires a Hash or ConnectionPool"
  end
```
