### PR TITLE
Update exception_handler.rb

### DIFF
--- a/lib/sidekiq/exception_handler.rb
+++ b/lib/sidekiq/exception_handler.rb
@@ -7,7 +7,7 @@ module Sidekiq
       def call(ex, ctxHash)
         Sidekiq.logger.warn(ctxHash) if !ctxHash.empty?
         Sidekiq.logger.warn ex
-        Sidekiq.logger.warn ex.backtrace.join("\n") unless ex.backtrace.nil?
+        Sidekiq.logger.warn ex.backtrace.join("\n") unless ex.nil? || ex.backtrace.nil?
       end
 
       # Set up default handler which just logs the error


### PR DESCRIPTION
a fix for NoMethodEror (undefined method `backtrace' for nil:NilClass) when ex. is nil