### PR TITLE
Fixing polling interval reset on window resize

### DIFF
--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -211,6 +211,7 @@ var debounce = function(fn, timeout)
 };
 
 window.onresize = debounce(function() {
+    clearInterval(poller);
     resetGraphs();
     renderGraphs();
 }, 125);


### PR DESCRIPTION
Fixes #1726

Aha! That was the missing `clearInterval`. There is a custom function that gets called on resizing the window that also re-renders the graphs and resets the polling interval. It is there that the polling interval needs to be cleared. 

Actually I think that was the funky behavior I noticed when I added the clearInterval on document load (previous bug fix). I didn't make the connection that it was being caused by resizing the window.
