### PR TITLE
Allow use of sidekiq_flags in capistrano task to start

### DIFF
--- a/lib/sidekiq/capistrano2.rb
+++ b/lib/sidekiq/capistrano2.rb
@@ -40,7 +40,7 @@ Capistrano::Configuration.instance.load do
     task :start, :roles => lambda { fetch(:sidekiq_role) }, :on_no_matching_servers => :continue do
       rails_env = fetch(:rails_env, "production")
       for_each_process do |pid_file, idx|
-        run "cd #{current_path} ; nohup #{fetch(:sidekiq_cmd)} -e #{rails_env} -C #{current_path}/config/sidekiq.yml -i #{idx} -P #{pid_file} >> #{current_path}/log/sidekiq.log 2>&1 &", :pty => false
+        run "cd #{current_path} ; nohup #{fetch(:sidekiq_cmd)} -e #{rails_env} -C #{current_path}/config/sidekiq.yml -i #{idx} -P #{pid_file} #{fetch(:sidekiq_flags)} >> #{current_path}/log/sidekiq.log 2>&1 &", :pty => false
       end
     end
 


### PR DESCRIPTION
# What

In the case where extra flags need to be set the capistrano task doesn't support that. 

For instance in my case the way we need to upstart sidekiq is

`sidekiq -r ./lib/sidekiq_server.rb` which loads some defaults.

The way I have been able to get around this for now is setting rails_env as 'production -r ./lib/sidekiq_server.rb' but that seems pretty hacky to me. 

Taking a note out of the puma-capistrano project they have a puma_flags that you can add additional flags to if need be.
# How to test

No real good test strategy except for having an app that requires something like -r
