### PR TITLE
Fix race condition that caused intermittent spec failures in zadd

### DIFF
--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -398,7 +398,7 @@ class TestWeb < Sidekiq::Test
       score = Time.now.to_f
       msg = { 'class' => 'HardWorker',
               'args' => ['bob', 1, Time.now.to_f],
-              'jid' => 'f39af2a05e8f4b24dbc0f1e4' }
+              'jid' => SecureRandom.hex(12) }
       Sidekiq.redis do |conn|
         conn.zadd('schedule', score, Sidekiq.dump_json(msg))
       end
@@ -413,7 +413,7 @@ class TestWeb < Sidekiq::Test
               'error_class' => 'RuntimeError',
               'retry_count' => 0,
               'failed_at' => Time.now.utc,
-              'jid' => 'f39af2a05e8f4b24dbc0f1e4'}
+              'jid' => SecureRandom.hex(12) }
       score = Time.now.to_f
       Sidekiq.redis do |conn|
         conn.zadd('retry', score, Sidekiq.dump_json(msg))
@@ -429,7 +429,7 @@ class TestWeb < Sidekiq::Test
               'error_class' => 'RuntimeError',
               'retry_count' => 0,
               'failed_at' => Time.now.utc,
-              'jid' => 'f39af2a05e8f4b24dbc0f1e4'}
+              'jid' => SecureRandom.hex(12) }
       score = Time.now.to_f
       Sidekiq.redis do |conn|
         conn.zadd('retry', score, Sidekiq.dump_json(msg))


### PR DESCRIPTION
Updated specs to use a random jid when adding a job in the specs, rather than a fixed jid.  This ensures that member objects passed to zadd are unique (which they may not be otherwise, if Time.now.to_f is the same).  This issue was causing intermittent failures of a couple specs on JRuby.  Not sure why it wasn't showing up on MRI.

As a side note, upgrading to JRuby 1.7.9 fixes this issue - https://github.com/jruby/jruby/issues/1291 - which means that after this PR is merged in specs should run green on JRuby.
