### PR TITLE
Allow Sidekiq::Stats#reset to reset individual stats independently

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -10,10 +10,12 @@ module Sidekiq
       Sidekiq.redis { |conn| conn.get("stat:failed") }.to_i
     end
 
-    def reset
+    def reset(*stats)
+      all   = %w(failed processed)
+      stats = stats.empty? ? all : all & stats.flatten.compact.map(&:to_s)
+
       Sidekiq.redis do |conn|
-        conn.set("stat:failed", 0)
-        conn.set("stat:processed", 0)
+        stats.each { |stat| conn.set("stat:#{stat}", 0) }
       end
     end
 


### PR DESCRIPTION
Update Sidekiq::Stats#reset behavior:
- Nothing changes unless arguments are provided
- If arguments are provided, resets any stats referenced
- Ignores arguments that do not reference an actual stat
