### PR TITLE
Translations for traditional Chinese.

### DIFF
--- a/web/locales/zh-tw.yml
+++ b/web/locales/zh-tw.yml
@@ -19,7 +19,7 @@
   Class: 類別
   Job: 工作
   Arguments: 引數
-  Extras: 額外
+  Extras: 額外資料
   Started: 開始於
   ShowAll: 全部顯示
   CurrentMessagesInQueue: 目前 <span class='title'>%{queue}</span> 佇列中的訊息


### PR DESCRIPTION
Is there a script which could generate all kinds of stubs, so that
I could translate items with exact context easily? Since some words
might make more sense to translate to different words in different
contexts, it would be much better to translate with context instead
of simply looking at the items.

For example, I am not very sure how "Extras" was used, and I don't
know how to translate it more correctly.

Also, "Process" and "Name" are missing in en.yml, and I added them
to zh-tw to avoid mixing English and traditional Chinese.

Lastly, to be honest, I don't really know how some terms should be
translated, and if there's a common way to translate them. Some terms
we don't really have translations, and just speak, talk and communicate
in English. I am not sure if I should keep them in English, or try to
translate them accordingly. For now I tried to translate everything.

Thanks!
