### PR TITLE
Nil messages

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -42,7 +42,7 @@ module Sidekiq
 
       ack = true
       begin
-        if msgstr.present?
+        if msgstr != nil
           msg = Sidekiq.load_json(msgstr)
           klass  = msg['class'].constantize
           worker = klass.new


### PR DESCRIPTION
I experienced a problem with nil messages with Sidekiq that would stop all workers from running:

```
WARN: {:message=>nil}
TypeError: no implicit conversion of nil into String
```

It's possible that this was concurrent with running out of space in Redis.

All workers would crash in this state, no jobs would execute, and it was difficult to work out how to clear the badly formatted jobs.

Adding a simple `if` statement resolved the issue. I'm not sure you will want to merge this without a test, but I thought I should present a solution for anyone else experiencing similar.
