### PR TITLE
Remove erb trim instruction on busy.erb page

### DIFF
--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -58,7 +58,7 @@
     <th><%= t('Started') %></th>
   </thead>
   <% workers.each_with_index do |(process, thread, msg), index| %>
-    <% job = Sidekiq::Job.new(msg['payload']) -%>
+    <% job = Sidekiq::Job.new(msg['payload']) %>
     <tr>
       <td><%= process %></td>
       <td><%= thread %></td>


### PR DESCRIPTION
Hey, I updated my sidekiq from 3.0.2 to 3.1.0 and the web **( busy.erb )** component raise a syntax error.

```
[ 2014-05-26 11:16:52.7334 35963/0x10c9e5000 Pool2/SmartSpawner.h:301 ]: Preloader for /Users/tdantas/Code/sidekiq-monitor started on PID 35980, listening on 
App 35980 stderr: SyntaxError - /Users/tdantas/.rvm/gems/ruby-1.9.3-p327@sidekiq-monitor/gems/sidekiq-3.1.0/web/views/busy.erb:61: syntax error, unexpected ';'                     
App 35980 stderr: ...kiq::Job.new(msg['payload']) -; @_out_buf.concat "\n"

```

To reproduce the error I created a simple example and verify that to ERB trim empty lines, we must pass an argument to trim mode.

```
require 'erb'
TEMPLATE = <<-EOF
  <%= name -%>
EOF
name = 'sidekiq'

puts '------- Without trim mode -------'
begin
  puts ERB.new(TEMPLATE).result(binding)
rescue Exception => e
  puts "Failed #{e.message}"
end

puts '------- With trim mode -------'
begin
  puts ERB.new(TEMPLATE, nil, '-').result(binding)
rescue
  puts 'Failed'
end
```

Output:   

```
------- Without trim mode -------
Failed (erb):1: syntax error, unexpected ')'
... "  "; _erbout.concat(( name -).to_s); _erbout.concat "\n"
...                                 ^

------- With trim mode -------
 sidekiq

```

Thanks
