### PR TITLE
Fix layout of the retry all checkbox

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -188,15 +188,16 @@ td form {
   margin-bottom: 0;
 }
 
-td.table-checkbox {
+.table tr > td.table-checkbox, .table tr > th.table-checkbox {
   padding: 0px;
 }
 
-td.table-checkbox label {
+table .table-checkbox label {
   height: 100%;
   width: 100%;
-  padding: 8px;
+  padding: 0px 16px;
   margin-bottom: 0;
+  line-height: 32px;
 }
 
 .navbar .navbar-brand {

--- a/web/views/retries.erb
+++ b/web/views/retries.erb
@@ -15,8 +15,10 @@
     <table class="table table-striped table-bordered table-white">
       <thead>
         <tr>
-          <th width="20px">
-            <input type="checkbox" class="check_all" />
+          <th width="20px" class="table-checkbox">
+            <label>
+              <input type="checkbox" class="check_all" />
+            </label>
           </th>
           <th width="25%"><%= t('NextRetry') %></th>
           <th width="11%"><%= t('RetryCount') %></th>


### PR DESCRIPTION
Fixes the select all checkbox on the retries page after my recent padding change.

**Before**
![screen shot 2013-12-14 at 6 09 27 pm](https://f.cloud.github.com/assets/167215/1748223/0f468856-64aa-11e3-955d-88e121bd319f.png)

**After**
![screen shot 2013-12-14 at 6 09 33 pm](https://f.cloud.github.com/assets/167215/1748282/ae2f93d2-64ae-11e3-9dc6-2b27ba139a5f.png)
