### PR TITLE
Use ActiveSupport.on_load hooks to extend rails components

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -1,11 +1,11 @@
 module Sidekiq
   def self.hook_rails!
-    if defined?(::ActiveRecord)
-      ::ActiveRecord::Base.__send__(:include, Sidekiq::Extensions::ActiveRecord)
+    ActiveSupport.on_load(:active_record) do
+      include Sidekiq::Extensions::ActiveRecord
     end
 
-    if defined?(::ActionMailer)
-      ::ActionMailer::Base.extend(Sidekiq::Extensions::ActionMailer)
+    ActiveSupport.on_load(:action_mailer) do
+      extend Sidekiq::Extensions::ActionMailer
     end
   end
 


### PR DESCRIPTION
Checking if the constant is define and including the extensions directly in the base class will for the class to be loaded. This may cause these components to be loaded before the time and be missconfigured if the sidekiq railtie is loaded before the components railtie.

It is unlikely to happen but is better be safe.
