### PR TITLE
[CI] allowing latest ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - jruby-19mode
   - rbx
   - 2.0.0
-  - 2.1.0
+  - 2.1
 matrix:
   allow_failures:
     - rvm: rbx


### PR DESCRIPTION
ruby is on 2.1.2 now, but, using just 2.1 on travis it will be automatically now and in future versions
