### PR TITLE
Add processes count to /stats

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ HEAD
 - Log Sidekiq Pro's Batch ID if available [#2076]
 - Refactor Processor Redis usage to avoid redis/redis-rb#490 [#]
 - Move /dashboard/stats to /stats.  Add /stats/queues. [moserke, #2099]
+- Add processes count to /stats [ismaelga, #2141]
 - Add better usage text for `sidekiqctl`.
 - `Sidekiq::Logging.with_context` is now a stack so you can set your
   own job context for logging purposes [grosser, #2110]

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -586,7 +586,7 @@ module Sidekiq
           end
         end
 
-        result.each_with_index do |(info, busy, at_s), i|
+        result.each do |info, busy, at_s|
           hash = Sidekiq.load_json(info)
           yield Process.new(hash.merge('busy' => busy.to_i, 'beat' => at_s.to_f))
         end

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -50,7 +50,7 @@ module Sidekiq
         p.quiet! if params[:quiet]
         p.stop! if params[:stop]
       else
-        Sidekiq::ProcessSet.new.each do |pro|
+        processes.each do |pro|
           pro.quiet! if params[:quiet]
           pro.stop! if params[:stop]
         end
@@ -219,6 +219,7 @@ module Sidekiq
           processed:  sidekiq_stats.processed,
           failed:     sidekiq_stats.failed,
           busy:       workers_size,
+          processes:  processes_size,
           enqueued:   sidekiq_stats.enqueued,
           scheduled:  sidekiq_stats.scheduled_size,
           retries:    sidekiq_stats.retry_size,

--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -46,6 +46,14 @@ module Sidekiq
       @workers ||= Sidekiq::Workers.new
     end
 
+    def processes_size
+      @processes_size ||= processes.size
+    end
+
+    def processes
+      @processes ||= Sidekiq::ProcessSet.new
+    end
+
     def stats
       @stats ||= Sidekiq::Stats.new
     end

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -404,6 +404,10 @@ class TestWeb < Sidekiq::Test
           assert_equal 4, @response["sidekiq"]["busy"]
         end
 
+        it 'reports processes' do
+          assert_equal 1, @response["sidekiq"]["processes"]
+        end
+
         it 'reports retries' do
           assert_equal 2, @response["sidekiq"]["retries"]
         end
@@ -568,7 +572,7 @@ class TestWeb < Sidekiq::Test
       Sidekiq.redis do |conn|
         conn.multi do
           conn.sadd("processes", key)
-          conn.hmset(key, 'busy', 4)
+          conn.hmset(key, 'info', Sidekiq.dump_json('hostname' => 'foo', 'started_at' => Time.now.to_f, "queues" => []), 'at', Time.now.to_f, 'busy', 4)
           conn.hmset("#{key}:workers", Time.now.to_f, msg)
         end
       end

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -21,7 +21,7 @@
     <th><%= t('Busy') %></th>
     <th>&nbsp;</th>
   </thead>
-  <% Sidekiq::ProcessSet.new.each do |process| %>
+  <% processes.each do |process| %>
     <tr>
       <td width="50%">
         <%= "#{process['hostname']}:#{process['pid']}" %>

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -65,7 +65,7 @@
     <th><%= t('Arguments') %></th>
     <th><%= t('Started') %></th>
   </thead>
-  <% workers.each_with_index do |(process, thread, msg), index| %>
+  <% workers.each do |process, thread, msg| %>
     <% job = Sidekiq::Job.new(msg['payload']) %>
     <tr>
       <td><%= process %></td>


### PR DESCRIPTION
Also removed unused `each_with_index`. Tell me if there is any reason to keep them or if I should remove it from the PR.

:yellow_heart: 