### PR TITLE
instead of calling class_attribute 3 times, we can do it in one call

### DIFF
--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -25,9 +25,7 @@ module Sidekiq
 
     def self.included(base)
       base.extend(ClassMethods)
-      base.class_attribute :sidekiq_options_hash
-      base.class_attribute :sidekiq_retry_in_block
-      base.class_attribute :sidekiq_retries_exhausted_block
+      base.class_attribute [ :sidekiq_options_hash, :sidekiq_retry_in_block, :sidekiq_retries_exhausted_block ]
     end
 
     def logger


### PR DESCRIPTION
Instead of calling class_attribute 3 times, we can do it in one call.
If more attributes are added in the future, it would be nice if they are added in the same array, rather than having one line for each attribute.
What do you think?
