### PR TITLE
Sidekiq/web: require active_support/core_ext/object to fix paging scheduled jobs

### DIFF
--- a/lib/sidekiq/core_ext.rb
+++ b/lib/sidekiq/core_ext.rb
@@ -1,4 +1,10 @@
 begin
+  require 'active_support/core_ext/object'
+rescue LoadError
+  # Shouldn't sidekiq depend on active_support?
+end
+
+begin
   require 'active_support/core_ext/class/attribute'
 rescue LoadError
 


### PR DESCRIPTION
Paging scheduled jobs fails with

```
NoMethodError at /sidekiq/scheduled
undefined method `try' for nil:NilClass
file: paginator.rb location: block in page line: 16
```

The Sidekiq web application has been mounted with

```
# config.ru
require 'sidekiq/web'
:
run Rack::URLMap.new(
  '/sidekiq' => Sidekiq::Web
)
```

When accessing _http://localhost:9292/sidekiq/scheduled_, the error above occurs, because the Active Support's `#try` method is invoked at line 16 in _lib/sidekiq/paginator.rb_ without requiring `active_support/core_ext/object` first.

This PR requires _active_support/core_ext/object_ in _lib/sidekiq/core_ext.rb_, it does not handle _LoadError_. I am wondering why Sidekiq re-implements methods if loading Active Support fails? Wouldn't it be much easier for Sidekiq to just depend on Active Support?
