### PR TITLE
Parse nested queues from .yml

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -340,7 +340,13 @@ module Sidekiq
     end
 
     def parse_queues(opts, queues_and_weights)
-      queues_and_weights.each { |queue_and_weight| parse_queue(opts, *queue_and_weight) }
+      queues_and_weights.each do |queue_and_weight|
+        if !queue_and_weight.is_a?(Array) || queue_and_weigth[1].is_a?(Integer)
+          parse_queue(opts, *queue_and_weight)
+        else
+          parse_queues(opts, queue_and_weight)
+        end
+      end
     end
 
     def parse_queue(opts, q, weight=nil)


### PR DESCRIPTION
I wanted to use links in .yml like this:

``` yaml
production:
  :queues: &default_queue
    - generic_tasks
    - other_generic_tasks
super_worker:
  :queues:
    - extra_tasks
    - *default_queue
```

So super_worker will perform extra_tasks first, but when there is no extra_tasks it'll work as usual worker.
extra_tasks can take very long time and I can't add these queues to default process 'cause all workers can get busy.

http://stackoverflow.com/a/4949139/1135874 - seems it's the only way to merge arrays in yaml.

I'll write specs if you like this change.
