### PR TITLE
Fix RedisConnection determine_redis_provider

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -68,7 +68,7 @@ module Sidekiq
       end
 
       def determine_redis_provider
-        ENV[ENV['REDIS_PROVIDER'] || 'REDIS_URL']
+        ENV['REDIS_PROVIDER'] || ENV['REDIS_URL']
       end
 
     end


### PR DESCRIPTION
This line was causing Sidekiq 3.0 to fail for me. I believe this is what was originally intended
