### PR TITLE
Use a named pipe for logging in upstart example

### DIFF
--- a/examples/upstart/manage-many/sidekiq.conf
+++ b/examples/upstart/manage-many/sidekiq.conf
@@ -21,8 +21,9 @@ description "Sidekiq Background Worker"
 stop on (stopping sidekiq-manager or runlevel [06])
 
 # change apps to match your deployment user if you want to use this as a less privileged user (recommended!)
-# setuid apps
-# setgid apps
+# setuid deploy
+# setgid deploy
+# env HOME=/home/apps
 
 respawn
 respawn limit 3 30
@@ -35,12 +36,7 @@ instance ${app}-${index}
 script
 # this script runs in /bin/sh by default
 # respawn as bash so we can source in rbenv
-exec /bin/bash <<EOT
-  # uncomment to use syslog for logging
-  # exec &> /dev/kmsg
-
-  export HOME=/home/apps
-
+exec /bin/bash <<'EOT'
   # Pick your poison :) Or none if you're using a system wide installed Ruby.
   # rbenv
   # source /home/apps/.bash_profile
@@ -54,6 +50,8 @@ exec /bin/bash <<EOT
 
   logger -t sidekiq "Starting process: $app-$index"
 
+  # Logs out to /var/log/upstart/sidekiq.log by default
+
   cd $app
   exec bundle exec sidekiq -i ${index} -e production -P tmp/pids/${app}-${index}.pid
 EOT
@@ -63,15 +61,6 @@ pre-stop script
 # this script runs in /bin/sh by default
 # respawn as bash so we can source in rbenv
 exec /bin/bash <<'EOT'
-  # Use a named pipe directed at logger for system logging.
-  fifopath = '/tmp/sidekiq-log-fifo'
-  mkfifo $fifopath
-  (logger -t sidekiq < $fifopath &)
-  exec > $fifopath
-  rm $fifopath
-
-  export HOME=/home/apps
-
   # Pick your poison :) Or none if you're using a system wide installed Ruby.
   # rbenv
   # source /home/apps/.bash_profile
@@ -84,6 +73,8 @@ exec /bin/bash <<'EOT'
   # source /home/apps/.rvm/scripts/rvm
 
   logger -t sidekiq "Stopping process: $app-$index"
+
+  # Logs out to /var/log/upstart/sidekiq.log by default
 
   cd $app
   exec bundle exec sidekiqctl stop tmp/pids/${app}-${index}.pid 2> /dev/null

--- a/examples/upstart/manage-one/sidekiq.conf
+++ b/examples/upstart/manage-one/sidekiq.conf
@@ -21,9 +21,9 @@ description "Sidekiq Background Worker"
 stop on (stopping workers or runlevel [06])
 
 # change to match your deployment user
-setuid deploy
-setgid deploy
-env HOME=/home/deploy
+# setuid deploy
+# setgid deploy
+# env HOME=/home/deploy
 
 respawn
 respawn limit 3 30
@@ -38,22 +38,20 @@ script
 # this script runs in /bin/sh by default
 # respawn as bash so we can source in rbenv
 exec /bin/bash <<'EOT'
-  # Use a named pipe directed at logger for system logging.
-  fifopath = '/tmp/sidekiq-log-fifo'
-  mkfifo $fifopath
-  (logger -t sidekiq < $fifopath &)
-  exec > $fifopath
-  rm $fifopath
+  # Pick your poison :) Or none if you're using a system wide installed Ruby.
+  # rbenv
+  # source /home/apps/.bash_profile
+  # OR
+  # source /home/apps/.profile
+  # OR system:
+  # source /etc/profile.d/rbenv.sh
+  #
+  # rvm
+  # source /home/apps/.rvm/scripts/rvm
 
-  # pull in system rbenv
-  source /etc/profile.d/rbenv.sh
-  # or
-  # pull in user installed rbenv
-  # export PATH="$HOME/.rbenv/bin:$PATH"
-  # eval "$(rbenv init -)"
-  # export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"
+  # Logs out to /var/log/upstart/sidekiq.log by default
 
-  cd /opt/theclymb/current
-  exec bin/sidekiq -i ${index} -e production 2> /dev/null
+  cd /var/www/app
+  exec bin/sidekiq -i ${index} -e production
 EOT
 end script


### PR DESCRIPTION
The ability to log directly to `/dev/kmsg` was removed in Ubuntu 14.04, making the existing example config fail to perform any real logging. Appending a pipe to the last `exec` within the `script` block gives upstart an incorrect PID to work with, which can lead to various issues.

This uses a FIFO solution that logs to syslog at any permission level and doesn't leave anything on the file system afterwards.
