### PR TITLE
Feature/generalized start script

### DIFF
--- a/examples/chef/cookbooks/sidekiq/templates/default/sidekiq.erb
+++ b/examples/chef/cookbooks/sidekiq/templates/default/sidekiq.erb
@@ -163,6 +163,8 @@ if [ -d $APP_ROOT ]; then
         RESULT=$?
         logger -t "monit-sidekiq[$$]" "Started with pid $! and exit $RESULT"
         echo $! > $PID_FILE
+        chown root:$USER $PID_FILE
+        chmod g+w        $PID_FILE
         sleep .1
       fi
       unlock_and_exit_cleanly 


### PR DESCRIPTION
A handful of generalizations to the example start script to allow assigning local configuration values and using it as-is in a deployed environment.
