### PR TITLE
Don't nil Celluloid.logger

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -155,7 +155,7 @@ module Sidekiq
       # because it spins up threads and creates locks which get
       # into a very bad state if forked.
       require 'celluloid/autostart'
-      Celluloid.logger = (options[:verbose] ? Sidekiq.logger : nil)
+      Celluloid.logger = Sidekiq.logger if options[:verbose]
 
       require 'sidekiq/manager'
       require 'sidekiq/scheduled'


### PR DESCRIPTION
Celluloid.logger is defined once Celluloid is required. Sidekiq setting the Celluloid.logger to `nil` ensures that it doesn't play nice with other gems that require Celluloid.logger to be available. [Listen](https://github.com/guard/listen) is one such gem. A related issue, and the one that prompted this PR, is https://github.com/mperham/sidekiq/issues/1858. I'm using Rails 4.1 and Ruby 2.0.0-p353

Though the initial reporter just hacked away the log calls from the Listen gem and others thought this was Listen's problem I maintain this is something Sidekiq is doing badly. 

I'd be interested to know the thoughts behind setting it to `nil` if my fix here isn't acceptable, it came about with https://github.com/mperham/sidekiq/commit/e38a3d785a76a4e5b5ffbbec87e579e466185e4c though the comments don't explain that particular line.
