### PR TITLE
Get specs running under Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 rvm:
   - 1.9.3
   - jruby-19mode
-  - rbx-2.1.1
+  - rbx
   - 2.0.0
 branches:
   only:
@@ -17,4 +17,4 @@ notifications:
 matrix:
   allow_failures:
     - rvm: jruby-19mode
-    - rvm: rbx-2.1.1
+    - rvm: rbx

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,9 @@
 source 'https://rubygems.org'
 gemspec
+
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'         # if using anything in the ruby standard library
+  gem 'psych'                    # if using yaml
+  gem 'minitest'                 # if using minitest
+  gem 'rubinius-developer_tools' # if using any of coverage, debugger, profiler
+end


### PR DESCRIPTION
Add rubinius-specific dependencies to get specs running.  Taken from blog post here - http://www.benjaminfleischer.com/2013/12/05/testing-rubinius-on-travis-ci/

Specs still fail on array equality, presumably for similar reasons as discussed here - https://github.com/jruby/jruby/issues/1291 - for JRuby, but they at least run.
