### PR TITLE
Remove the line which says that workers exit at a USR1 after stopping. T...

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,6 @@
 2.17.0
 -----------
 
-- Change USR1 signal handling to exit process as soon as all workers are quiet. [#1358]
 - Change `Sidekiq::Client#push_bulk` to return an array of pushed `jid`s. [#1315, barelyknown]
 - Web UI refactoring to use more API internally (yummy dogfood!)
 - Much faster Sidekiq::Job#delete performance for larger queue sizes


### PR DESCRIPTION
...his is not true and has never been the case. Use TERM for exiting after stopping with a timeout.
