### PR TITLE
Paves the way for sharding Sidekiq in the same installation. Still does ...

### DIFF
--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -25,6 +25,7 @@ module Sidekiq
     def initialize(options={})
       logger.debug { options.inspect }
       @options = options
+      @redis_pool = Sidekiq.redis_pool
       @count = options[:concurrency] || 25
       @done_callback = nil
 
@@ -146,7 +147,7 @@ module Sidekiq
 
     def ❤(key)
       begin
-        Sidekiq.redis do |conn|
+        @redis_pool.with do |conn|
           conn.multi do
             conn.hmset(key, 'busy', @busy.size, 'beat', Time.now.to_f)
             conn.expire(key, 60)

--- a/lib/sidekiq/paginator.rb
+++ b/lib/sidekiq/paginator.rb
@@ -8,7 +8,7 @@ module Sidekiq
       starting = pageidx * page_size
       ending = starting + page_size - 1
 
-      Sidekiq.redis do |conn|
+      settings.redis_pool.with do |conn|
         type = conn.type(key)
 
         case type

--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -51,21 +51,21 @@ module Sidekiq
     end
 
     def retries_with_score(score)
-      Sidekiq.redis do |conn|
+      settings.redis_pool.with do |conn|
         conn.zrangebyscore('retry', score, score)
       end.map { |msg| Sidekiq.load_json(msg) }
     end
 
     def location
-      Sidekiq.redis { |conn| conn.client.location }
+      settings.redis_pool.with { |conn| conn.client.location }
     end
 
     def redis_connection
-      Sidekiq.redis { |conn| conn.client.id }
+      settings.redis_pool.with { |conn| conn.client.id }
     end
 
     def namespace
-      @@ns ||= Sidekiq.redis {|conn| conn.respond_to?(:namespace) ? conn.namespace : nil }
+      @@ns ||= settings.redis_pool.with {|conn| conn.respond_to?(:namespace) ? conn.namespace : nil }
     end
 
     def root_path


### PR DESCRIPTION
...not allow the fetcher to use more than one Redis instance, but API and web could with more work.

---

I only spent 10 minutes on this pull but wanted to show a POC where we could go down a path to kill `Sidekiq.redis` global state (start injecting it in or using the thread local variable, which is probably better, in which case I'd rewrite some of this). I don't think that a Sidekiq server should ever shard out -- that is, a given Sidekiq process should always pull jobs from a single Redis instance. But I think that the API and Web UI should support a single application accessing all the Redis instances. For the web UI, I'd ideally like to mount Sidekiq::Web at multiple URLs and have them talk to different Redis instances so I don't have to deploy a separate application for each.

Anyway, this isn't very pressing, for my use case, I can make due with what I've got in 3.0 but wanted to float this out.
