### PR TITLE
Fix typo for determining redis provider

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -68,7 +68,7 @@ module Sidekiq
       end
 
       def determine_redis_provider
-        ENV[ENV['REDIS_PROVIDER'] || 'REDIS_URL']
+        ENV['REDIS_PROVIDER'] || ENV['REDIS_URL']
       end
 
     end


### PR DESCRIPTION
Hey!

There was a typo in the RedisConnection since 3.0 that caused the migration to 3.0 for Heroku per the example not to work. Here's the fix :-)
