### PR TITLE
Set strict option correctly when using multiple queue options.

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -258,9 +258,9 @@ module Sidekiq
           opts[:profile] = arg
         end
 
-        o.on "-q", "--queue QUEUE[,WEIGHT]...", "Queues to process with optional weights" do |arg|
-          queues_and_weights = arg.scan(/([\w\.-]+),?(\d*)/)
-          parse_queues opts, queues_and_weights
+        o.on "-q", "--queue QUEUE[,WEIGHT]", "Queues to process with optional weights" do |arg|
+          queue, weight = arg.split(",")
+          parse_queue opts, queue, weight
         end
 
         o.on '-r', '--require [PATH|DIR]', "Location of Rails application with workers or file to require" do |arg|
@@ -336,7 +336,7 @@ module Sidekiq
     end
 
     def parse_queues(opts, queues_and_weights)
-      queues_and_weights.each {|queue_and_weight| parse_queue(opts, *queue_and_weight)}
+      queues_and_weights.each { |queue_and_weight| parse_queue(opts, *queue_and_weight) }
     end
 
     def parse_queue(opts, q, weight=nil)

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -51,11 +51,6 @@ class TestCli < Sidekiq::Test
     end
 
     it 'sets strictly ordered queues if weights are not present' do
-      @cli.parse(['sidekiq', '-q', 'foo,bar', '-r', './test/fake_env.rb'])
-      assert_equal true, !!Sidekiq.options[:strict]
-    end
-
-    it 'sets strictly ordered queues if weights are not present multiple queue options' do
       @cli.parse(['sidekiq', '-q', 'foo', '-q', 'bar', '-r', './test/fake_env.rb'])
       assert_equal true, !!Sidekiq.options[:strict]
     end
@@ -66,11 +61,6 @@ class TestCli < Sidekiq::Test
     end
 
     it 'does not set strictly ordered queues if weights are present with multiple queues' do
-      @cli.parse(['sidekiq', '-q', 'foo,3,bar', '-r', './test/fake_env.rb'])
-      assert_equal false, !!Sidekiq.options[:strict]
-    end
-
-    it 'does not set strictly ordered queues if weights are present with multiple queue options' do
       @cli.parse(['sidekiq', '-q', 'foo,3', '-q', 'bar', '-r', './test/fake_env.rb'])
       assert_equal false, !!Sidekiq.options[:strict]
     end
@@ -80,18 +70,13 @@ class TestCli < Sidekiq::Test
       assert_equal 30, Sidekiq.options[:timeout]
     end
 
-    it 'handles multiple queues with weights with multiple switches' do
+    it 'handles multiple queues with weights' do
       @cli.parse(['sidekiq', '-q', 'foo,3', '-q', 'bar', '-r', './test/fake_env.rb'])
       assert_equal %w(foo foo foo bar), Sidekiq.options[:queues]
     end
 
-    it 'handles multiple queues with weights with a single switch' do
-      @cli.parse(['sidekiq', '-q', 'bar,foo,3', '-r', './test/fake_env.rb'])
-      assert_equal %w(bar foo foo foo), Sidekiq.options[:queues]
-    end
-
     it 'handles queues with multi-word names' do
-      @cli.parse(['sidekiq', '-q', 'queue_one,queue-two', '-r', './test/fake_env.rb'])
+      @cli.parse(['sidekiq', '-q', 'queue_one', '-q', 'queue-two', '-r', './test/fake_env.rb'])
       assert_equal %w(queue_one queue-two), Sidekiq.options[:queues]
     end
 


### PR DESCRIPTION
`sidekiq -q high,2,low` and `sidekiq -q high,2 -q low` now both result in the `:strict` option being `false`. It used to erroneously be `true` for the latter.
