### PR TITLE
Set sizing of summary bar li's

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -128,8 +128,13 @@ header.row .pagination {
 .summary_bar ul li {
   padding: 4px 0 2px 0;
   text-align: center;
+  width: 14%;
 }
 @media (max-width: 767px) and (min-width: 400px) {
+  .summary_bar ul li {
+    width: 100%;
+  }
+
   .summary_bar ul li span {
     width: 50% !important;
   }


### PR DESCRIPTION
Before:

![before](https://cloud.githubusercontent.com/assets/744212/2539142/386d2232-b5c5-11e3-9256-76e1f0713283.png)

After:

![after](https://cloud.githubusercontent.com/assets/744212/2539146/3b6c5980-b5c5-11e3-895e-fa5c4573ff85.png)

Mobile:

![mobile](https://cloud.githubusercontent.com/assets/744212/2539153/4e40b506-b5c5-11e3-9005-d1cbcd84ab2d.png)
