### PR TITLE
Implement prioritized queues.

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -101,7 +101,7 @@ module Sidekiq
   end
 
   def self.default_worker_options
-    defined?(@default_worker_options) ? @default_worker_options : { 'retry' => true, 'queue' => 'default' }
+    defined?(@default_worker_options) ? @default_worker_options : { 'retry' => true, 'queue' => 'default', 'priority' => 0 }
   end
 
   def self.load_json(string)

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -69,7 +69,7 @@ module Sidekiq
       @name = params[:name]
       @queue = Sidekiq::Queue.new(@name)
       (@current_page, @total_size, @messages) = page("queue:#{@name}", params[:page], @count)
-      @messages = @messages.map {|msg| Sidekiq::Job.new(msg, @name) }
+      @messages = @messages.map {|msg, priority| Sidekiq::Job.new(msg, @name) }
       erb :queue
     end
 

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -83,10 +83,10 @@ class TestApi < Sidekiq::Test
 
       it "returns a hash of queue and size in order" do
         Sidekiq.redis do |conn|
-          conn.rpush 'queue:foo', '{}'
+          conn.zadd 'queue:foo', 0, '{}'
           conn.sadd 'queues', 'foo'
 
-          3.times { conn.rpush 'queue:bar', '{}' }
+          3.times { |x| conn.zadd 'queue:bar', 0, "{\"id\": #{x}}" }
           conn.sadd 'queues', 'bar'
         end
 
@@ -104,10 +104,10 @@ class TestApi < Sidekiq::Test
 
       it "returns total enqueued jobs" do
         Sidekiq.redis do |conn|
-          conn.rpush 'queue:foo', '{}'
+          conn.zadd 'queue:foo', 0, '{}'
           conn.sadd 'queues', 'foo'
 
-          3.times { conn.rpush 'queue:bar', '{}' }
+          3.times { |x| conn.zadd 'queue:bar', 0, "{\"id\": #{x}}" }
           conn.sadd 'queues', 'bar'
         end
 

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -23,18 +23,18 @@ class TestExtensions < Sidekiq::Test
 
     it 'allows delayed execution of ActiveRecord class methods' do
       assert_equal [], Sidekiq::Queue.all.map(&:name)
-      assert_equal 0, Sidekiq.redis {|c| c.llen('queue:default') }
+      assert_equal 0, Sidekiq.redis {|c| c.zcard('queue:default') }
       MyModel.delay.long_class_method
       assert_equal ['default'], Sidekiq::Queue.all.map(&:name)
-      assert_equal 1, Sidekiq.redis {|c| c.llen('queue:default') }
+      assert_equal 1, Sidekiq.redis {|c| c.zcard('queue:default') }
     end
 
     it 'uses and stringifies specified options' do
       assert_equal [], Sidekiq::Queue.all.map(&:name)
-      assert_equal 0, Sidekiq.redis {|c| c.llen('queue:notdefault') }
+      assert_equal 0, Sidekiq.redis {|c| c.zcard('queue:notdefault') }
       MyModel.delay(queue: :notdefault).long_class_method
       assert_equal ['notdefault'], Sidekiq::Queue.all.map(&:name)
-      assert_equal 1, Sidekiq.redis {|c| c.llen('queue:notdefault') }
+      assert_equal 1, Sidekiq.redis {|c| c.zcard('queue:notdefault') }
     end
 
     it 'allows delayed scheduling of AR class methods' do
@@ -57,10 +57,10 @@ class TestExtensions < Sidekiq::Test
 
     it 'allows delayed delivery of ActionMailer mails' do
       assert_equal [], Sidekiq::Queue.all.map(&:name)
-      assert_equal 0, Sidekiq.redis {|c| c.llen('queue:default') }
+      assert_equal 0, Sidekiq.redis {|c| c.zcard('queue:default') }
       UserMailer.delay.greetings(1, 2)
       assert_equal ['default'], Sidekiq::Queue.all.map(&:name)
-      assert_equal 1, Sidekiq.redis {|c| c.llen('queue:default') }
+      assert_equal 1, Sidekiq.redis {|c| c.zcard('queue:default') }
     end
 
     it 'allows delayed scheduling of AM mails' do

--- a/test/test_scheduled.rb
+++ b/test/test_scheduled.rb
@@ -44,10 +44,10 @@ class TestScheduled < Sidekiq::Test
         @poller.poll
 
         Sidekiq.redis do |conn|
-          assert_equal 0, conn.llen("queue:queue_1")
-          assert_equal 1, conn.llen("queue:queue_2")
-          assert_equal 0, conn.llen("queue:queue_5")
-          assert_equal 1, conn.llen("queue:queue_6")
+          assert_equal 0, conn.zcard("queue:queue_1")
+          assert_equal 1, conn.zcard("queue:queue_2")
+          assert_equal 0, conn.zcard("queue:queue_5")
+          assert_equal 1, conn.zcard("queue:queue_6")
         end
       ensure
         Sidekiq.client_middleware.remove Stopper
@@ -68,14 +68,14 @@ class TestScheduled < Sidekiq::Test
         @poller.poll
 
         Sidekiq.redis do |conn|
-          assert_equal 1, conn.llen("queue:queue_1")
-          assert_equal enqueued_time.to_f, Sidekiq.load_json(conn.lrange("queue:queue_1", 0, -1)[0])['enqueued_at']
-          assert_equal 1, conn.llen("queue:queue_2")
-          assert_equal enqueued_time.to_f, Sidekiq.load_json(conn.lrange("queue:queue_2", 0, -1)[0])['enqueued_at']
-          assert_equal 1, conn.llen("queue:queue_4")
-          assert_equal enqueued_time.to_f, Sidekiq.load_json(conn.lrange("queue:queue_4", 0, -1)[0])['enqueued_at']
-          assert_equal 1, conn.llen("queue:queue_5")
-          assert_equal enqueued_time.to_f, Sidekiq.load_json(conn.lrange("queue:queue_5", 0, -1)[0])['enqueued_at']
+          assert_equal 1, conn.zcard("queue:queue_1")
+          assert_equal enqueued_time.to_f, Sidekiq.load_json(conn.zrange("queue:queue_1", 0, -1)[0])['enqueued_at']
+          assert_equal 1, conn.zcard("queue:queue_2")
+          assert_equal enqueued_time.to_f, Sidekiq.load_json(conn.zrange("queue:queue_2", 0, -1)[0])['enqueued_at']
+          assert_equal 1, conn.zcard("queue:queue_4")
+          assert_equal enqueued_time.to_f, Sidekiq.load_json(conn.zrange("queue:queue_4", 0, -1)[0])['enqueued_at']
+          assert_equal 1, conn.zcard("queue:queue_5")
+          assert_equal enqueued_time.to_f, Sidekiq.load_json(conn.zrange("queue:queue_5", 0, -1)[0])['enqueued_at']
         end
 
         assert_equal 1, @retry.size

--- a/test/test_scheduling.rb
+++ b/test/test_scheduling.rb
@@ -37,8 +37,8 @@ class TestScheduling < Sidekiq::Test
     end
 
     it 'schedules job right away on negative timestamp/interval' do
-      @redis.expect :sadd,  true, ['queues', 'custom_queue']
-      @redis.expect :lpush, true, ['queue:custom_queue', Array]
+      @redis.expect :sadd, true, ['queues', 'custom_queue']
+      @redis.expect :zadd, true, ['queue:custom_queue', 0, String]
       assert ScheduledWorker.perform_in(-300, 'mike')
       @redis.verify
     end

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -80,7 +80,7 @@ class TestWeb < Sidekiq::Test
 
     it 'can delete a queue' do
       Sidekiq.redis do |conn|
-        conn.rpush('queue:foo', '{}')
+        conn.zadd('queue:foo', 0, '{}')
         conn.sadd('queues', 'foo')
       end
 
@@ -98,9 +98,9 @@ class TestWeb < Sidekiq::Test
 
     it 'can delete a job' do
       Sidekiq.redis do |conn|
-        conn.rpush('queue:foo', "{}")
-        conn.rpush('queue:foo', "{\"foo\":\"bar\"}")
-        conn.rpush('queue:foo', "{\"foo2\":\"bar2\"}")
+        conn.zadd('queue:foo', 0, "{}")
+        conn.zadd('queue:foo', 0, "{\"foo\":\"bar\"}")
+        conn.zadd('queue:foo', 0, "{\"foo2\":\"bar2\"}")
       end
 
       get '/queues/foo'
@@ -110,7 +110,7 @@ class TestWeb < Sidekiq::Test
       assert_equal 302, last_response.status
 
       Sidekiq.redis do |conn|
-        refute conn.lrange('queue:foo', 0, -1).include?("{\"foo\":\"bar\"}")
+        refute conn.zrange('queue:foo', 0, -1).include?("{\"foo\":\"bar\"}")
       end
     end
 


### PR DESCRIPTION
This pull-request implements numeric priorities inside queues.

Priority is either defined by an `Integer` or a `Proc` that takes the `#perform` method arguments as its own arguments, and it's defined on the `sidekiq_options` call. An example would be:

``` ruby
class HeavyWorker
  include Sidekiq::Worker
  sidekiq_options priority: -> (account_id) {
    Account.find(account_id).vip? ? 0 : 10
  }

  def perform(account_id)
    # Do some work.
  end
end
```

Lower priority value items are picked up first. Same priority value items work on a FIFO basis.

I've made sure the fetches are atomic, the tests pass, but the only couple things I'm not sure are:
- Latency (because the last item in the list might not be the last one inserted.)
- Migration path (current queues will have the wrong data type in Redis)

@mperham could do with some feedback regarding these points (and the whole PR in general.)
