### PR TITLE
added require 'sidekiq/api' for calling stats

### DIFF
--- a/examples/sinkiq.rb
+++ b/examples/sinkiq.rb
@@ -7,6 +7,7 @@
 require 'sinatra'
 require 'sidekiq'
 require 'redis'
+require 'sidekiq/api'
 
 $redis = Redis.new
 


### PR DESCRIPTION
This is now needed as per https://github.com/meskyanichi/hirefire-resource/issues/20#issuecomment-40135831.  This is required for the app to run.
