### PR TITLE
trap nil args passed to display_args

### DIFF
--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -111,7 +111,7 @@ module Sidekiq
       args.map do |arg|
         a = arg.inspect
         h(truncate(a))
-      end.join(", ")
+      end.join(", ") if args
     end
 
     RETRY_JOB_KEYS = Set.new(%w(


### PR DESCRIPTION
I encountered an issue with sidekiq-failures gem pushing nil to display_args method.

https://github.com/mhfs/sidekiq-failures/issues/69
