### PR TITLE
Break long payloads in Sidekiq web

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -675,10 +675,12 @@ div.interval-slider input {
 .args {
   overflow-y: auto;
   max-height: 100px;
+  word-break: break-all;
 }
 .args-extended {
   overflow-y: scroll;
   max-height: 500px;
+  word-break: break-all;
 }
 
 


### PR DESCRIPTION
Big payloads without spaces create a very big horizontal scrollbar otherwise.
