### PR TITLE
Wrap retry page worker arguments

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -897,6 +897,9 @@ img.smallogo {
   background: rgba(255, 255, 255, 0.2);
   border-radius: 3px;
 }
+.code-wrap {
+  white-space: normal;
+}
 .args {
   overflow-y: auto;
   max-height: 100px;

--- a/web/views/_job_info.erb
+++ b/web/views/_job_info.erb
@@ -19,7 +19,7 @@
     <tr>
       <th><%= t('Arguments') %></th>
       <td>
-        <code>
+        <code class="code-wrap">
           <!-- We don't want to truncate any job arguments when viewing a single job's status page -->
           <div class="args-extended"><%= display_args(job['args'], nil) %></div>
         </code>


### PR DESCRIPTION
Simple CSS change to force the worker arguments to wrap instead of display off the page.

Fixes #1375 
