### PR TITLE
add fix for google translate bar

### DIFF
--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -7,6 +7,7 @@
     <link href="<%= root_path %>stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />
     <script type="text/javascript" src="<%= root_path %>javascripts/application.js"></script>
     <script type="text/javascript" src="<%= root_path %>javascripts/locales/jquery.timeago.<%= locale %>.js"></script>
+    <meta name="google" value="notranslate" />
   </head>
   <body class="admin">
     <div class="navbar navbar-default navbar-fixed-top">


### PR DESCRIPTION
Occasionally when I'm running Sidekiq Web I'll get this notification
![sidekiq](https://cloud.githubusercontent.com/assets/15485/2547360/c234c7f6-b64f-11e3-9890-1c25d2887f6c.png)

Whilst just a small issue it's a bit annoying, adding this HTML to the head will disable that.
