### PR TITLE
'Booting Sidekiq' should be logged as debug

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -65,7 +65,7 @@ module Sidekiq
           scrubbed_options[:password] = redacted
         end
         if Sidekiq.server?
-          Sidekiq.logger.info("Booting Sidekiq #{Sidekiq::VERSION} with redis options #{scrubbed_options}")
+          Sidekiq.logger.debug("Booting Sidekiq #{Sidekiq::VERSION} with redis options #{scrubbed_options}")
         else
           Sidekiq.logger.debug("#{Sidekiq::NAME} client with redis options #{scrubbed_options}")
         end


### PR DESCRIPTION
IMHO "Booting Sidekiq" should be logged in 'debug' (not 'info').

What do you think?
