### PR TITLE
Improve web page's load speed

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -1,6 +1,3 @@
-@import url(//fonts.googleapis.com/css?family=Gudea:400,700);
-@import url(//fonts.googleapis.com/css?family=Armata);
-
 * {
   box-sizing: border-box;
 }

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -8,6 +8,14 @@
     <script type="text/javascript" src="<%= root_path %>javascripts/application.js"></script>
     <script type="text/javascript" src="<%= root_path %>javascripts/locales/jquery.timeago.<%= locale %>.js"></script>
     <meta name="google" content="notranslate" />
+    <script>
+$(function(){
+ setTimeout(function(){
+  $('HEAD').append($('<link href="//fonts.googleapis.com/css?family=Gudea:400,700" media="screen" rel="stylesheet" type="text/css" />'));
+  $('HEAD').append($('<link href="//fonts.googleapis.com/css?family=Armata" media="screen" rel="stylesheet" type="text/css" />'));
+ }, 100);
+});
+</script>
   </head>
   <body class="admin">
     <%= erb :_nav %>


### PR DESCRIPTION
Most of Google's services are blocked in China, including **fonts.googleapis.com**. The requests to it woud be timeout in China:
![1](https://cloud.githubusercontent.com/assets/2853675/5792805/8962317a-9f65-11e4-94e5-91c87d1f2cfa.png)
During loading fonts, the page is blank. After timeout(10-20 seconds), the page can be rendered.

So I make fonts lazy loading, try to improve page's load speed, especially in China.