### PR TITLE
Replaced class and instance level `send`

### DIFF
--- a/lib/sidekiq/actor.rb
+++ b/lib/sidekiq/actor.rb
@@ -28,10 +28,10 @@ module Sidekiq
 
     def self.included(klass)
       if $TESTING
-        klass.send(:include, InstanceMethods)
-        klass.send(:extend, ClassMethods)
+        klass.__send__(:include, InstanceMethods)
+        klass.__send__(:extend, ClassMethods)
       else
-        klass.send(:include, Celluloid)
+        klass.__send__(:include, Celluloid)
       end
     end
   end

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -203,7 +203,7 @@ module Sidekiq
     end
 
     def [](name)
-      @item.send(:[], name)
+      @item.__send__(:[], name)
     end
   end
 

--- a/lib/sidekiq/extensions/action_mailer.rb
+++ b/lib/sidekiq/extensions/action_mailer.rb
@@ -14,7 +14,7 @@ module Sidekiq
 
       def perform(yml)
         (target, method_name, args) = YAML.load(yml)
-        msg = target.send(method_name, *args)
+        msg = target.__send__(method_name, *args)
         # The email method can return nil, which causes ActionMailer to return
         # an undeliverable empty message.
         msg.deliver if msg && (msg.to || msg.cc || msg.bcc) && msg.from

--- a/lib/sidekiq/extensions/active_record.rb
+++ b/lib/sidekiq/extensions/active_record.rb
@@ -16,7 +16,7 @@ module Sidekiq
 
       def perform(yml)
         (target, method_name, args) = YAML.load(yml)
-        target.send(method_name, *args)
+        target.__send__(method_name, *args)
       end
     end
 

--- a/lib/sidekiq/extensions/class_methods.rb
+++ b/lib/sidekiq/extensions/class_methods.rb
@@ -14,7 +14,7 @@ module Sidekiq
 
       def perform(yml)
         (target, method_name, args) = YAML.load(yml)
-        target.send(method_name, *args)
+        target.__send__(method_name, *args)
       end
     end
 
@@ -36,4 +36,4 @@ module Sidekiq
   end
 end
 
-Module.send(:include, Sidekiq::Extensions::Klass)
+Module.__send__(:include, Sidekiq::Extensions::Klass)

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -1,7 +1,7 @@
 module Sidekiq
   def self.hook_rails!
     if defined?(::ActiveRecord)
-      ::ActiveRecord::Base.send(:include, Sidekiq::Extensions::ActiveRecord)
+      ::ActiveRecord::Base.__send__(:include, Sidekiq::Extensions::ActiveRecord)
     end
 
     if defined?(::ActionMailer)

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -294,8 +294,8 @@ class TestCli < Sidekiq::Test
       describe 'when weight is present' do
         it 'concatenates queues by factor of weight and sets strict to false' do
           opts = { strict: true }
-          @cli.send :parse_queues, opts, [['often', 7], ['repeatedly', 3]]
-          @cli.send :parse_queues, opts, [['once']]
+          @cli.__send__ :parse_queues, opts, [['often', 7], ['repeatedly', 3]]
+          @cli.__send__ :parse_queues, opts, [['once']]
           assert_equal (%w[often] * 7 + %w[repeatedly] * 3 + %w[once]), opts[:queues]
           assert !opts[:strict]
         end
@@ -304,8 +304,8 @@ class TestCli < Sidekiq::Test
       describe 'when weight is not present' do
         it 'returns queues and sets strict' do
           opts = { strict: true }
-          @cli.send :parse_queues, opts, [['once'], ['one_time']]
-          @cli.send :parse_queues, opts, [['einmal']]
+          @cli.__send__ :parse_queues, opts, [['once'], ['one_time']]
+          @cli.__send__ :parse_queues, opts, [['einmal']]
           assert_equal %w[once one_time einmal], opts[:queues]
           assert opts[:strict]
         end
@@ -316,7 +316,7 @@ class TestCli < Sidekiq::Test
       describe 'when weight is present' do
         it 'concatenates queue to opts[:queues] weight number of times and sets strict to false' do
           opts = { strict: true }
-          @cli.send :parse_queue, opts, 'often', 7
+          @cli.__send__ :parse_queue, opts, 'often', 7
           assert_equal %w[often] * 7, opts[:queues]
           assert !opts[:strict]
         end
@@ -325,7 +325,7 @@ class TestCli < Sidekiq::Test
       describe 'when weight is not present' do
         it 'concatenates queue to opts[:queues] once and leaves strict true' do
           opts = { strict: true }
-          @cli.send :parse_queue, opts, 'once', nil
+          @cli.__send__ :parse_queue, opts, 'once', nil
           assert_equal %w[once], opts[:queues]
           assert opts[:strict]
         end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -226,11 +226,11 @@ class TestClient < Sidekiq::Test
 
   describe 'item normalization' do
     it 'defaults retry to true' do
-      assert_equal true, Sidekiq::Client.new.send(:normalize_item, 'class' => QueuedWorker, 'args' => [])['retry']
+      assert_equal true, Sidekiq::Client.new.__send__(:normalize_item, 'class' => QueuedWorker, 'args' => [])['retry']
     end
 
     it "does not normalize numeric retry's" do
-      assert_equal 2, Sidekiq::Client.new.send(:normalize_item, 'class' => CWorker, 'args' => [])['retry']
+      assert_equal 2, Sidekiq::Client.new.__send__(:normalize_item, 'class' => CWorker, 'args' => [])['retry']
     end
   end
 end

--- a/test/test_exception_handler.rb
+++ b/test/test_exception_handler.rb
@@ -59,7 +59,7 @@ class TestExceptionHandler < Sidekiq::Test
     end
 
     after do
-      Object.send(:remove_const, "Airbrake") # HACK should probably inject Airbrake etc into this class in the future
+      Object.__send__(:remove_const, "Airbrake") # HACK should probably inject Airbrake etc into this class in the future
     end
 
     it "notifies Airbrake" do
@@ -75,7 +75,7 @@ class TestExceptionHandler < Sidekiq::Test
     end
 
     after do
-      Object.send(:remove_const, "Honeybadger") # HACK should probably inject Honeybadger etc into this class in the future
+      Object.__send__(:remove_const, "Honeybadger") # HACK should probably inject Honeybadger etc into this class in the future
     end
 
     it "notifies Honeybadger" do
@@ -91,7 +91,7 @@ class TestExceptionHandler < Sidekiq::Test
     end
 
     after do
-      Object.send(:remove_const, "ExceptionNotifier")
+      Object.__send__(:remove_const, "ExceptionNotifier")
     end
 
     it "notifies ExceptionNotifier" do
@@ -120,7 +120,7 @@ class TestExceptionHandler < Sidekiq::Test
     end
 
     after do
-      Object.send(:remove_const, "Exceptional")
+      Object.__send__(:remove_const, "Exceptional")
     end
 
     it "notifies Exceptional" do

--- a/test/test_redis_connection.rb
+++ b/test/test_redis_connection.rb
@@ -77,7 +77,7 @@ class TestRedisConnection < Sidekiq::Test
         ENV[v] = nil
       end
       ENV[var] = uri
-      assert_equal uri, Sidekiq::RedisConnection.send(:determine_redis_provider)
+      assert_equal uri, Sidekiq::RedisConnection.__send__(:determine_redis_provider)
       ENV[var] = nil
     end
 

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -210,7 +210,7 @@ class TestRetry < Sidekiq::Test
         end
 
         it 'calls worker.retries_exhausted after too many retries' do
-          assert_equal [1,2, "foo", "retried_method"], handler.send(:retries_exhausted, worker.new, msg)
+          assert_equal [1,2, "foo", "retried_method"], handler.__send__(:retries_exhausted, worker.new, msg)
         end
       end
 
@@ -226,7 +226,7 @@ class TestRetry < Sidekiq::Test
         end
 
         it 'calls worker sidekiq_retries_exhausted_block after too many retries' do
-          new_msg      = handler.send(:retries_exhausted, worker.new, msg)
+          new_msg      = handler.__send__(:retries_exhausted, worker.new, msg)
           expected_msg = msg.merge('called_by_callback' => true)
 
           assert_equal expected_msg, new_msg, "sidekiq_retries_exhausted block not called"
@@ -288,15 +288,15 @@ class TestRetry < Sidekiq::Test
       let(:handler) { Sidekiq::Middleware::Server::RetryJobs.new }
 
       it "retries with a default delay" do
-        refute_equal 4, handler.send(:delay_for, worker, 2)
+        refute_equal 4, handler.__send__(:delay_for, worker, 2)
       end
 
       it "retries with a custom delay" do
-        assert_equal 4, handler.send(:delay_for, custom_worker, 2)
+        assert_equal 4, handler.__send__(:delay_for, custom_worker, 2)
       end
 
       it "falls back to the default retry on exception" do
-        refute_equal 4, handler.send(:delay_for, error_worker, 2)
+        refute_equal 4, handler.__send__(:delay_for, error_worker, 2)
         assert_match(/Failure scheduling retry using the defined `sidekiq_retry_in`/,
                      File.read(@tmp_log_path), 'Log entry missing for sidekiq_retry_in')
       end


### PR DESCRIPTION
Replaced with `__send__` from std lib
- `send` can now be overridden to be more semantically meaningful
  - `message.send(user_id)` as opposed to `message.send_message(user_id)`
- `__send__` makes it clear that the reflective version is intended
