### PR TITLE
Clean up logic and docs for Client#push(_bulk)

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -55,7 +55,7 @@ module Sidekiq
     # All options must be strings, not symbols.  NB: because we are serializing to JSON, all
     # symbols in 'args' will be converted to strings.
     #
-    # Returns a unique Job ID.
+    # Returns a unique Job ID.  If middleware stops the job, nil will be returned instead.
     #
     # Example:
     #   push('queue' => 'my_queue', 'class' => MyWorker, 'args' => ['foo', 1, :bat => 'bar'])
@@ -64,8 +64,10 @@ module Sidekiq
       normed = normalize_item(item)
       payload = process_single(item['class'], normed)
 
-      raw_push([payload]) if payload
-      payload['jid']
+      if payload
+        raw_push([payload])
+        payload['jid']
+      end
     end
 
     ##


### PR DESCRIPTION
`Client#raw_push` always returns true now.  Therefore, there is no need to
check for a false return value and `Client#push` can only return nil if middleware stops the job.

The possible outcomes of a call to `push` are:
- a `jid` returned
- `nil` due to middleware
-  an exception raised

This change is motivated by changing the classification of a `nil` return from an error condition to a no-op that can be ignored unless the client code needs to know that the middleware interrupted.