### PR TITLE
Mention that Sidekiq 3 requires Ruby 2.0 which will prevent 1.9 installs in the future

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -7,7 +7,10 @@ Gem::Specification.new do |gem|
   gem.description   = gem.summary = "Simple, efficient background processing for Ruby"
   gem.homepage      = "http://sidekiq.org"
   gem.license       = "LGPL-3.0"
-
+  
+  # Sidekiq 3 requires ruby 2.0.x
+  gem.required_ruby_version = '~> 2.0'
+  
   gem.executables   = ['sidekiq', 'sidekiqctl']
   gem.files         = `git ls-files | grep -Ev '^(myapp|examples)'`.split("\n")
   gem.test_files    = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
This will prevent broken installs for people who didn't read the Readme like they should have, and will have effect once the new Bundler stuff takes hold (http://andre.arko.net/2014/03/28/the-new-rubygems-index-format/)
