### PR TITLE
Test Celluloid's TaskThread runner for stability

### DIFF
--- a/lib/sidekiq/actor.rb
+++ b/lib/sidekiq/actor.rb
@@ -7,6 +7,8 @@ module Sidekiq
       def new_link(*args)
         new(*args)
       end
+      def task_class(*args)
+      end
     end
 
     module InstanceMethods
@@ -33,6 +35,7 @@ module Sidekiq
         klass.__send__(:extend, ClassMethods)
       else
         klass.__send__(:include, Celluloid)
+        klass.task_class ::Celluloid::TaskThread
       end
     end
   end


### PR DESCRIPTION
Sidekiq uses Celluloid's TaskFiber by default.  MRI was recently discovered to have a Fiber bug which could lead to uncommitted transactions, open locks and other really odd behavior.  I'm unclear how to reproduce the problem but we should check TaskThread again to see if it's a stable replacement.

https://bugs.ruby-lang.org/issues/10540

/cc @halorgium