### PR TITLE
make sure relative_time web helper is using a time object

### DIFF
--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'time'
 
 module Sidekiq
   # This is not a public API
@@ -90,7 +91,7 @@ module Sidekiq
     end
 
     def relative_time(time)
-      %{<time datetime="#{time.getutc.iso8601}">#{time}</time>}
+      %{<time datetime="#{time.to_time.getutc.iso8601}">#{time}</time>}
     end
 
     def job_params(job, score)


### PR DESCRIPTION
The `relative_time` web helper assumes it will always be dealing with objects that respond to `.getutc`. Somewhere in our app, we're ending up with a `DateTime` object getting delivered here, which results in this exception:

```
NoMethodError - undefined method `getutc' for #<DateTime:0x000000018586c0>:
2014-03-21T20:20:02.206877+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/sidekiq-2.17.7/lib/sidekiq/web_helpers.rb:93:in `relative_time'
```

We're not doing anything funky with `perform_async` or `perform_at` so I assume this is caused by some other 3rd-party gem like activesupport that affects the relationship of time-like objects. My change here seems like the safest way to guard against problems like this. 
