### PR TITLE
Prevent exceptions caused by Sidekiq::Shutdown from causing jobs to be retried

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -64,6 +64,12 @@ module Sidekiq
           # ignore, will be pushed back onto queue during hard_shutdown
           raise
         rescue Exception => e
+          # In Ruby 2.1.0 only, check if exception is a result of shutdown.
+          # If so, will be pushed back onto queue during hard_shutdown.
+          if defined?(e.cause) && e.cause.class == Sidekiq::Shutdown
+            raise Sidekiq::Shutdown
+          end
+
           raise e unless msg['retry']
           max_retry_attempts = retry_attempts_from(msg['retry'], @max_retries)
 


### PR DESCRIPTION
Jobs in progress during a Sidekiq shutdown/restart are requeued for immediate execution. They should not also be queued for retry. Unfortunately, when a `Sidekiq::Shutdown` is raised during, e.g., an ActiveRecord query, this cause cause another exception (e.g. `ActiveRecord::StatementInvalid`) to be raised, which will trigger Sidekiq to put the job into the Retry queue, in addition to restarting automatically when Sidekiq is next started. In effect, this causes the job to be duplicated.

This is an attempt at a cleaner fix than that proposed with mperham#1354, also discussed on mperham#897. Because it depends on Exception#cause, this fix will only be effective on Ruby 2.1.0; however, the code will run on earlier Rubies.
