### PR TITLE
Don't ack on unexpected failures from updating Redis stats and other exceptions

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -56,6 +56,8 @@ module Sidekiq
           ack = false
         rescue Exception => ex
           handle_exception(ex, msg || { :message => msgstr })
+          # Don't acknowledge the work since we didn't properly finish it
+          ack = false
           raise
         ensure
           work.acknowledge if ack


### PR DESCRIPTION
Line 97 of processor.rb, the top of #stats, failed with a connection timeout. This raised an exception to line 57 in processor.rb; however, the ensure block removed the job from the local queue. This job was lost, even with reliable fetch.
