### PR TITLE
Fixed two bugs related to plain-old Ruby execution

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -218,7 +218,7 @@ module Sidekiq
     def boot_system
       ENV['RACK_ENV'] = ENV['RAILS_ENV'] = environment
 
-      raise ArgumentError, "#{options[:require]} does not exist" unless File.exist?(options[:require])
+      raise ArgumentError, "#{options[:require]} does not exist" unless File.exist?("#{options[:require]}.rb")
 
       if File.directory?(options[:require])
         require 'rails'
@@ -237,6 +237,7 @@ module Sidekiq
         end
         options[:tag] ||= default_tag
       else
+        $LOAD_PATH.unshift(File.expand_path(Dir.getwd))
         require options[:require]
       end
     end
@@ -255,7 +256,7 @@ module Sidekiq
     def validate!
       options[:queues] << 'default' if options[:queues].empty?
 
-      if !File.exist?(options[:require]) ||
+      if !File.exist?("#{options[:require]}.rb") ||
          (File.directory?(options[:require]) && !File.exist?("#{options[:require]}/config/application.rb"))
         logger.info "=================================================================="
         logger.info "  Please point sidekiq to a Rails 3/4 application or a Ruby file  "

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -25,7 +25,7 @@ class TestCli < Sidekiq::Test
     end
 
     it 'does not require the specified Ruby code' do
-      @cli.parse(['sidekiq', '-r', './test/fake_env.rb'])
+      @cli.parse(['sidekiq', '-r', './test/fake_env'])
       refute($LOADED_FEATURES.any? { |x| x =~ /fake_env/ })
       assert @cli.valid?
     end


### PR DESCRIPTION
Fixed two bugs related to plain-old Ruby execution: 
1. $LOAD_PATH needs to include execution path of sidekiq to allow the specified ruby files to be required. 
2. Require expects the require argument to NOT have .rb appended. Assumption in code was that .rb was included.
