### PR TITLE
Do not override RAILS_ENV

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -190,7 +190,7 @@ module Sidekiq
     end
 
     def boot_system
-      ENV['RACK_ENV'] = ENV['RAILS_ENV'] = environment
+      ENV['RACK_ENV'] = ENV['RAILS_ENV'] ||= environment
 
       raise ArgumentError, "#{options[:require]} does not exist" unless File.exist?(options[:require])
 


### PR DESCRIPTION
I couldn't find any way to run different sidekiq configurations under same Rails environment.
