### PR TITLE
Fixing initial polling behavior

### DIFF
--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -172,7 +172,6 @@ var setSliderLabel = function(val) {
 
 $(function(){
   renderGraphs();
-  clearInterval(poller);
 
   if (typeof localStorage.timeInterval !== 'undefined'){
     $('div.interval-slider input').val(localStorage.timeInterval);


### PR DESCRIPTION
Fixes #1713

I checked the initial polling behavior again after seeing @brandonhilkert's comment and he's right in that the polling did indeed not start right away. 

I found and fixed the bug: an extra `clearInterval()` on document load which prevented the polling from starting. It should be working as expected now.
