### PR TITLE
Forcibly break cell content for columns that get too wide

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -197,6 +197,18 @@ td form {
   padding: 0px;
 }
 
+.table td {
+  /* Non standard for webkit */
+  word-break: break-word;
+
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  hyphens: auto;
+
+  -ms-word-break: break-all;
+  word-break: break-all;
+}
+
 table .table-checkbox label {
   height: 100%;
   width: 100%;


### PR DESCRIPTION
This should fix #1652.
## Chrome 35.0.1916.27 beta

![screen shot 2014-04-15 at 6 22 38 pm](https://cloud.githubusercontent.com/assets/342081/2713919/42cf0816-c4ee-11e3-83bf-279ecd7e50c0.png)
## Firefox 27.0.1

![screen shot 2014-04-15 at 6 23 20 pm](https://cloud.githubusercontent.com/assets/342081/2713923/484a25fa-c4ee-11e3-963b-1b3b1c9e6062.png)
## IE9 on Win7 (via VirtualBox)

![screen shot 2014-04-15 at 6 31 23 pm](https://cloud.githubusercontent.com/assets/342081/2713928/617f40d2-c4ee-11e3-9676-754b598f2be6.png)
