### PR TITLE
Only call ActiveRecord::Base.clear_active_connections! if possible.

### DIFF
--- a/lib/sidekiq/middleware/server/active_record.rb
+++ b/lib/sidekiq/middleware/server/active_record.rb
@@ -5,7 +5,9 @@ module Sidekiq
         def call(*args)
           yield
         ensure
-          ::ActiveRecord::Base.clear_active_connections! if defined?(::ActiveRecord)
+          if defined?(::ActiveRecord::Base) && ::ActiveRecord::Base.respond_to?(:clear_active_connections!)
+            ::ActiveRecord::Base.clear_active_connections!
+          end
         end
       end
     end


### PR DESCRIPTION
In some cases, ActiveRecord can be defined, even if ActiveRecord::Base is not.

We have one such wonky case.
