### PR TITLE
Add -I --include cli option

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -179,7 +179,7 @@ module Sidekiq
 
       cfile = opts[:config_file]
       opts = parse_config(cfile).merge(opts) if cfile
-      
+
       opts[:strict] = true if opts[:strict].nil?
 
       options.merge!(opts)
@@ -277,6 +277,10 @@ module Sidekiq
 
         o.on '-C', '--config PATH', "path to YAML config file" do |arg|
           opts[:config_file] = arg
+        end
+
+        o.on '-I', '--include', "Add a path to Sidekiq's load directory" do |path|
+          $LOAD_PATH.unshift File.expand_path("../../../#{path}", __FILE__)
         end
 
         o.on '-L', '--logfile PATH', "path to writable logfile" do |arg|

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -30,6 +30,13 @@ class TestCli < Sidekiq::Test
       assert @cli.valid?
     end
 
+    it 'adds new directories onto the load path' do
+      old_path = $LOAD_PATH
+      @cli.parse(['sidekiq', '-I', './test'])
+      assert($LOAD_PATH.include? File.expand_path('../', __FILE__))
+      $LOAD_PATH.delete(File.expand_path('../', __FILE__))
+    end
+
     it 'changes concurrency' do
       @cli.parse(['sidekiq', '-c', '60', '-r', './test/fake_env.rb'])
       assert_equal 60, Sidekiq.options[:concurrency]


### PR DESCRIPTION
Allows manipulation of the load path via the CLI. Useful when you're writing
a non Rails Sidekiq consumer and want to add specific local code into the load path.
