### PR TITLE
Log the in progress work as a warning when force terminating.

### DIFF
--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -166,7 +166,8 @@ module Sidekiq
 
           requeue
 
-          logger.warn { "Terminating #{@busy.size} busy worker threads, work still in progress #{@in_progress.values.inspect}" }
+          logger.warn { "Terminating #{@busy.size} busy worker threads" }
+          logger.warn { "Work still in progress #{@in_progress.values.inspect}" }
           @busy.each do |processor|
             if processor.alive? && t = @threads.delete(processor.object_id)
               t.raise Shutdown


### PR DESCRIPTION
Helps trace through logs to understand what jobs got run more than once if a worker was forced to shutdown.
