### PR TITLE
Add ASCII logo, banner on startup in development

### DIFF
--- a/lib/sidekiq/banner.rb
+++ b/lib/sidekiq/banner.rb
@@ -1,0 +1,33 @@
+module Sidekiq
+  module Banner
+    def print_oss_banner
+      puts %q{         s
+        ss
+   sss  sss         ss
+   s  sss s   ssss sss   ____  _     _      _    _
+   s     sssss ssss     / ___|(_) __| | ___| | _(_) __ _
+  s         sss         \___ \| |/ _` |/ _ \ |/ / |/ _` |
+  s sssss  s             ___) | | (_| |  __/   <| | (_| |
+  ss    s  s            |____/|_|\__,_|\___|_|\_\_|\__, |
+  s     s s                                           |_|
+        s s
+       sss
+       sss }
+    end
+
+    def print_pro_banner
+      puts %q{         s
+        ss
+   sss  sss         ss
+   s  sss s   ssss sss   ____  _     _      _    _         ____
+   s     sssss ssss     / ___|(_) __| | ___| | _(_) __ _  |  _ \ _ __ ___
+  s         sss         \___ \| |/ _` |/ _ \ |/ / |/ _` | | |_) | '__/ _ \
+  s sssss  s             ___) | | (_| |  __/   <| | (_| | |  __/| | | (_) |
+  ss    s  s            |____/|_|\__,_|\___|_|\_\_|\__, | |_|   |_|  \___/
+  s     s s                                           |_|
+        s s
+       sss
+       sss }
+    end
+  end
+end

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -6,6 +6,7 @@ require 'optparse'
 require 'erb'
 
 require 'sidekiq'
+require 'sidekiq/banner'
 require 'sidekiq/util'
 
 module Sidekiq
@@ -18,6 +19,7 @@ module Sidekiq
   class Shutdown < Interrupt; end
 
   class CLI
+    include Banner
     include Util
     include Singleton
 
@@ -52,6 +54,19 @@ module Sidekiq
           end
         rescue ArgumentError
           puts "Signal #{sig} not supported"
+        end
+      end
+
+      # Print logo and banner for development
+      if options[:environment] == 'development'
+        if Sidekiq::NAME == 'Sidekiq Pro'
+          puts "\e[#{31}m"
+          print_pro_banner
+          puts "\e[0m"
+        else
+          puts "\e[#{31}m"
+          print_oss_banner
+          puts "\e[0m"
         end
       end
 


### PR DESCRIPTION
1. Banners in `Sidekiq::Banners`
2. Check if we are in `development`
3. Check `Sidekiq::NAME` and print appropriate banner.

To avoid cluttering the `print_oss_banner` method with escaping color codes, I opted to just wrap the
method with the red and reset codes. Hope this is what you were looking for! I :heart: Sidekiq!
