### PR TITLE
Option to remove the generic aliases which MAY clash

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -9,6 +9,21 @@ module Sidekiq
     end
   end
 
+  # Removes the generic aliases which MAY clash with names of already
+  #  created methods by other applications. The methods `sidekiq_delay`,
+  #  `sidekiq_delay_for` and `sidekiq_delay_until` can be used instead.
+  def self.namespace_delay_methods
+    [Extensions::ActiveRecord, 
+     Extensions::ActionMailer, 
+     Extensions::Klass].each do |mod|
+      mod.module_eval do
+        remove_method :delay if respond_to?(:delay)
+        remove_method :delay_for if respond_to?(:delay_for)
+        remove_method :delay_until if respond_to?(:delay_until)
+      end
+    end
+  end
+
   class Rails < ::Rails::Engine
     config.autoload_paths << File.expand_path("#{config.root}/app/workers") if File.exist?("#{config.root}/app/workers")
 


### PR DESCRIPTION
This pull request solves https://github.com/mperham/sidekiq/issues/1647.

Please add `Sidekiq.namespace_delay_methods` to your config/initializers/sidekiq.rb and the DangerousAttributeErrors will go away.

Instead of the `delay`, `delay_for` and `delay_until` methods,
use
`sidekiq_delay`
`sidekiq_delay_for` and
`sidekiq_delay_until` respectively

Hope this helps
