### PR TITLE
Fix warnings in tests

### DIFF
--- a/lib/sidekiq/core_ext.rb
+++ b/lib/sidekiq/core_ext.rb
@@ -6,7 +6,6 @@ rescue LoadError
   # Class#class_attribute helper.
   class Class
     def class_attribute(*attrs)
-      instance_reader = true
       instance_writer = true
 
       attrs.each do |name|
@@ -29,14 +28,12 @@ rescue LoadError
             val
           end
 
-          if instance_reader
-            def #{name}
-              defined?(@#{name}) ? @#{name} : self.class.#{name}
-            end
+          def #{name}
+            defined?(@#{name}) ? @#{name} : self.class.#{name}
+          end
 
-            def #{name}?
-              !!#{name}
-            end
+          def #{name}?
+            !!#{name}
           end
         RUBY
 

--- a/myapp/config/boot.rb
+++ b/myapp/config/boot.rb
@@ -3,4 +3,4 @@ require 'rubygems'
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -109,7 +109,7 @@ class TestCli < Sidekiq::Test
       after do
         Sidekiq.logger = @old_logger
         Sidekiq.options.delete(:logfile)
-        File.unlink @tmp_log_path if File.exists?(@tmp_log_path)
+        File.unlink @tmp_log_path if File.exist?(@tmp_log_path)
       end
 
       it 'sets the logfile path' do

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -177,7 +177,7 @@ class TestClient < Sidekiq::Test
     end
     it 'returns the jids for the jobs' do
       Sidekiq::Client.push_bulk('class' => 'QueuedWorker', 'args' => (1..2).to_a.map { |x| Array(x) }).each do |jid|
-        assert_match /[0-9a-f]{12}/, jid
+        assert_match(/[0-9a-f]{12}/, jid)
       end
     end
   end
@@ -207,9 +207,9 @@ class TestClient < Sidekiq::Test
       Sidekiq.client_middleware.add Stopper
       begin
         assert_equal nil, Sidekiq::Client.push('class' => MyWorker, 'args' => [0])
-        assert_match /[0-9a-f]{12}/, Sidekiq::Client.push('class' => MyWorker, 'args' => [1])
+        assert_match(/[0-9a-f]{12}/, Sidekiq::Client.push('class' => MyWorker, 'args' => [1]))
         Sidekiq::Client.push_bulk('class' => MyWorker, 'args' => [[0], [1]]).each do |jid|
-          assert_match /[0-9a-f]{12}/, jid
+          assert_match(/[0-9a-f]{12}/, jid)
         end
       ensure
         Sidekiq.client_middleware.remove Stopper

--- a/test/test_exception_handler.rb
+++ b/test/test_exception_handler.rb
@@ -32,9 +32,9 @@ class TestExceptionHandler < Sidekiq::Test
       Component.new.invoke_exception(:a => 1)
       @str_logger.rewind
       log = @str_logger.readlines
-      assert_match /a=>1/, log[0], "didn't include the context"
-      assert_match /Something didn't work!/, log[1], "didn't include the exception message"
-      assert_match /test\/test_exception_handler.rb/, log[2], "didn't include the backtrace"
+      assert_match(/a=>1/, log[0], "didn't include the context")
+      assert_match(/Something didn't work!/, log[1], "didn't include the exception message")
+      assert_match(/test\/test_exception_handler.rb/, log[2], "didn't include the backtrace")
     end
 
     describe "when the exception does not have a backtrace" do
@@ -45,7 +45,7 @@ class TestExceptionHandler < Sidekiq::Test
         begin
           Component.new.handle_exception exception
           pass
-        rescue => e
+        rescue StandardError
           flunk "failed handling a nil backtrace"
         end
       end

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -244,7 +244,7 @@ class TestRetry < Sidekiq::Test
       after do
         Sidekiq.logger = @old_logger
         Sidekiq.options.delete(:logfile)
-        File.unlink @tmp_log_path if File.exists?(@tmp_log_path)
+        File.unlink @tmp_log_path if File.exist?(@tmp_log_path)
       end
 
       let(:custom_worker) do

--- a/test/test_sidekiq.rb
+++ b/test/test_sidekiq.rb
@@ -40,11 +40,11 @@ class TestSidekiq < Sidekiq::Test
       e = assert_raises ArgumentError do
         Sidekiq.on(:startp)
       end
-      assert_match /Invalid event name/, e.message
+      assert_match(/Invalid event name/, e.message)
       e = assert_raises ArgumentError do
         Sidekiq.on('startup')
       end
-      assert_match /Symbols only/, e.message
+      assert_match(/Symbols only/, e.message)
       Sidekiq.on(:startup) do
         1 + 1
       end

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -42,9 +42,9 @@ class TestWeb < Sidekiq::Test
 
       get '/busy'
       assert_equal 200, last_response.status
-      assert_match /status-active/, last_response.body
-      assert_match /critical/, last_response.body
-      assert_match /WebWorker/, last_response.body
+      assert_match(/status-active/, last_response.body)
+      assert_match(/critical/, last_response.body)
+      assert_match(/WebWorker/, last_response.body)
     end
 
     it 'can display queues' do
@@ -52,8 +52,8 @@ class TestWeb < Sidekiq::Test
 
       get '/queues'
       assert_equal 200, last_response.status
-      assert_match /foo/, last_response.body
-      refute_match /HardWorker/, last_response.body
+      assert_match(/foo/, last_response.body)
+      refute_match(/HardWorker/, last_response.body)
     end
 
     it 'handles queue view' do
@@ -100,15 +100,15 @@ class TestWeb < Sidekiq::Test
     it 'can display retries' do
       get '/retries'
       assert_equal 200, last_response.status
-      assert_match /found/, last_response.body
-      refute_match /HardWorker/, last_response.body
+      assert_match(/found/, last_response.body)
+      refute_match(/HardWorker/, last_response.body)
 
       add_retry
 
       get '/retries'
       assert_equal 200, last_response.status
-      refute_match /found/, last_response.body
-      assert_match /HardWorker/, last_response.body
+      refute_match(/found/, last_response.body)
+      assert_match(/HardWorker/, last_response.body)
     end
 
     it 'can display a single retry' do
@@ -117,7 +117,7 @@ class TestWeb < Sidekiq::Test
       assert_equal 302, last_response.status
       get "/retries/#{job_params(*params)}"
       assert_equal 200, last_response.status
-      assert_match /HardWorker/, last_response.body
+      assert_match(/HardWorker/, last_response.body)
     end
 
     it 'handles missing retry' do
@@ -133,7 +133,7 @@ class TestWeb < Sidekiq::Test
 
       get "/retries"
       assert_equal 200, last_response.status
-      refute_match /#{params.first['args'][2]}/, last_response.body
+      refute_match(/#{params.first['args'][2]}/, last_response.body)
     end
 
     it 'can delete all retries' do
@@ -153,21 +153,21 @@ class TestWeb < Sidekiq::Test
 
       get '/queues/default'
       assert_equal 200, last_response.status
-      assert_match /#{params.first['args'][2]}/, last_response.body
+      assert_match(/#{params.first['args'][2]}/, last_response.body)
     end
 
     it 'can display scheduled' do
       get '/scheduled'
       assert_equal 200, last_response.status
-      assert_match /found/, last_response.body
-      refute_match /HardWorker/, last_response.body
+      assert_match(/found/, last_response.body)
+      refute_match(/HardWorker/, last_response.body)
 
       add_scheduled
 
       get '/scheduled'
       assert_equal 200, last_response.status
-      refute_match /found/, last_response.body
-      assert_match /HardWorker/, last_response.body
+      refute_match(/found/, last_response.body)
+      assert_match(/HardWorker/, last_response.body)
     end
 
     it 'can display a single scheduled job' do
@@ -176,7 +176,7 @@ class TestWeb < Sidekiq::Test
       assert_equal 302, last_response.status
       get "/scheduled/#{job_params(*params)}"
       assert_equal 200, last_response.status
-      assert_match /HardWorker/, last_response.body
+      assert_match(/HardWorker/, last_response.body)
     end
 
     it 'handles missing scheduled job' do
@@ -192,7 +192,7 @@ class TestWeb < Sidekiq::Test
 
       get '/queues/default'
       assert_equal 200, last_response.status
-      assert_match /#{params.first['args'][2]}/, last_response.body
+      assert_match(/#{params.first['args'][2]}/, last_response.body)
     end
 
     it 'can delete a single scheduled job' do
@@ -203,7 +203,7 @@ class TestWeb < Sidekiq::Test
 
       get "/scheduled"
       assert_equal 200, last_response.status
-      refute_match /#{params.first['args'][2]}/, last_response.body
+      refute_match(/#{params.first['args'][2]}/, last_response.body)
     end
 
     it 'can delete scheduled' do
@@ -230,12 +230,12 @@ class TestWeb < Sidekiq::Test
         assert_equal 1, q.size
         get '/queues/default'
         assert_equal 200, last_response.status
-        assert_match /#{params[0]['args'][2]}/, last_response.body
+        assert_match(/#{params[0]['args'][2]}/, last_response.body)
       end
     end
 
     it 'can retry all retries' do
-      msg, score = add_retry
+      msg = add_retry.first
       add_retry
 
       post "/retries/all/retry", 'retry' => 'Retry'
@@ -253,7 +253,7 @@ class TestWeb < Sidekiq::Test
       params = add_xss_retry
       get '/retries'
       assert_equal 200, last_response.status
-      assert_match /FailWorker/, last_response.body
+      assert_match(/FailWorker/, last_response.body)
 
       assert last_response.body.include?( "fail message: &lt;a&gt;hello&lt;&#x2F;a&gt;" )
       assert !last_response.body.include?( "fail message: <a>hello</a>" )
@@ -274,7 +274,7 @@ class TestWeb < Sidekiq::Test
 
       get '/busy'
       assert_equal 200, last_response.status
-      assert_match /FailWorker/, last_response.body
+      assert_match(/FailWorker/, last_response.body)
       assert last_response.body.include?( "&lt;a&gt;hello&lt;&#x2F;a&gt;" )
       assert !last_response.body.include?( "<a>hello</a>" )
 
@@ -316,7 +316,7 @@ class TestWeb < Sidekiq::Test
         end
 
         get '/custom'
-        assert_match /Changed text/, last_response.body
+        assert_match(/Changed text/, last_response.body)
 
       ensure
         Sidekiq::Web.tabs.delete 'Custom Tab'
@@ -390,7 +390,7 @@ class TestWeb < Sidekiq::Test
         (_, score) = add_dead
         get 'morgue'
         assert_equal 200, last_response.status
-        assert_match /#{score}/, last_response.body
+        assert_match(/#{score}/, last_response.body)
       end
 
       it 'can delete all dead' do
@@ -411,7 +411,7 @@ class TestWeb < Sidekiq::Test
 
         get '/queues/foo'
         assert_equal 200, last_response.status
-        assert_match /#{params.first['args'][2]}/, last_response.body
+        assert_match(/#{params.first['args'][2]}/, last_response.body)
       end
     end
 


### PR DESCRIPTION
1. Fixed warnings in Sidekiq test code
2. Fixed a warning in lib/sidekiq/core_ext.rb - the heredoc method of using class_eval doesn't use variables in the caller's scope.

Addresses issue #1578
