### PR TITLE
fix alias_method order bug

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -57,8 +57,6 @@ module Sidekiq
   class EmptyQueueError < RuntimeError; end
 
   class Client
-    alias_method :raw_push_real, :raw_push
-
     def raw_push(payloads)
       if Sidekiq::Testing.fake?
         payloads.each do |job|
@@ -78,6 +76,8 @@ module Sidekiq
         raw_push_real(payloads)
       end
     end
+
+    alias_method :raw_push_real, :raw_push
   end
 
   module Worker


### PR DESCRIPTION
alias_method's load order is wrong. 
As a result, bundle exec rake spec is failed....

```
/Users/u1/Repos/controller/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.0.0/lib/sidekiq/testing.rb:59:in `alias_method': undefined method `raw_push' for class `Sidekiq::Client' (NameError)
    from /Users/u1/Repos/controller/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.0.0/lib/sidekiq/testing.rb:59:in `<class:Client>'
    from /Users/u1/Repos/controller/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.0.0/lib/sidekiq/testing.rb:58:in `<module:Sidekiq>'
    from /Users/u1/Repos/controller/vendor/bundle/ruby/2.1.0/gems/sidekiq-3.0.0/lib/sidekiq/testing.rb:3:in `<top (required)>'
    from /Users/u1/Repos/controller/vendor/bundle/ruby/2.1.0/gems/rspec-sidekiq-1.0.0/lib/rspec-sidekiq.rb:1:in `require'
    from /Users/u1/Repos/controller/vendor/bundle/ruby/2.1.0/gems/rspec-sidekiq-1.0.0/lib/rspec-sidekiq.rb:1:in `<top (required)>'
    from /Users/u1/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.1/lib/bundler/runtime.rb:76:in `require'
    from /Users/u1/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.1/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
    from /Users/u1/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.1/lib/bundler/runtime.rb:72:in `each'
    from /Users/u1/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.1/lib/bundler/runtime.rb:72:in `block in require'
    from /Users/u1/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.1/lib/bundler/runtime.rb:61:in `each'
    from /Users/u1/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.1/lib/bundler/runtime.rb:61:in `require'
    from /Users/u1/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/bundler-1.6.1/lib/bundler.rb:132:in `require'
```
