### PR TITLE
Cleans up execute_job

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -49,7 +49,7 @@ module Sidekiq
 
         stats(worker, msg, queue) do
           Sidekiq.server_middleware.invoke(worker, msg, queue) do
-            execute_job(worker, cloned(msg['args']))
+            worker.perform(*cloned(msg['args']))
           end
         end
       rescue Sidekiq::Shutdown
@@ -69,10 +69,6 @@ module Sidekiq
 
     def inspect
       "<Processor##{object_id.to_s(16)}>"
-    end
-
-    def execute_job(worker, cloned_args)
-      worker.perform(*cloned_args)
     end
 
     private

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -149,11 +149,7 @@ module Sidekiq
 
       # Drain and run all jobs for this worker
       def drain
-        while job = jobs.shift do
-          worker = new
-          worker.jid = job['jid']
-          execute_job(worker, job['args'])
-        end
+        perform_one while !jobs.empty?
       end
 
       # Pop out a single job and perform it
@@ -162,11 +158,7 @@ module Sidekiq
         job = jobs.shift
         worker = new
         worker.jid = job['jid']
-        execute_job(worker, job['args'])
-      end
-
-      def execute_job(worker, args)
-        worker.perform(*args)
+        worker.perform(*job['args'])
       end
     end
 

--- a/test/test_processor.rb
+++ b/test/test_processor.rb
@@ -39,12 +39,6 @@ class TestProcessor < Sidekiq::Test
       assert_equal 1, $invokes
     end
 
-    it 'executes a worker as expected' do
-      worker = Minitest::Mock.new
-      worker.expect(:perform, nil, [1, 2, 3])
-      @processor.execute_job(worker, [1, 2, 3])
-    end
-
     it 'passes exceptions to ExceptionHandler' do
       actor = Minitest::Mock.new
       actor.expect(:real_thread, nil, [nil, Thread])

--- a/test/test_testing_fake.rb
+++ b/test/test_testing_fake.rb
@@ -261,11 +261,5 @@ class TestTesting < Sidekiq::Test
       assert_equal 1, FirstWorker.count
       assert_equal 1, SecondWorker.count
     end
-
-    it 'can execute a job' do
-      worker = Minitest::Mock.new
-      worker.expect(:perform, nil, [1, 2, 3])
-      DirectWorker.execute_job(worker, [1, 2, 3])
-    end
   end
 end


### PR DESCRIPTION
A while back I submitted [a PR](https://github.com/mperham/sidekiq/pull/1938) that exposed a way to customize how a job was executed, in so much as how perform was actually called on the worker. I duplicated that in the sidekiq/testing, and have since determined that was a mistake and am rectifying that here.

In doing what I talk about in that original PR, I realized there was still some finagling to get it to behave correctly for the specs, and then I realized that it wasn't very unified and didn't push through to the actual functionality that I wanted to make sure was working -- after some back and forth (captured on https://github.com/mperham/sidekiq/pull/2097) @mperham decided he'd rather remove it.

Also cleans up the drain method in the test harness.