### PR TITLE
changed location of pid file in upstart example

### DIFF
--- a/examples/upstart/manage-many/sidekiq.conf
+++ b/examples/upstart/manage-many/sidekiq.conf
@@ -53,7 +53,7 @@ exec /bin/bash <<'EOT'
   # Logs out to /var/log/upstart/sidekiq.log by default
 
   cd $app
-  exec bundle exec sidekiq -i ${index} -e production -P tmp/pids/${app}-${index}.pid
+  exec bundle exec sidekiq -i ${index} -e production -P ${app}/tmp/pids/sidekiq-${index}.pid
 EOT
 end script
 
@@ -77,6 +77,6 @@ exec /bin/bash <<'EOT'
   # Logs out to /var/log/upstart/sidekiq.log by default
 
   cd $app
-  exec bundle exec sidekiqctl stop tmp/pids/${app}-${index}.pid 2> /dev/null
+  exec bundle exec sidekiqctl stop ${app}/tmp/pids/sidekiq-${index}.pid 2> /dev/null
 EOT
 end script


### PR DESCRIPTION
Changed it to be in <app-name>/tmp/pids/sidekiq-n.pid. Otherwise, it was attempting to save it to tmp/pids/<app-name>, which resulted in something like app/pids//var/www/app-name-n.pid.
