### PR TITLE
pass :safe => false to YAML.load for SafeYAML

### DIFF
--- a/lib/sidekiq/extensions/class_methods.rb
+++ b/lib/sidekiq/extensions/class_methods.rb
@@ -13,7 +13,8 @@ module Sidekiq
       include Sidekiq::Worker
 
       def perform(yml)
-        (target, method_name, args) = YAML.load(yml)
+        args = [yml, *(defined?(SafeYAML) && [{ :safe => false }])]
+        (target, method_name, args) = YAML.load(*args)
         target.send(method_name, *args)
       end
     end


### PR DESCRIPTION
Let me acknowledge up front that this is an odd PR. I totally wouldn't blame you for rejecting it.

For a brief explanation of why I'm proposing this, see dtao/safe_yaml#53.

But here's the situation in a nutshell. My gem, SafeYAML, patches `YAML.load` so that application developers can protect against the arbitrary object deserialization exploit found in Rails (and other frameworks) last year. This gem only allows "safe" types to be deserialized: strings, numbers, hashes, etc. The idea is that by requiring SafeYAML, a dev can ensure that none of the libraries they're depending on will expose their app to this vulnerability.

Of course, Sidekiq _needs_ to deserialize arbitrary objects for the `delay` extension to work. So here I am suggesting that before calling `YAML.load`, you first see whether the `SafeYAML` module is defined and, if so, pass the requisite `:safe => false` option, letting SafeYAML know not to interfere on this particular call.
