### PR TITLE
Some more frozen strings.

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -27,7 +27,7 @@ module Sidekiq
 
     def queues
       Sidekiq.redis do |conn|
-        queues = conn.smembers('queues')
+        queues = conn.smembers('queues'.freeze)
 
         lengths = conn.pipelined do
           queues.each do |queue|
@@ -118,7 +118,7 @@ module Sidekiq
     include Enumerable
 
     def self.all
-      Sidekiq.redis {|c| c.smembers('queues') }.sort.map {|q| Sidekiq::Queue.new(q) }
+      Sidekiq.redis {|c| c.smembers('queues'.freeze) }.sort.map {|q| Sidekiq::Queue.new(q) }
     end
 
     attr_reader :name
@@ -174,7 +174,7 @@ module Sidekiq
       Sidekiq.redis do |conn|
         conn.multi do
           conn.del(@rname)
-          conn.srem("queues", name)
+          conn.srem("queues".freeze, name)
         end
       end
     end

--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -160,7 +160,7 @@ module Sidekiq
         ts = (int < 1_000_000_000 ? now + int : int)
 
         item = { 'class' => klass, 'args' => args, 'at' => ts, 'queue' => queue }
-        item.delete('at') if ts <= now
+        item.delete('at'.freeze) if ts <= now
 
         klass.client_push(item)
       end
@@ -186,14 +186,14 @@ module Sidekiq
 
     def atomic_push(conn, payloads)
       if payloads.first['at']
-        conn.zadd('schedule', payloads.map do |hash|
-          at = hash.delete('at').to_s
+        conn.zadd('schedule'.freeze, payloads.map do |hash|
+          at = hash.delete('at'.freeze).to_s
           [at, Sidekiq.dump_json(hash)]
         end)
       else
         q = payloads.first['queue']
         to_push = payloads.map { |entry| Sidekiq.dump_json(entry) }
-        conn.sadd('queues', q)
+        conn.sadd('queues'.freeze, q)
         conn.lpush("queue:#{q}", to_push)
       end
     end

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -48,7 +48,7 @@ module Sidekiq
         item = { 'class' => self, 'args' => args, 'at' => ts }
 
         # Optimization to enqueue something now that is scheduled to go out now or in the past
-        item.delete('at') if ts <= now
+        item.delete('at'.freeze) if ts <= now
 
         client_push(item)
       end


### PR DESCRIPTION
Note that both in this and the sidekiq-pro pull I didn't `.freeze` any hash accessors, because according to https://groups.google.com/forum/#!topic/rack-devel/SKAE_yqN8-0, it should be that in Ruby 2.2 that'll happen automatically, so I'd rather not litter the code any more than it needs to be.