### PR TITLE
Fix backtrace option on HardWorker

### DIFF
--- a/myapp/app/workers/hard_worker.rb
+++ b/myapp/app/workers/hard_worker.rb
@@ -1,6 +1,6 @@
 class HardWorker
   include Sidekiq::Worker
-  sidekiq_options :backtrace => 5
+  sidekiq_options :backtrace => true
 
   def perform(name, count, salt)
     raise name if name == 'crash'


### PR DESCRIPTION
Set backtrace option to true instead of 5 on HardWorker. I think it was a copy/paste mistake.
