### PR TITLE
Update generator generated test file naming

### DIFF
--- a/lib/generators/sidekiq/worker_generator.rb
+++ b/lib/generators/sidekiq/worker_generator.rb
@@ -29,7 +29,7 @@ module Sidekiq
         template_file = File.join(
             'spec/workers',
             class_path,
-            "#{file_name}_spec.rb"
+            "#{file_name}_worker_spec.rb"
         )
         template 'worker_spec.rb.erb', template_file
       end
@@ -38,7 +38,7 @@ module Sidekiq
         template_file = File.join(
             'test/workers',
             class_path,
-            "#{file_name}_test.rb"
+            "#{file_name}_worker_test.rb"
         )
         template 'worker_test.rb.erb', template_file
       end


### PR DESCRIPTION
Current if you use `rails g sidekiq:worker foo`, it will generate:
- `app/workers/foo_worker.rb`
- `spec/workers/foo_spec.rb`

I believe it should be `spec/workers/foo_worker_spec.rb` instead, right?
