### PR TITLE
Remove branches and notifications directives from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,6 @@ rvm:
   - jruby-19mode
   - rbx
   - 2.0.0
-branches:
-  only:
-    - master
-notifications:
-  irc: "irc.freenode.org#sidekiq"
-  email:
-    recipients:
-      - sidekiq@librelist.org
 matrix:
   allow_failures:
     - rvm: jruby-19mode


### PR DESCRIPTION
I'm not sure if these are here deliberately, or only as a vestige from back in the day, but I'd like to suggest that these directives be removed.

One of the big plusses for Travis is the ability to do CI runs on forked repos and PRs.  With the branches restriction this doesn't happen unless development occurs on the master branch.  In practice this means that I always wind up making a commit that removes these directives and then rolling it back when I submit a PR.

At the same time we don't want to notify the IRC channel or mailing list every time there's a failed build on a forked repo.  

So I suggest removing both these directives.  @mperham - your thoughts?  
