### PR TITLE
require celluloid for actor

### DIFF
--- a/lib/sidekiq/actor.rb
+++ b/lib/sidekiq/actor.rb
@@ -1,3 +1,5 @@
+require 'celluloid'
+
 module Sidekiq
   module Actor
 


### PR DESCRIPTION
If you try to `require 'sidekiq/fetch'` it blows up.

```
/Users/nolanevans/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/sidekiq-3.1.2/lib/sidekiq/actor.rb:35:in `included': uninitialized constant Sidekiq::Actor::Celluloid (NameError)
    from /Users/nolanevans/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/sidekiq-3.1.2/lib/sidekiq/fetch.rb:12:in `include'
    from /Users/nolanevans/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/sidekiq-3.1.2/lib/sidekiq/fetch.rb:12:in `<class:Fetcher>'
    from /Users/nolanevans/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/sidekiq-3.1.2/lib/sidekiq/fetch.rb:10:in `<module:Sidekiq>'
    from /Users/nolanevans/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/sidekiq-3.1.2/lib/sidekiq/fetch.rb:5:in `<top (required)>'
    from /Users/nolanevans/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/nolanevans/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/nolanevans/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/sidekiq-limit_fetch-0.7/lib/sidekiq/limit_fetch.rb:2:in `<top (required)>'
    from /Users/nolanevans/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `require'
    from /Users/nolanevans/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
    from /Users/nolanevans/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:144:in `require'
    from /Users/nolanevans/Development/home_details/app/boot.rb:19:in `<top (required)>'
    from /Users/nolanevans/Development/home_details/app/api.rb:1:in `require_relative'
    from /Users/nolanevans/Development/home_details/app/api.rb:1:in `<top (required)>'
```

I think this belongs here, otherwise every plugin would need to require celluloid to require fetch.
