### PR TITLE
Added name of queues to proctitle

### DIFF
--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -136,7 +136,7 @@ module Sidekiq
       proctitle = ['sidekiq', Sidekiq::VERSION]
       proctitle << data['tag'] unless data['tag'].empty?
       proctitle << "[#{@busy.size} of #{data['concurrency']} busy]"
-      proctitle << "(#{data['queues'].join(',')})" unless data['queues'].empty?
+      proctitle << "(#{data['queues'].join(',')})" unless data['queues'].nil?
       proctitle << 'stopping' if stopped?
       $0 = proctitle.join(' ')
 


### PR DESCRIPTION
I've added a small improvement to the proctitle displayed when doing `top` or `ps` on the console, to show the names of the queues that sidekiq will be monitoring.

This is very useful when you have several sidekiq processes on one machine and want to distinguish (mostly to kill) between them.
