### PR TITLE
add optional support for user installed rbenv

### DIFF
--- a/examples/upstart/manage-one/sidekiq.conf
+++ b/examples/upstart/manage-one/sidekiq.conf
@@ -42,6 +42,11 @@ exec /bin/bash <<'EOT'
 
   # pull in system rbenv
   source /etc/profile.d/rbenv.sh
+  # or 
+  # pull in user installed rbenv
+  # export PATH="$HOME/.rbenv/bin:$PATH"
+  # eval "$(rbenv init -)"
+  # export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"
 
   cd /opt/theclymb/current
   exec bin/sidekiq -i ${index} -e production


### PR DESCRIPTION
this is a followup to the ubuntu 14.04 upstart issue documented here: http://stackoverflow.com/questions/26439555/did-upstart-or-bash-scripts-change-on-ubuntu-14-04-trying-to-boot-sidekiq-with/26439998?noredirect=1#comment41552314_26439998

This adds support for people who installed rbenv in the deploy user directory 
