### PR TITLE
Calling `poll_interval=` doesn't account for scaling due to interval randomization

### DIFF
--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -51,7 +51,10 @@ module Sidekiq
             logger.error ex.backtrace.first
           end
 
-          after(poll_interval * rand) { poll }
+          # Randomizing scales the interval by half since
+          # on average calling `rand` returns 0.5.
+          # We make up for this by doubling the interval
+          after(poll_interval * 2 * rand) { poll }
         end
       end
 
@@ -73,7 +76,7 @@ module Sidekiq
       def poll_interval
         Sidekiq.options[:poll_interval] ||= begin
           pcount = Sidekiq.redis {|c| c.scard('processes') } || 1
-          pcount * 15 * 2
+          pcount * 15
         end
       end
 


### PR DESCRIPTION
While integrating Sidetiq and needing to adjust the scheduled job polling frequency, I discovered this issue.

Workaround is included here for more information and context: https://github.com/tobiassvn/sidetiq/wiki/Configuration#polling 

It seems to me that it's the `poll` methods responsibility to account for the randomization scaling, not the `poll_interval` method's. If you'd like it done a different way, or if I'm thinking incorrectly about this being an issue, just let me know.
