### PR TITLE
Only show Retry Args vertical scrollbar if needed.

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -898,7 +898,7 @@ img.smallogo {
   border-radius: 3px;
 }
 .args {
-  overflow-y: scroll;
+  overflow-y: auto;
   max-height: 100px;
 }
 .args-extended {


### PR DESCRIPTION
It's only cosmetic, but disabled scrollbars were appearing when not needed and adding clutter.

![](https://www.evernote.com/shard/s1/sh/8da8e66c-2601-477b-bd24-a4f798c5d309/8bdd9355d34ee7f9de7965ccef7f866b/deep/0/Sidekiq.png)
