### PR TITLE
Optional extension loading

### DIFF
--- a/lib/sidekiq/extensions/class_methods.rb
+++ b/lib/sidekiq/extensions/class_methods.rb
@@ -36,4 +36,4 @@ module Sidekiq
   end
 end
 
-Module.__send__(:include, Sidekiq::Extensions::Klass)
+Module.__send__(:include, Sidekiq::Extensions::Klass) unless defined?(::Rails)

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -1,5 +1,7 @@
 module Sidekiq
   def self.hook_rails!
+    return if defined?(@delay_removed)
+
     ActiveSupport.on_load(:active_record) do
       include Sidekiq::Extensions::ActiveRecord
     end
@@ -7,12 +9,16 @@ module Sidekiq
     ActiveSupport.on_load(:action_mailer) do
       extend Sidekiq::Extensions::ActionMailer
     end
+
+    Module.__send__(:include, Sidekiq::Extensions::Klass)
   end
 
   # Removes the generic aliases which MAY clash with names of already
   #  created methods by other applications. The methods `sidekiq_delay`,
   #  `sidekiq_delay_for` and `sidekiq_delay_until` can be used instead.
   def self.remove_delay!
+    @delay_removed = true
+
     [Extensions::ActiveRecord,
      Extensions::ActionMailer,
      Extensions::Klass].each do |mod|

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -100,6 +100,21 @@ class TestExtensions < Sidekiq::Test
     def queue_size(name='default')
       Sidekiq::Queue.new(name).size
     end
+
+    it 'allows removing of the #delay methods' do
+      Sidekiq.remove_delay!
+      assert_equal 0, queue_size
+      assert_raises NoMethodError do
+        SomeModule.delay.doit(Date.today)
+      end
+
+      Sidekiq.instance_eval { remove_instance_variable :@delay_removed }
+      # Reload modified modules
+      load 'sidekiq/extensions/action_mailer.rb'
+      load 'sidekiq/extensions/active_record.rb'
+      load 'sidekiq/extensions/generic_proxy.rb'
+      load 'sidekiq/extensions/class_methods.rb'
+    end
   end
 
 end


### PR DESCRIPTION
Relates to #1684

The developer can load Sidekiq without the extensions injected by requiring `sidekiq/no_extensions` instead of  `sidekiq`.
