### PR TITLE
extracts worker.perform so call can be enhanced

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -49,7 +49,7 @@ module Sidekiq
 
         stats(worker, msg, queue) do
           Sidekiq.server_middleware.invoke(worker, msg, queue) do
-            worker.perform(*cloned(msg['args']))
+            execute_job(worker, cloned(msg['args']))
           end
         end
       rescue Sidekiq::Shutdown
@@ -69,6 +69,10 @@ module Sidekiq
 
     def inspect
       "<Processor##{object_id.to_s(16)}>"
+    end
+
+    def execute_job(worker, cloned_args)
+      worker.perform(*cloned_args)
     end
 
     private

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -153,7 +153,7 @@ module Sidekiq
         while job = jobs.shift do
           worker = new
           worker.jid = job['jid']
-          worker.perform(*job['args'])
+          execute_job(worker, job['args'])
         end
       end
 
@@ -163,7 +163,11 @@ module Sidekiq
         job = jobs.shift
         worker = new
         worker.jid = job['jid']
-        worker.perform(*job['args'])
+        execute_job(worker, job['args'])
+      end
+
+      def execute_job(worker, args)
+        worker.perform(*args)
       end
     end
 

--- a/test/test_processor.rb
+++ b/test/test_processor.rb
@@ -39,6 +39,12 @@ class TestProcessor < Sidekiq::Test
       assert_equal 1, $invokes
     end
 
+    it 'executes a worker as expected' do
+      worker = Minitest::Mock.new
+      worker.expect(:perform, nil, [1, 2, 3])
+      @processor.execute_job(worker, [1, 2, 3])
+    end
+
     it 'passes exceptions to ExceptionHandler' do
       actor = Minitest::Mock.new
       actor.expect(:real_thread, nil, [nil, Thread])

--- a/test/test_testing_fake.rb
+++ b/test/test_testing_fake.rb
@@ -261,5 +261,11 @@ class TestTesting < Sidekiq::Test
       assert_equal 1, FirstWorker.count
       assert_equal 1, SecondWorker.count
     end
+
+    it 'can execute a job' do
+      worker = Minitest::Mock.new
+      worker.expect(:perform, nil, [1, 2, 3])
+      DirectWorker.execute_job(worker, [1, 2, 3])
+    end
   end
 end


### PR DESCRIPTION
I would like to open the discussion on keyword arguments.

This pull request simply extracts the calls to worker.perform in such a way that it can be uniformly enhanced for both the processor, and the test harness. The reason for this is to allow keyword arguments to be used -- albeit with some effort, but without having to take over large methods.

I'm open to ideas, feedback, or criticism and I've only recently ventured down this path.
