### PR TITLE
Added rescue to prevent crashing on Windows

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -46,8 +46,12 @@ module Sidekiq
       self_read, self_write = IO.pipe
 
       %w(INT TERM USR1 USR2 TTIN).each do |sig|
-        trap sig do
-          self_write.puts(sig)
+        begin
+          trap sig do
+            self_write.puts(sig)
+          end
+        rescue ArgumentError
+          puts "Signal #{sig} not supported"
         end
       end
 


### PR DESCRIPTION
'unsupported signal SIGUSR1' occurs when running on Windows. SIGINT is supported in Windows. This will fail quietly and log an argument error in the console, while still working alongside the redis server.
