### PR TITLE
Require the dependencies necessary for Fetch and Actor in their respective files.

### DIFF
--- a/lib/sidekiq/actor.rb
+++ b/lib/sidekiq/actor.rb
@@ -1,3 +1,5 @@
+require 'celluloid'
+
 module Sidekiq
   module Actor
 

--- a/lib/sidekiq/fetch.rb
+++ b/lib/sidekiq/fetch.rb
@@ -1,4 +1,5 @@
 require 'sidekiq'
+require 'sidekiq/util'
 require 'sidekiq/actor'
 
 module Sidekiq


### PR DESCRIPTION
Ran into an issue implementing DynamicFetch similar to this: https://zeropush.com/blog/dynamic-queues-in-sidekiq

The trouble was that requiring sidekiq/fetch for extension led to some missing definition errors. This code fixes the issue.

One possible tweak is to only require celluloid when Actor is included.
