### PR TITLE
@in_progress got cleared in #requeue but was being logged after the requ...

### DIFF
--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -162,12 +162,11 @@ module Sidekiq
         watchdog("Manager#hard_shutdown_in died") do
           # We've reached the timeout and we still have busy workers.
           # They must die but their messages shall live on.
-          logger.info("Still waiting for #{@busy.size} busy workers")
+          logger.warn { "Terminating #{@busy.size} busy worker threads" }
+          logger.warn { "Work still in progress #{@in_progress.values.inspect}" }
 
           requeue
 
-          logger.warn { "Terminating #{@busy.size} busy worker threads" }
-          logger.warn { "Work still in progress #{@in_progress.values.inspect}" }
           @busy.each do |processor|
             if processor.alive? && t = @threads.delete(processor.object_id)
               t.raise Shutdown


### PR DESCRIPTION
...eue. Also, removing redundant log statement.

```
Dec 21 00:43:33 production.log: [ 5:43:33.109328098] (27825) [WARN] Terminating 1 busy worker threads

# Wrong, in progress had values but was cleared before this log statement
Dec 21 00:43:33 production.log: [ 5:43:33.109530450] (27825) [WARN] Work still in progress []
```
