### PR TITLE
Rely on perform_one for inline testing

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -66,12 +66,11 @@ module Sidekiq
         end
         true
       elsif Sidekiq::Testing.inline?
-        payloads.each do |item|
-          jid = item['jid'] || SecureRandom.hex(12)
-          marshalled = Sidekiq.load_json(Sidekiq.dump_json(item))
-          worker = marshalled['class'].constantize.new
-          worker.jid = jid
-          worker.perform(*marshalled['args'])
+        payloads.each do |job|
+          job['jid'] ||= SecureRandom.hex(12)
+          klass = job['class'].constantize
+          klass.jobs.unshift Sidekiq.load_json(Sidekiq.dump_json(job))
+          klass.perform_one
         end
         true
       else


### PR DESCRIPTION
Inline testing currently overrides `perform_async` to simply directly call

``` ruby
SomeJob.new.perform(*args)
```

after round-tripping `*args` through JSON serialization/deserialization and setting up a fake `worker.jid` value.

After #1938, most (all?) other places now use `execute_job` instead, which indirectly calls `SomeJob.new.perform(*args)`.

`testing.rb` defines a `perform_one` which is one of the places where the new `execute_job` method is used. It also takes care of setting `worker.jid`.

This change replaces the inline testing mode from a direct `SomeJob.new.perform` method call to instead:
1. Place a job on the faked array queue, at the front of the list.
2. Immediately call `perform_one`, to take the job off the front of the list.

This reduces the duplication around what it means to execute a job, makes the usage of `execute_job` consistent across applications, and improves `inline!` testing's mirroring of how the job would actually be run — by "placing" it on a queue and then "pulling" the job off the queue straight away.

As a bonus, any third-party gems which provide an implementation of `execute_job` (such as in #1938) can test that their `execute_job` is working by using `perform_async` with `inline!` testing, instead of manually calling `perform_one` in the `fake!` testing mode or disabling Sidekiq testing entirely.
