### PR TITLE
Retry job without raising exception

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -18,6 +18,7 @@ module Sidekiq
   # otherwise Ruby's Thread#kill will commit.  See #377.
   # DO NOT RESCUE THIS ERROR.
   class Shutdown < Interrupt; end
+  class Retry < Exception; end
 
   class CLI
     include Util


### PR DESCRIPTION
I've built a callback system based on Sidekiq. It is really simply. You register an URL and when something happens my server will make post to it. My clients love it. Joey, one of my best client, has the worst sysadmin I know. It is not so rare to get his site offline. I told him: don't worry, Sidekiq will try to post to your server sometime after first fail. Everything is working well, except, when Joey's site is offline, I got thousands exceptions. My boss gets crazy and start to call me. I would like to use Sidekiq retry system but I don't want to see those exceptions at my log, actually, I just want to say to Sidekiq: there is nothing I can do for it right know but, please, process this code as it has failed.

This _pr_ works fine, but it is still just a _POC_. I would like to know what do you think about it.

ps: as you see, english is not my first language ;)