### PR TITLE
Require Sidekiq before using it

### DIFF
--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -1,3 +1,4 @@
+require 'sidekiq'
 require 'sidekiq/client'
 require 'sidekiq/core_ext'
 


### PR DESCRIPTION
Sidekiq::Worker depends on Sidekiq.default_worker_options, but does not require it. Requiring things before you use them is awesome.
