### PR TITLE
Rescue from ArgumentError when deserializing YAML

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -206,8 +206,14 @@ module Sidekiq
       # Unwrap known wrappers so they show up in a human-friendly manner in the Web UI
       @klass ||= case klass
                  when /\ASidekiq::Extensions::Delayed/
-                   (target, method, _) = YAML.load(args[0])
-                   "#{target}.#{method}"
+                   begin
+                     (target, method, _) = YAML.load(args[0])
+                     "#{target}.#{method}"
+                   rescue ::ArgumentError => ex
+                     Sidekiq.logger.error ex.message
+                     Sidekiq.logger.error ex.backtrace.join("\n") unless ex.backtrace.nil?
+                     klass
+                   end
                  when "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
                    args[0]
                  else
@@ -219,8 +225,14 @@ module Sidekiq
       # Unwrap known wrappers so they show up in a human-friendly manner in the Web UI
       @args ||= case klass
                 when /\ASidekiq::Extensions::Delayed/
-                  (_, _, arg) = YAML.load(args[0])
-                  arg
+                  begin
+                    (_, _, arg) = YAML.load(args[0])
+                    arg
+                  rescue ::ArgumentError => ex
+                    Sidekiq.logger.error ex.message
+                    Sidekiq.logger.error ex.backtrace.join("\n") unless ex.backtrace.nil?
+                    args
+                  end
                 when "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
                   args[1..-1]
                 else


### PR DESCRIPTION
YAML.load expects the job's class to exist already. In development, classes are loaded dynamically but YAML.load does not trigger autoloading, so hitting /retries will blow up. In this event we rescue the ArgumentError, log it, and fall back to the wrapper job class name.
