### PR TITLE
Remove daemonization for JRuby

### DIFF
--- a/lib/sidekiq/tasks/sidekiq.rake
+++ b/lib/sidekiq/tasks/sidekiq.rake
@@ -98,6 +98,7 @@ namespace :sidekiq do
               execute :bundle, :exec, :sidekiq, "-d -i #{idx} -P #{pid_full_path(pid_file)} #{fetch(:sidekiq_options)}"
             end
           else
+            execute "echo 'Since JRuby doesn't support Process.daemon, Sidekiq will be running without the -d flag."
             if fetch(:sidekiq_cmd)
               execute fetch(:sidekiq_cmd), "-i #{idx} -P #{pid_full_path(pid_file)} #{fetch(:sidekiq_options)} >/dev/null 2>&1 &"
             else


### PR DESCRIPTION
As said on https://github.com/mperham/sidekiq/pull/719, I removed `-d` option for JRuby, since it doesn't support `Process.daemon`.

Hope you like it!
