### PR TITLE
Allow user-specified maximum error message size

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+Master
+------
+
+- Add ability to truncate error messages with the `error_message_limit` option.
+
 3.2.1
 -----------
 
@@ -173,7 +178,7 @@ middleware, see 3.0-Upgrade.md.**
 
 - Automatically use the config file found at `config/sidekiq.yml`, if not passed `-C`. [#1481]
 - Store 'retried\_at' and 'failed\_at' timestamps as Floats, not Strings. [#1473]
-- A `USR2` signal will now reopen _all_ logs, using IO#reopen. Thus, instead of creating a new Logger object, 
+- A `USR2` signal will now reopen _all_ logs, using IO#reopen. Thus, instead of creating a new Logger object,
   Sidekiq will now just update the existing Logger's file descriptor [#1163].
 - Remove pidfile when shutting down if started with `-P` [#1470]
 

--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -49,6 +49,9 @@ module Sidekiq
       #       chain.add Middleware::Server::RetryJobs, :max_retries => 7
       #     end
       #   end
+      #
+      # The error message may be truncated to a maximum size by specifying an
+      # `error_message_limit` in a worker's `sidekiq_options` or globally.
       class RetryJobs
         include Sidekiq::Util
 
@@ -75,7 +78,7 @@ module Sidekiq
           else
             queue
           end
-          msg['error_message'] = e.message
+          msg['error_message'] = e.message[0..(msg['error_message_limit'].to_i - 1)]
           msg['error_class'] = e.class.name
           count = if msg['retry_count']
             msg['retried_at'] = Time.now.to_f

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -259,6 +259,24 @@ class TestRetry < Sidekiq::Test
       @redis.verify
     end
 
+    it 'truncates the error_message down to the user-specified limit' do
+      @redis.expect :zadd, 1, ['retry', String, String]
+      msg = { 'class' => 'Bob', 'args' => [1,2,'foo'], 'retry' => true, 'error_message_limit' => 10 }
+      handler = Sidekiq::Middleware::Server::RetryJobs.new
+      assert_raises RuntimeError do
+        handler.call(worker, msg, 'default') do
+          raise "kerblammo! (Truncate this part, please.)"
+        end
+      end
+      assert_equal 'default', msg["queue"]
+      assert_equal 'kerblammo!', msg["error_message"]
+      assert_equal 'RuntimeError', msg["error_class"]
+      assert_equal 0, msg["retry_count"]
+      refute msg["error_backtrace"]
+      assert msg["failed_at"]
+      @redis.verify
+    end
+
     describe "custom retry delay" do
       before do
         @old_logger    = Sidekiq.logger


### PR DESCRIPTION
Errors can have messages that are very large. When they are raised, redis space is rapidly depleted.

An example of this problem is an INSERT or UPDATE in ActiveRecord with a very large blob of data. When ActiveRecord fails, it puts the entire SQL statement into the error message.
