### PR TITLE
Add non-production environment names to web UI title

### DIFF
--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -172,5 +172,11 @@ module Sidekiq
         redirect url
       end
     end
+
+    def environment_title_prefix
+      environment = Sidekiq.options[:environment] || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+
+      "[#{environment.upcase}] " unless environment == "production"
+    end
   end
 end

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title><%= Sidekiq::NAME %></title>
+    <title><%= environment_title_prefix %><%= Sidekiq::NAME %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link href="<%= root_path %>stylesheets/bootstrap.css" media="screen" rel="stylesheet" type="text/css" />
     <link href="<%= root_path %>stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Something like this would be pretty helpful for us since we often have Sidekiq web UI tabs open for local, staging, production, etc. all at once.

(Also, I wasn't sure if non-Rails Ruby apps are supported, but obviously more frameworks could be supported pretty easily.)
