### PR TITLE
Fix NoMethodError: undefined method `backtrace' for nil:NilClass

### DIFF
--- a/lib/sidekiq/exception_handler.rb
+++ b/lib/sidekiq/exception_handler.rb
@@ -6,8 +6,11 @@ module Sidekiq
     class Logger
       def call(ex, ctxHash)
         Sidekiq.logger.warn(ctxHash) if !ctxHash.empty?
-        Sidekiq.logger.warn ex
-        Sidekiq.logger.warn ex.backtrace.join("\n") unless ex.backtrace.nil?
+
+        if ex
+          Sidekiq.logger.warn ex
+          Sidekiq.logger.warn ex.backtrace.join("\n") unless ex.backtrace.nil?
+        end
       end
 
       # Set up default handler which just logs the error
@@ -20,8 +23,11 @@ module Sidekiq
           handler.call(ex, ctxHash)
         rescue => ex
           Sidekiq.logger.error "!!! ERROR HANDLER THREW AN ERROR !!!"
-          Sidekiq.logger.error ex
-          Sidekiq.logger.error ex.backtrace.join("\n") unless ex.backtrace.nil?
+
+          if ex
+            Sidekiq.logger.error ex
+            Sidekiq.logger.error ex.backtrace.join("\n") unless ex.backtrace.nil?
+          end
         end
       end
     end


### PR DESCRIPTION
There are errors without exception object. The backtrace is

```
NoMethodError: undefined method `backtrace' for nil:NilClass
... 10 non-project frames
1
File "[/project/]/shared/bundle/ruby/2.1.0/gems/sidekiq-3.2.1/lib/sidekiq/exception_handler.rb" line 10 in call
2
File "[/project/]/shared/bundle/ruby/2.1.0/gems/sidekiq-3.2.1/lib/sidekiq/exception_handler.rb" line 20 in block in handle_exception
3
File "[/project/]/shared/bundle/ruby/2.1.0/gems/sidekiq-3.2.1/lib/sidekiq/exception_handler.rb" line 18 in each
4
File "[/project/]/shared/bundle/ruby/2.1.0/gems/sidekiq-3.2.1/lib/sidekiq/exception_handler.rb" line 18 in handle_exception
5
File "[/project/]shared/bundle/ruby/2.1.0/gems/sidekiq-3.2.1/lib/sidekiq/launcher.rb" line 31 in actor_died
6
File "[/project/]/shared/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/actor.rb" line 357 in handle_exit_event
7
File "[/project/]/shared/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/actor.rb" line 340 in block in handle_system_event
8
File "[/project/]/shared/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/actor.rb" line 416 in block in task
9
File "[/project/]/shared/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/tasks.rb" line 55 in block in initialize
10
File "[/project/]/shared/bundle/ruby/2.1.0/gems/celluloid-0.15.2/lib/celluloid/tasks/task_fiber.rb" line 13 in block in create
```
