### PR TITLE
Add testing strategy: test_inline_with_fake_delay

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -30,6 +30,10 @@ module Sidekiq
         __set_test_mode(:inline, &block)
       end
 
+      def inline_with_fake_delay!(&block)
+        __set_test_mode(:inline_with_fake_delay, &block)
+      end
+
       def enabled?
         self.__test_mode != :disable
       end
@@ -44,6 +48,10 @@ module Sidekiq
 
       def inline?
         self.__test_mode == :inline
+      end
+
+      def inline_with_fake_delay?
+        self.__test_mode == :inline_with_fake_delay
       end
     end
   end
@@ -67,6 +75,14 @@ module Sidekiq
           perform_now(item)
         end
         true
+      elsif Sidekiq::Testing.inline_with_fake_delay?
+        payloads.each do |job|
+          if job.has_key? 'at'
+            add_to_queue(job)
+          else
+            perform_now(job)
+          end
+        end
       else
         raw_push_real(payloads)
       end

--- a/test/test_testing_inline_with_fake_delay.rb
+++ b/test/test_testing_inline_with_fake_delay.rb
@@ -1,0 +1,63 @@
+require 'helper'
+require 'sidekiq'
+require 'sidekiq/worker'
+require 'active_record'
+require 'action_mailer'
+require 'sidekiq/rails'
+require 'sidekiq/extensions/action_mailer'
+require 'sidekiq/extensions/active_record'
+
+Sidekiq.hook_rails!
+
+class TestInlineWithFakeDelay < Sidekiq::Test
+  describe 'sidekiq inline with fake delay testing' do
+    class InlineError < RuntimeError ; end
+
+    class InlineWorker
+      include Sidekiq::Worker
+      def perform(pass)
+        raise InlineError unless pass
+      end
+    end
+
+    class DelayedWorker
+      include Sidekiq::Worker
+      def perform(a, b)
+        a + b
+      end
+    end
+
+    before do
+      require 'sidekiq/testing.rb'
+      Sidekiq::Testing.inline_with_fake_delay!
+      DelayedWorker.jobs.clear
+    end
+
+    after do
+      Sidekiq::Testing.disable!
+    end
+
+    it 'stubs the async call for delayed workers' do
+      assert_equal 0, DelayedWorker.jobs.size
+      DelayedWorker.perform_in(10, 1, 2)
+      assert_equal 1, DelayedWorker.jobs.size
+      DelayedWorker.perform_at(10, 1, 2)
+      assert_equal 2, DelayedWorker.jobs.size
+    end
+
+    it 'stubs the async call' do
+      assert_equal 0, DelayedWorker.jobs.size
+      DelayedWorker.perform_async(1, 2)
+      assert_equal 0, DelayedWorker.jobs.size
+
+      assert InlineWorker.perform_async(true)
+
+      assert Sidekiq::Client.enqueue(InlineWorker, true)
+      assert_equal 0, InlineWorker.jobs.size
+
+      assert_raises InlineError do
+        Sidekiq::Client.enqueue(InlineWorker, false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The test_inline_with_fake_delay testing strategy will perform async workers directly and adds delayed workers to the queue instead of performing them directly.
