### PR TITLE
add default_action_mailer_options

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,12 @@
+HEAD
+-----------
+- Sidekiq.default\_action\_mailer\_options allows you to configure default
+  options for active mailer extensions.
+
+```ruby
+Sidekiq.default_action_mailer_options = { 'queue' => 'mailer'}
+```
+
 2.17.1
 -----------
 

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -97,6 +97,14 @@ module Sidekiq
     @default_worker_options || { 'retry' => true, 'queue' => 'default' }
   end
 
+  def self.default_action_mailer_options=(hash)
+    @default_action_mailer_options = default_action_mailer_options.merge(hash)
+  end
+
+  def self.default_action_mailer_options
+    @default_action_mailer_options || {}
+  end
+
   def self.load_json(string)
     JSON.parse(string)
   end

--- a/lib/sidekiq/extensions/action_mailer.rb
+++ b/lib/sidekiq/extensions/action_mailer.rb
@@ -23,17 +23,23 @@ module Sidekiq
 
     module ActionMailer
       def sidekiq_delay(options={})
-        Proxy.new(DelayedMailer, self, options)
+        Proxy.new(DelayedMailer, self, sidekiq_options(options))
       end
       def sidekiq_delay_for(interval, options={})
-        Proxy.new(DelayedMailer, self, options.merge('at' => Time.now.to_f + interval.to_f))
+        Proxy.new(DelayedMailer, self, sidekiq_options(options).merge('at' => Time.now.to_f + interval.to_f))
       end
       def sidekiq_delay_until(timestamp, options={})
-        Proxy.new(DelayedMailer, self, options.merge('at' => timestamp.to_f))
+        Proxy.new(DelayedMailer, self, sidekiq_options(options).merge('at' => timestamp.to_f))
       end
       alias_method :delay, :sidekiq_delay
       alias_method :delay_for, :sidekiq_delay_for
       alias_method :delay_until, :sidekiq_delay_until
+
+      private
+
+      def sidekiq_options(opts={})
+        Sidekiq.default_action_mailer_options.merge(opts)
+      end
     end
 
   end

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -75,6 +75,17 @@ class TestExtensions < Sidekiq::Test
       assert_equal 1, Sidekiq.redis {|c| c.zcard('schedule') }
     end
 
+    describe 'default_action_mailer_options' do
+      before { Sidekiq.default_action_mailer_options = {queue: :mailer} }
+      after { Sidekiq.default_action_mailer_options = {} }
+
+      it 'allows delayed delivery of ActionMailer mails' do
+        assert_equal [], Sidekiq::Queue.all.map(&:name)
+        UserMailer.delay.greetings(1, 2)
+        assert_equal ['mailer'], Sidekiq::Queue.all.map(&:name)
+      end
+    end
+
     class SomeClass
       def self.doit(arg)
       end


### PR DESCRIPTION
Is's made to put all from email sidekiq task to particular queue, not default

``` ruby
Sidekiq.default_action_mailer_options = {queue: :mailer}
```
