### PR TITLE
Cancel retries on particular exceptions

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -56,10 +56,14 @@ module Sidekiq
 
         def initialize(options = {})
           @max_retries = options.fetch(:max_retries, DEFAULT_MAX_RETRY_ATTEMPTS)
+          @ignored_exceptions = Array(options.fetch(:ignored_exceptions, nil))
         end
 
         def call(worker, msg, queue)
           yield
+        rescue *@ignored_exceptions
+          # no-op
+          msg['retry'] = false
         rescue Sidekiq::Shutdown
           # ignore, will be pushed back onto queue during hard_shutdown
           raise

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -3,6 +3,9 @@ require 'sidekiq/scheduled'
 require 'sidekiq/middleware/server/retry_jobs'
 
 class TestRetry < Sidekiq::Test
+  class ErrorToBeIgnored < StandardError
+  end
+
   describe 'middleware' do
     before do
       @redis = Minitest::Mock.new
@@ -28,6 +31,18 @@ class TestRetry < Sidekiq::Test
         end
       end
       assert_equal msg, msg2
+    end
+
+    it 'allows disabling retry on specified exceptions' do
+      msg = { 'class' => 'Bob', 'args' => [1,2,'foo'] }
+      msg2 = msg.dup
+      handler = Sidekiq::Middleware::Server::RetryJobs.new({:ignored_exceptions => [ErrorToBeIgnored]})
+
+      handler.call(worker, msg2, 'default') do
+        raise ErrorToBeIgnored.new
+      end
+
+      assert_equal msg.merge('retry' => false), msg2
     end
 
     it 'allows a numeric retry' do


### PR DESCRIPTION
For instance, if a job fails to find a record and throws an
`ActiveRecord::RecordNotFound` exception, that might be ok
