### PR TITLE
Terminate the poller and the fetcher synchronously.

### DIFF
--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -43,12 +43,12 @@ module Sidekiq
       watchdog('Launcher#stop') do
         @done = true
         Sidekiq::Fetcher.done!
-        manager.async.stop(:shutdown => true, :timeout => @options[:timeout])
-
         fetcher.terminate if fetcher.alive?
         poller.terminate if poller.alive?
 
+        manager.async.stop(:shutdown => true, :timeout => @options[:timeout])
         manager.wait(:shutdown)
+
         # Requeue everything in case there was a worker who grabbed work while stopped
         Sidekiq::Fetcher.strategy.bulk_requeue([], @options)
       end


### PR DESCRIPTION
Perhaps a fix for the issue described in #1406.

@mperham see any issues here? I'm still not a celluloid pro so it's possible this is not good, but all the tests pass.
