### PR TITLE
Sort keys in locales in alphabetical order

### DIFF
--- a/web/locales/cs.yml
+++ b/web/locales/cs.yml
@@ -1,68 +1,68 @@
 # elements like %{queue} are variables and should not be translated
 cs:
-  Dashboard: Kontrolní panel
-  Status: Stav
-  Time: Čas
-  Namespace: Jmenný prostor
-  Realtime: V reálném čase
-  History: Historie
-  Busy: Zaneprázdněné
-  Processed: Zpracované
-  Failed: Nezdařené
-  Scheduled: Naplánované
-  Retries: Opakování
-  Enqueued: Zařazené
-  Worker: Worker
-  LivePoll: Průběžně aktualizovat
-  StopPolling: Zastavit průběžnou aktualizaci
-  Queue: Fronta
-  Class: Třída
-  Job: Úkol
-  Arguments: Argumenty
-  Extras: Doplňky
-  Started: Začal
-  ShowAll: Ukázat všechny
-  CurrentMessagesInQueue: Aktuální úkoly ve frontě <span class='title'>%{queue}</span>
-  Delete: Odstranit
+  Actions: Akce
+  active: aktivní
   AddToQueue: Přidat do fronty
+  AreYouSure: Jste si jisti?
   AreYouSureDeleteJob: Jste si jisti, že chcete odstranit tento úkol?
   AreYouSureDeleteQueue: Jste si jisti, že chcete odstranit frontu %{queue}?
-  Queues: Fronty
-  Size: Velikost
-  Actions: Akce
-  NextRetry: Další opakování
-  RetryCount: Počet opakování
-  RetryNow: Opakovat teď
-  LastRetry: Poslední opakování
-  OriginallyFailed: Původně se nezdařilo
-  AreYouSure: Jste si jisti?
+  Arguments: Argumenty
+  Busy: Zaneprázdněné
+  Class: Třída
+  Connections: Připojení
+  CurrentMessagesInQueue: Aktuální úkoly ve frontě <span class='title'>%{queue}</span>
+  Dashboard: Kontrolní panel
+  Dead: Mrtvý
+  DeadJobs: Mrtvé úkoly
+  Delete: Odstranit
   DeleteAll: Odstranit vše
-  RetryAll: Opakovat vše
-  NoRetriesFound: Nebyla nalezena žádná opakování
+  Enqueued: Zařazené
   Error: Chyba
+  ErrorBacktrace: Chybový výstup
   ErrorClass: Třída chyby
   ErrorMessage: Chybová zpráva
-  ErrorBacktrace: Chybový výstup
-  GoBack: ← Zpět
-  NoScheduledFound: Nebyly nalezeny žádné naplánované úkoly
-  When: Kdy
-  ScheduledJobs: Naplánované úkoly
-  idle: nečinný
-  active: aktivní
-  Version: Verze
-  Connections: Připojení
-  MemoryUsage: Využití paměti
-  PeakMemoryUsage: Nejvyšší využití paměti
-  Uptime: Uptime (dny)
-  OneWeek: 1 týden
-  OneMonth: 1 měsíc
-  ThreeMonths: 3 měsíce
-  SixMonths: 6 měsíců
+  Extras: Doplňky
+  Failed: Nezdařené
   Failures: Selhání
-  DeadJobs: Mrtvé úkoly
+  GoBack: ← Zpět
+  History: Historie
+  idle: nečinný
+  Job: Úkol
+  Jobs: Úkoly
+  LastRetry: Poslední opakování
+  LivePoll: Průběžně aktualizovat
+  MemoryUsage: Využití paměti
+  Namespace: Jmenný prostor
+  NextRetry: Další opakování
   NoDeadJobsFound: Nebyly nalezeny žádné mrtvé úkoly
-  Dead: Mrtvý
+  NoRetriesFound: Nebyla nalezena žádná opakování
+  NoScheduledFound: Nebyly nalezeny žádné naplánované úkoly
+  OneMonth: 1 měsíc
+  OneWeek: 1 týden
+  OriginallyFailed: Původně se nezdařilo
+  PeakMemoryUsage: Nejvyšší využití paměti
+  Processed: Zpracované
   Processes: Procesy
+  Queue: Fronta
+  Queues: Fronty
+  Realtime: V reálném čase
+  Retries: Opakování
+  RetryAll: Opakovat vše
+  RetryCount: Počet opakování
+  RetryNow: Opakovat teď
+  Scheduled: Naplánované
+  ScheduledJobs: Naplánované úkoly
+  ShowAll: Ukázat všechny
+  SixMonths: 6 měsíců
+  Size: Velikost
+  Started: Začal
+  Status: Stav
+  StopPolling: Zastavit průběžnou aktualizaci
   Thread: Vlákno
   Threads: Vlákna
-  Jobs: Úkoly
+  ThreeMonths: 3 měsíce
+  Time: Čas
+  Uptime: Uptime (dny)
+  Version: Verze
+  When: Kdy
+  Worker: Worker

--- a/web/locales/da.yml
+++ b/web/locales/da.yml
@@ -1,68 +1,68 @@
 # elements like %{queue} are variables and should not be translated
 da:
-  Dashboard: Instrumentbræt
-  Status: Status
-  Time: Tid
-  Namespace: Namespace
-  Realtime: Real-time
-  History: Historik
-  Busy: Travl
-  Processed: Processeret
-  Failed: Fejlet
-  Scheduled: Planlagt
-  Retries: Forsøg
-  Enqueued: I kø
-  Worker: Arbejder
-  LivePoll: Live Poll
-  StopPolling: Stop Polling
-  Queue: Kø
-  Class: Klasse
-  Job: Job
-  Arguments: Argumenter
-  Extras: Ekstra
-  Started: Startet
-  ShowAll: Vis alle
-  CurrentMessagesInQueue: Nuværende beskeder i <span class='title'>%{queue}</span>
-  Delete: Slet
+  Actions: Actions
+  active: aktiv
   AddToQueue: Tilføj til kø
+  AreYouSure: Er du sikker?
   AreYouSureDeleteJob: Er du sikker på at du vil slette dette job?
   AreYouSureDeleteQueue: Er du sikker på at du vil slette %{queue} køen?
-  Queues: Køer
-  Size: Størrelse
-  Actions: Actions
-  NextRetry: Næste forsøg
-  RetryCount: Antal forsøg
-  RetryNow: Prøv igen nu
-  LastRetry: Sidste forsøg
-  OriginallyFailed: Oprindeligt fejlet
-  AreYouSure: Er du sikker?
+  Arguments: Argumenter
+  Busy: Travl
+  Class: Klasse
+  Connections: Forbindelser
+  CurrentMessagesInQueue: Nuværende beskeder i <span class='title'>%{queue}</span>
+  Dashboard: Instrumentbræt
+  Dead: Død
+  DeadJobs: Døde jobs
+  Delete: Slet
   DeleteAll: Slet alle
-  RetryAll: Forsøg alle
-  NoRetriesFound: Ingen gen-forsøg var fundet
+  Enqueued: I kø
   Error: Fejl
+  ErrorBacktrace: Fejl backtrace
   ErrorClass: Fejl klasse
   ErrorMessage: Fejl besked
-  ErrorBacktrace: Fejl backtrace
-  GoBack: ← Tilbage
-  NoScheduledFound: Ingen jobs i kø fundet
-  When: Når
-  ScheduledJobs: Jobs i kø
-  idle: idle
-  active: aktiv
-  Version: Version
-  Connections: Forbindelser
-  MemoryUsage: RAM forbrug
-  PeakMemoryUsage: Peak RAM forbrug
-  Uptime: Oppetid (dage)
-  OneWeek: 1 uge
-  OneMonth: 1 måned
-  ThreeMonths: 3 måneder
-  SixMonths: 6 måneder
+  Extras: Ekstra
+  Failed: Fejlet
   Failures: Fejl
-  DeadJobs: Døde jobs
+  GoBack: ← Tilbage
+  History: Historik
+  idle: idle
+  Job: Job
+  Jobs: Jobs
+  LastRetry: Sidste forsøg
+  LivePoll: Live Poll
+  MemoryUsage: RAM forbrug
+  Namespace: Namespace
+  NextRetry: Næste forsøg
   NoDeadJobsFound: Ingen døde jobs fundet
-  Dead: Død
+  NoRetriesFound: Ingen gen-forsøg var fundet
+  NoScheduledFound: Ingen jobs i kø fundet
+  OneMonth: 1 måned
+  OneWeek: 1 uge
+  OriginallyFailed: Oprindeligt fejlet
+  PeakMemoryUsage: Peak RAM forbrug
+  Processed: Processeret
   Processes: Processer
+  Queue: Kø
+  Queues: Køer
+  Realtime: Real-time
+  Retries: Forsøg
+  RetryAll: Forsøg alle
+  RetryCount: Antal forsøg
+  RetryNow: Prøv igen nu
+  Scheduled: Planlagt
+  ScheduledJobs: Jobs i kø
+  ShowAll: Vis alle
+  SixMonths: 6 måneder
+  Size: Størrelse
+  Started: Startet
+  Status: Status
+  StopPolling: Stop Polling
   Thread: Tråd
   Threads: Tråde
-  Jobs: Jobs
+  ThreeMonths: 3 måneder
+  Time: Tid
+  Uptime: Oppetid (dage)
+  Version: Version
+  When: Når
+  Worker: Arbejder

--- a/web/locales/de.yml
+++ b/web/locales/de.yml
@@ -1,69 +1,69 @@
 # elements like %{queue} are variables and should not be translated
 de:
-  Dashboard: Dashboard
-  Status: Status
-  Time: Zeit
-  Namespace: Namensraum
-  Realtime: Echtzeit
-  History: Verlauf
-  Busy: Beschäftigt
-  Processed: Verarbeitet
-  Failed: Fehlgeschlagen
-  Scheduled: Geplant
-  Retries: Versuche
-  Enqueued: In der Warteschlange
-  Worker: Arbeiter
-  LivePoll: Live Poll
-  StopPolling: Abfrage stoppen
-  Queue: Warteschlange
-  Class: Klasse
-  Job: Job
-  Extras: Extras
-  Arguments: Argumente
-  Started: Gestartet
-  ShowAll: Alle anzeigen
-  CurrentMessagesInQueue: Aktuelle Nachrichten in <span class='title'>%{queue}</span>
-  Delete: Löschen
+  Actions: Aktionen
+  active: aktiv
   AddToQueue: In Warteschlange einreihen
+  AreYouSure: Bist du sicher?
   AreYouSureDeleteJob: Möchtest du diesen Job wirklich löschen?
   AreYouSureDeleteQueue: Möchtest du %{queue} wirklich löschen?
-  Queues: Warteschlangen
-  Size: Größe
-  Actions: Aktionen
-  NextRetry: Nächster Versuch
-  RetryCount: Anzahl der Versuche
-  RetryNow: Jetzt erneut versuchen
-  Kill: Töten
-  LastRetry: Letzter Versuch
-  OriginallyFailed: Ursprünglich fehlgeschlagen
-  AreYouSure: Bist du sicher?
+  Arguments: Argumente
+  Busy: Beschäftigt
+  Class: Klasse
+  Connections: Verbindungen
+  CurrentMessagesInQueue: Aktuelle Nachrichten in <span class='title'>%{queue}</span>
+  Dashboard: Dashboard
+  Dead: Tot
+  DeadJobs: Gestorbene Jobs
+  Delete: Löschen
   DeleteAll: Alle löschen
-  RetryAll: Alle erneut versuchen
-  NoRetriesFound: Keine erneuten Versuche gefunden
+  Enqueued: In der Warteschlange
   Error: Fehler
+  ErrorBacktrace: Fehlerbericht
   ErrorClass: Fehlerklasse
   ErrorMessage: Fehlernachricht
-  ErrorBacktrace: Fehlerbericht
-  GoBack: ← Zurück
-  NoScheduledFound: Keine geplanten Jobs gefunden
-  When: Wann
-  ScheduledJobs: Jobs in Wartschlange
-  idle: inaktiv
-  active: aktiv
-  Version: Version
-  Connections: Verbindungen
-  MemoryUsage: RAM-Nutzung
-  PeakMemoryUsage: Maximale RAM-Nutzung
-  Uptime: Laufzeit
-  OneWeek: 1 Woche
-  OneMonth: 1 Monat
-  ThreeMonths: 3 Monate
-  SixMonths: 6 Monate
+  Extras: Extras
+  Failed: Fehlgeschlagen
   Failures: Ausfälle
-  DeadJobs: Gestorbene Jobs
+  GoBack: ← Zurück
+  History: Verlauf
+  idle: inaktiv
+  Job: Job
+  Jobs: Jobs
+  Kill: Töten
+  LastRetry: Letzter Versuch
+  LivePoll: Live Poll
+  MemoryUsage: RAM-Nutzung
+  Namespace: Namensraum
+  NextRetry: Nächster Versuch
   NoDeadJobsFound: Keine toten Jobs gefunden
-  Dead: Tot
+  NoRetriesFound: Keine erneuten Versuche gefunden
+  NoScheduledFound: Keine geplanten Jobs gefunden
+  OneMonth: 1 Monat
+  OneWeek: 1 Woche
+  OriginallyFailed: Ursprünglich fehlgeschlagen
+  PeakMemoryUsage: Maximale RAM-Nutzung
+  Processed: Verarbeitet
   Processes: Prozesse
+  Queue: Warteschlange
+  Queues: Warteschlangen
+  Realtime: Echtzeit
+  Retries: Versuche
+  RetryAll: Alle erneut versuchen
+  RetryCount: Anzahl der Versuche
+  RetryNow: Jetzt erneut versuchen
+  Scheduled: Geplant
+  ScheduledJobs: Jobs in Wartschlange
+  ShowAll: Alle anzeigen
+  SixMonths: 6 Monate
+  Size: Größe
+  Started: Gestartet
+  Status: Status
+  StopPolling: Abfrage stoppen
   Thread: Thread
   Threads: Threads
-  Jobs: Jobs
+  ThreeMonths: 3 Monate
+  Time: Zeit
+  Uptime: Laufzeit
+  Version: Version
+  When: Wann
+  Worker: Arbeiter

--- a/web/locales/el.yml
+++ b/web/locales/el.yml
@@ -1,68 +1,68 @@
 # elements like %{queue} are variables and should not be translated
 el: # <---- change this to your locale code
-  Dashboard: Πίνακας Ελέγχου
-  Status: Κατάσταση
-  Time: Χρόνος
-  Namespace: Namespace
-  Realtime: Τρέχουσα Κατάσταση
-  History: Ιστορικό
-  Busy: Απασχολημένο
-  Processed: Επεξεργάστηκε
-  Failed: Απέτυχε
-  Scheduled: Προγραματίστηκε
-  Retries: Προσπάθειες
-  Enqueued: Μπήκαν στην στοίβα
-  Worker: Εργάτης
-  LivePoll: Τρέχουσα Κατάσταση
-  StopPolling: Διακοπή Τρέχουσας Κατάστασης
-  Queue: Στοίβα
-  Class: Κλάση
-  Job: Εργασία
-  Arguments: Ορίσματα
-  Extras: Extras
-  Started: Ξεκίνησαν
-  ShowAll: Εμφάνιση Όλων
-  CurrentMessagesInQueue: Τρέχουσες εργασίες <span class='title'>%{queue}</span>
-  Delete: Διαγραφή
+  Actions: Ενέργειες
+  active: ενεργή
   AddToQueue: Προσθήκη στην στοίβα
+  AreYouSure: Είστε σίγουρος?
   AreYouSureDeleteJob: Θέλετε να διαγράψετε την εργασία αυτη;
   AreYouSureDeleteQueue: Θέλετε να διαγράψετε την %{queue} στοίβα?
-  Queues: Στοίβες
-  Size: Μέγεθος
-  Actions: Ενέργειες
-  NextRetry: Επόμενη προσπάθεια
-  RetryCount: Αριθμός προσπαθειών
-  RetryNow: Προσπάθησε τώρα
-  LastRetry: Τελευταία προσπάθεια
-  OriginallyFailed: Αρχικές Αποτυχίες
-  AreYouSure: Είστε σίγουρος?
+  Arguments: Ορίσματα
+  Busy: Απασχολημένο
+  Class: Κλάση
+  Connections: Συνδέσεις
+  CurrentMessagesInQueue: Τρέχουσες εργασίες <span class='title'>%{queue}</span>
+  Dashboard: Πίνακας Ελέγχου
+  Dead: Αδρανείς
+  DeadJobs: Αδρανείς Εργασίες
+  Delete: Διαγραφή
   DeleteAll: Διαγραφή όλων
-  RetryAll: Επανάληψη Όλων
-  NoRetriesFound: Δεν βρέθηκαν προσπάθειες
+  Enqueued: Μπήκαν στην στοίβα
   Error: Σφάλμα
+  ErrorBacktrace: Σφάλμα Backtrace
   ErrorClass: Κλάση σφάλματος
   ErrorMessage: Μήνυμα Σφάλματος
-  ErrorBacktrace: Σφάλμα Backtrace
-  GoBack: ← Πίσω
-  NoScheduledFound: Δεν βρέθηκαν προγραμματισμένες εργασίες
-  When: Πότε
-  ScheduledJobs: Προγραμματισμένες Εργασίες
-  idle: αδρανής
-  active: ενεργή
-  Version: Έκδοση
-  Connections: Συνδέσεις
-  MemoryUsage: Χρήση Μνήμης
-  PeakMemoryUsage: Μέγιστη Χρήση Μνήμης
-  Uptime: Διάρκεια Λειτουργείας (ημέρες)
-  OneWeek: 1 εβδομάδα
-  OneMonth: 1 μήνας
-  ThreeMonths: 3 μήνες
-  SixMonths: 6 μήνες
+  Extras: Extras
+  Failed: Απέτυχε
   Failures: Αποτυχίες
-  DeadJobs: Αδρανείς Εργασίες
+  GoBack: ← Πίσω
+  History: Ιστορικό
+  idle: αδρανής
+  Job: Εργασία
+  Jobs: Εργασίες
+  LastRetry: Τελευταία προσπάθεια
+  LivePoll: Τρέχουσα Κατάσταση
+  MemoryUsage: Χρήση Μνήμης
+  Namespace: Namespace
+  NextRetry: Επόμενη προσπάθεια
   NoDeadJobsFound: Δεν βρέθηκαν αδρανείς εργασίες
-  Dead: Αδρανείς
+  NoRetriesFound: Δεν βρέθηκαν προσπάθειες
+  NoScheduledFound: Δεν βρέθηκαν προγραμματισμένες εργασίες
+  OneMonth: 1 μήνας
+  OneWeek: 1 εβδομάδα
+  OriginallyFailed: Αρχικές Αποτυχίες
+  PeakMemoryUsage: Μέγιστη Χρήση Μνήμης
+  Processed: Επεξεργάστηκε
   Processes: Διεργασίες
+  Queue: Στοίβα
+  Queues: Στοίβες
+  Realtime: Τρέχουσα Κατάσταση
+  Retries: Προσπάθειες
+  RetryAll: Επανάληψη Όλων
+  RetryCount: Αριθμός προσπαθειών
+  RetryNow: Προσπάθησε τώρα
+  Scheduled: Προγραματίστηκε
+  ScheduledJobs: Προγραμματισμένες Εργασίες
+  ShowAll: Εμφάνιση Όλων
+  SixMonths: 6 μήνες
+  Size: Μέγεθος
+  Started: Ξεκίνησαν
+  Status: Κατάσταση
+  StopPolling: Διακοπή Τρέχουσας Κατάστασης
   Thread: Νήμα
   Threads: Νήματα
-  Jobs: Εργασίες
+  ThreeMonths: 3 μήνες
+  Time: Χρόνος
+  Uptime: Διάρκεια Λειτουργείας (ημέρες)
+  Version: Έκδοση
+  When: Πότε
+  Worker: Εργάτης

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -1,75 +1,75 @@
 # elements like %{queue} are variables and should not be translated
 en: # <---- change this to your locale code
-  Dashboard: Dashboard
-  Status: Status
-  Time: Time
-  Namespace: Namespace
-  Realtime: Real-time
-  History: History
-  Busy: Busy
-  Processed: Processed
-  Failed: Failed
-  Scheduled: Scheduled
-  Retries: Retries
-  Enqueued: Enqueued
-  Worker: Worker
-  LivePoll: Live Poll
-  StopPolling: Stop Polling
-  Queue: Queue
-  Class: Class
-  Job: Job
-  Arguments: Arguments
-  Extras: Extras
-  Started: Started
-  ShowAll: Show All
-  CurrentMessagesInQueue: Current jobs in <span class='title'>%{queue}</span>
-  Delete: Delete
+  Actions: Actions
+  active: active
   AddToQueue: Add to queue
+  AreYouSure: Are you sure?
   AreYouSureDeleteJob: Are you sure you want to delete this job?
   AreYouSureDeleteQueue: Are you sure you want to delete the %{queue} queue?
-  Queues: Queues
-  Size: Size
-  Actions: Actions
-  NextRetry: Next Retry
-  RetryCount: Retry Count
-  RetryNow: Retry Now
-  Kill: Kill
-  LastRetry: Last Retry
-  OriginallyFailed: Originally Failed
-  AreYouSure: Are you sure?
+  Arguments: Arguments
+  Busy: Busy
+  Class: Class
+  Connections: Connections
+  CurrentMessagesInQueue: Current jobs in <span class='title'>%{queue}</span>
+  Dashboard: Dashboard
+  Dead: Dead
+  DeadJobs: Dead Jobs
+  Delete: Delete
   DeleteAll: Delete All
-  RetryAll: Retry All
-  NoRetriesFound: No retries were found
+  Enqueued: Enqueued
   Error: Error
+  ErrorBacktrace: Error Backtrace
   ErrorClass: Error Class
   ErrorMessage: Error Message
-  ErrorBacktrace: Error Backtrace
-  GoBack: ← Back
-  NoScheduledFound: No scheduled jobs were found
-  When: When
-  ScheduledJobs: Scheduled Jobs
-  idle: idle
-  active: active
-  Version: Version
-  Connections: Connections
-  MemoryUsage: Memory Usage
-  PeakMemoryUsage: Peak Memory Usage
-  Uptime: Uptime (days)
-  OneWeek: 1 week
-  OneMonth: 1 month
-  ThreeMonths: 3 months
-  SixMonths: 6 months
+  Extras: Extras
+  Failed: Failed
   Failures: Failures
-  DeadJobs: Dead Jobs
+  GoBack: ← Back
+  History: History
+  idle: idle
+  Job: Job
+  Jobs: Jobs
+  Kill: Kill
+  LastRetry: Last Retry
+  LivePoll: Live Poll
+  MemoryUsage: Memory Usage
+  Namespace: Namespace
+  NextRetry: Next Retry
   NoDeadJobsFound: No dead jobs were found
-  Dead: Dead
+  NoRetriesFound: No retries were found
+  NoScheduledFound: No scheduled jobs were found
+  OneMonth: 1 month
+  OneWeek: 1 week
+  OriginallyFailed: Originally Failed
+  Paused: Paused
+  PeakMemoryUsage: Peak Memory Usage
+  PollingInterval: Polling interval
+  Processed: Processed
   Processes: Processes
+  Queue: Queue
+  Queues: Queues
+  Quiet: Quiet
+  QuietAll: Quiet All
+  Realtime: Real-time
+  Retries: Retries
+  RetryAll: Retry All
+  RetryCount: Retry Count
+  RetryNow: Retry Now
+  Scheduled: Scheduled
+  ScheduledJobs: Scheduled Jobs
+  ShowAll: Show All
+  SixMonths: 6 months
+  Size: Size
+  Started: Started
+  Status: Status
+  Stop: Stop
+  StopAll: Stop All
+  StopPolling: Stop Polling
   Thread: Thread
   Threads: Threads
-  Jobs: Jobs
-  Paused: Paused
-  Stop: Stop
-  Quiet: Quiet
-  StopAll: Stop All
-  QuietAll: Quiet All
-  PollingInterval: Polling interval
+  ThreeMonths: 3 months
+  Time: Time
+  Uptime: Uptime (days)
+  Version: Version
+  When: When
+  Worker: Worker

--- a/web/locales/es.yml
+++ b/web/locales/es.yml
@@ -1,69 +1,69 @@
 # elements like %{queue} are variables and should not be translated
 es:
-  Dashboard: Panel de Control
-  Status: Estatus
-  Time: Tiempo
-  Namespace: Espacio de Nombre
-  Realtime: Tiempo Real
-  History: Historial
-  Busy: Ocupado
-  Processed: Procesadas
-  Failed: Fallidas
-  Scheduled: Programadas
-  Retries: Reintentos
-  Enqueued: En Fila
-  Worker: Trabajador
-  LivePoll: Sondeo en Vivo
-  StopPolling: Detener Sondeo
-  Queue: Fila
-  Class: Clase
-  Job: Trabajo
-  Arguments: Argumentos
-  Extras: Extras
-  Started: Hora de Inicio
-  ShowAll: Mostrar Todo
-  CurrentMessagesInQueue: Mensajes actualmente en <span class='title'>%{queue}</span>
-  Delete: Eliminar
+  Actions: Acciones
+  active: activo
   AddToQueue: Añadir a fila
+  AreYouSure: ¿Estás seguro?
   AreYouSureDeleteJob: ¿Estás seguro de eliminar este trabajo?
   AreYouSureDeleteQueue: ¿Estás seguro de eliminar la fila  %{queue}?
-  Queues: Filas
-  Size: Tamaño
-  Actions: Acciones
-  NextRetry: Siguiente Intento
-  RetryCount: Numero de Reintentos
-  RetryNow: Reintentar Ahora
-  Kill: Matar
-  LastRetry: Último Reintento
-  OriginallyFailed: Falló Originalmente
-  AreYouSure: ¿Estás seguro?
+  Arguments: Argumentos
+  Busy: Ocupado
+  Class: Clase
+  Connections: Conexiones
+  CurrentMessagesInQueue: Mensajes actualmente en <span class='title'>%{queue}</span>
+  Dashboard: Panel de Control
+  Dead: Muerto
+  DeadJobs: Trabajos muertos
+  Delete: Eliminar
   DeleteAll: Borrar Todo
-  RetryAll: Reintentar Todo
-  NoRetriesFound: No se encontraron reintentos
+  Enqueued: En Fila
   Error: Error
+  ErrorBacktrace: Trazado del Error
   ErrorClass: Clase del Error
   ErrorMessage: Mensaje de Error
-  ErrorBacktrace: Trazado del Error
-  GoBack: ← Regresar
-  NoScheduledFound: No se encontraron trabajos pendientes
-  When: Cuando
-  ScheduledJobs: Trabajos programados
-  idle: inactivo
-  active: activo
-  Version: Versión
-  Connections: Conexiones
-  MemoryUsage: Uso de Memoria
-  PeakMemoryUsage: Máximo Uso de Memoria
-  Uptime: Tiempo de Funcionamiento (días)
-  OneWeek: 1 semana
-  OneMonth: 1 mes
-  ThreeMonths: 3 meses
-  SixMonths: 6 meses
+  Extras: Extras
+  Failed: Fallidas
   Failures: Fallas
-  DeadJobs: Trabajos muertos
+  GoBack: ← Regresar
+  History: Historial
+  idle: inactivo
+  Job: Trabajo
+  Jobs: Trabajos
+  Kill: Matar
+  LastRetry: Último Reintento
+  LivePoll: Sondeo en Vivo
+  MemoryUsage: Uso de Memoria
+  Namespace: Espacio de Nombre
+  NextRetry: Siguiente Intento
   NoDeadJobsFound: No hay trabajos muertos
-  Dead: Muerto
+  NoRetriesFound: No se encontraron reintentos
+  NoScheduledFound: No se encontraron trabajos pendientes
+  OneMonth: 1 mes
+  OneWeek: 1 semana
+  OriginallyFailed: Falló Originalmente
+  PeakMemoryUsage: Máximo Uso de Memoria
+  Processed: Procesadas
   Processes: Procesos
+  Queue: Fila
+  Queues: Filas
+  Realtime: Tiempo Real
+  Retries: Reintentos
+  RetryAll: Reintentar Todo
+  RetryCount: Numero de Reintentos
+  RetryNow: Reintentar Ahora
+  Scheduled: Programadas
+  ScheduledJobs: Trabajos programados
+  ShowAll: Mostrar Todo
+  SixMonths: 6 meses
+  Size: Tamaño
+  Started: Hora de Inicio
+  Status: Estatus
+  StopPolling: Detener Sondeo
   Thread: Hilo
   Threads: Hilos
-  Jobs: Trabajos
+  ThreeMonths: 3 meses
+  Time: Tiempo
+  Uptime: Tiempo de Funcionamiento (días)
+  Version: Versión
+  When: Cuando
+  Worker: Trabajador

--- a/web/locales/fr.yml
+++ b/web/locales/fr.yml
@@ -1,69 +1,69 @@
 # elements like %{queue} are variables and should not be translated
 fr:
-  Dashboard: Tableau de Bord
-  Status: État
-  Time: Heure
-  Namespace: Namespace
-  Realtime: Temps réel
-  History: Historique
-  Busy: Occupées
-  Processed: Traitées
-  Failed: Échouées
-  Scheduled: Planifiée
-  Retries: Tentatives
-  Enqueued: En queue
-  Worker: Travailleur
-  LivePoll: Temps réel
-  StopPolling: Arrêt du temps réel
-  Queue: Queue
-  Class: Classe
-  Job: Tâche
-  Arguments: Arguments
-  Extras: Extras
-  Started: Démarrées
-  ShowAll: Montrer tout
-  CurrentMessagesInQueue: Messages actuellement dans <span class='title'>%{queue}</span>
-  Delete: Supprimer
+  Actions: Actions
+  active: actives
   AddToQueue: Ajouter à la queue
+  AreYouSure: Êtes-vous certain ?
   AreYouSureDeleteJob: Êtes-vous certain de vouloir supprimer cette tâche ?
   AreYouSureDeleteQueue: Êtes-vous certain de vouloir supprimer la queue %{queue} ?
-  Queues: Queues
-  Size: Taille
-  Actions: Actions
-  NextRetry: Prochain essai
-  RetryCount: Nombre d'essais
-  RetryNow: Réessayer maintenant
-  Kill: Tuer
-  LastRetry: Dernier essai
-  OriginallyFailed: Échec originel
-  AreYouSure: Êtes-vous certain ?
+  Arguments: Arguments
+  Busy: Occupées
+  Class: Classe
+  Connections: Connexions
+  CurrentMessagesInQueue: Messages actuellement dans <span class='title'>%{queue}</span>
+  Dashboard: Tableau de Bord
+  Dead: Morte
+  DeadJobs: Tâches mortes
+  Delete: Supprimer
   DeleteAll: Tout supprimer
-  RetryAll: Tout réessayer
-  NoRetriesFound: Aucune tâche à réessayer n’a été trouvée
+  Enqueued: En queue
   Error: Erreur
+  ErrorBacktrace: Backtrace d’erreur
   ErrorClass: Classe d’erreur
   ErrorMessage: Message d’erreur
-  ErrorBacktrace: Backtrace d’erreur
-  GoBack: ← Retour
-  NoScheduledFound: Pas de tâches planifiées trouvées
-  When: Quand
-  ScheduledJobs: Tâches planifiées
-  idle: en attente
-  active: actives
-  Version: Version
-  Connections: Connexions
-  MemoryUsage: Mémoire utilisée
-  PeakMemoryUsage: Mémoire utilisée (max.)
-  Uptime: Uptime (jours)
-  OneWeek: 1 semaine
-  OneMonth: 1 mois
-  ThreeMonths: 3 mois
-  SixMonths: 6 mois
+  Extras: Extras
+  Failed: Échouées
   Failures: Echecs
-  DeadJobs: Tâches mortes
+  GoBack: ← Retour
+  History: Historique
+  idle: en attente
+  Job: Tâche
+  Jobs: Tâches
+  Kill: Tuer
+  LastRetry: Dernier essai
+  LivePoll: Temps réel
+  MemoryUsage: Mémoire utilisée
+  Namespace: Namespace
+  NextRetry: Prochain essai
   NoDeadJobsFound: Aucune tâche morte n'a été trouvée
-  Dead: Morte
+  NoRetriesFound: Aucune tâche à réessayer n’a été trouvée
+  NoScheduledFound: Pas de tâches planifiées trouvées
+  OneMonth: 1 mois
+  OneWeek: 1 semaine
+  OriginallyFailed: Échec originel
+  PeakMemoryUsage: Mémoire utilisée (max.)
+  Processed: Traitées
   Processes: Processus
+  Queue: Queue
+  Queues: Queues
+  Realtime: Temps réel
+  Retries: Tentatives
+  RetryAll: Tout réessayer
+  RetryCount: Nombre d'essais
+  RetryNow: Réessayer maintenant
+  Scheduled: Planifiée
+  ScheduledJobs: Tâches planifiées
+  ShowAll: Montrer tout
+  SixMonths: 6 mois
+  Size: Taille
+  Started: Démarrées
+  Status: État
+  StopPolling: Arrêt du temps réel
   Thread: Fil
   Threads: Fils
-  Jobs: Tâches
+  ThreeMonths: 3 mois
+  Time: Heure
+  Uptime: Uptime (jours)
+  Version: Version
+  When: Quand
+  Worker: Travailleur

--- a/web/locales/it.yml
+++ b/web/locales/it.yml
@@ -1,69 +1,69 @@
 # elements like %{queue} are variables and should not be translated
 it:
-  Dashboard: Dashboard
-  Status: Stato
-  Time: Ora
-  Namespace: Namespace
-  Realtime: Tempo reale
-  History: Storia
-  Busy: Occupato
-  Processed: Processato
-  Failed: Fallito
-  Scheduled: Pianificato
-  Retries: Nuovi tentativi
-  Enqueued: In coda
-  Worker: Lavoratore
-  LivePoll: Live poll
-  StopPolling: Ferma il polling
-  Queue: Coda
-  Class: Classe
-  Job: Lavoro
-  Arguments: Argomenti
-  Extras: Extra
-  Started: Iniziato
-  ShowAll: Mostra tutti
-  CurrentMessagesInQueue: Messaggi in <span class='title'>%{queue}</span>
-  Delete: Cancella
+  Actions: Azioni
+  active: attivo
   AddToQueue: Aggiungi alla coda
+  AreYouSure: Sei sicuro?
   AreYouSureDeleteJob: Sei sicuro di voler cancellare questo lavoro?
   AreYouSureDeleteQueue: Sei sicuro di voler cancellare la coda %{queue}?
-  Queues: Code
-  Size: Dimensione
-  Actions: Azioni
-  NextRetry: Prossimo tentativo
-  RetryCount: Totale tentativi
-  RetryNow: Riprova
-  Kill: Uccidere
-  LastRetry: Ultimo tentativo
-  OriginallyFailed: Primo fallimento
-  AreYouSure: Sei sicuro?
+  Arguments: Argomenti
+  Busy: Occupato
+  Class: Classe
+  Connections: Connessioni
+  CurrentMessagesInQueue: Messaggi in <span class='title'>%{queue}</span>
+  Dashboard: Dashboard
+  Dead: Arrestato
+  DeadJobs: Lavori arrestati
+  Delete: Cancella
   DeleteAll: Cancella tutti
-  RetryAll: Riprova tutti
-  NoRetriesFound: Non sono stati trovati nuovi tentativi
+  Enqueued: In coda
   Error: Errore
+  ErrorBacktrace: Backtrace dell'errore
   ErrorClass: Classe dell'errore
   ErrorMessage: Messaggio di errore
-  ErrorBacktrace: Backtrace dell'errore
-  GoBack: ← Indietro
-  NoScheduledFound: Non ci sono lavori pianificati
-  When: Quando
-  ScheduledJobs: Lavori pianificati
-  idle: inattivo
-  active: attivo
-  Version: Versione
-  Connections: Connessioni
-  MemoryUsage: Memoria utilizzata
-  PeakMemoryUsage: Memoria utilizzata (max.)
-  Uptime: Uptime (giorni)
-  OneWeek: 1 settimana
-  OneMonth: 1 mese
-  ThreeMonths: 3 mesi
-  SixMonths: 6 mesi
+  Extras: Extra
+  Failed: Fallito
   Failures: Fallimenti
-  DeadJobs: Lavori arrestati
+  GoBack: ← Indietro
+  History: Storia
+  idle: inattivo
+  Job: Lavoro
+  Jobs: Lavori
+  Kill: Uccidere
+  LastRetry: Ultimo tentativo
+  LivePoll: Live poll
+  MemoryUsage: Memoria utilizzata
+  Namespace: Namespace
+  NextRetry: Prossimo tentativo
   NoDeadJobsFound: Non ci sono lavori arrestati
-  Dead: Arrestato
+  NoRetriesFound: Non sono stati trovati nuovi tentativi
+  NoScheduledFound: Non ci sono lavori pianificati
+  OneMonth: 1 mese
+  OneWeek: 1 settimana
+  OriginallyFailed: Primo fallimento
+  PeakMemoryUsage: Memoria utilizzata (max.)
+  Processed: Processato
   Processes: Processi
+  Queue: Coda
+  Queues: Code
+  Realtime: Tempo reale
+  Retries: Nuovi tentativi
+  RetryAll: Riprova tutti
+  RetryCount: Totale tentativi
+  RetryNow: Riprova
+  Scheduled: Pianificato
+  ScheduledJobs: Lavori pianificati
+  ShowAll: Mostra tutti
+  SixMonths: 6 mesi
+  Size: Dimensione
+  Started: Iniziato
+  Status: Stato
+  StopPolling: Ferma il polling
   Thread: Thread
   Threads: Thread
-  Jobs: Lavori
+  ThreeMonths: 3 mesi
+  Time: Ora
+  Uptime: Uptime (giorni)
+  Version: Versione
+  When: Quando
+  Worker: Lavoratore

--- a/web/locales/ja.yml
+++ b/web/locales/ja.yml
@@ -1,69 +1,69 @@
 # elements like %{queue} are variables and should not be translated
 ja:
-  Dashboard: ダッシュボード
-  Status: 状態
-  Time: 時間
-  Namespace: ネームスペース
-  Realtime: リアルタイム
-  History: 履歴
-  Busy: ビジー
-  Processed: 処理完了
-  Failed: 失敗
-  Scheduled: 予定
-  Retries: 再試行
-  Enqueued: 待機状態
-  Worker: 動作中の作業
-  LivePoll: ポーリング開始
-  StopPolling: ポーリング停止
-  Queue: キュー
-  Class: クラス
-  Job: ジョブ
-  Arguments: 引数
-  Extras: エクストラ
-  Started: 開始
-  ShowAll: 全て見せる
-  CurrentMessagesInQueue: <span class='title'>%{queue}</span>に メッセージがあります
-  Delete: 削除
+  Actions: アクション
+  active: アクティブ
   AddToQueue: キューに追加
+  AreYouSure: いいですか？
   AreYouSureDeleteJob: このジョブを削除しますか？
   AreYouSureDeleteQueue: この %{queue} キューを削除しますか?
-  Queues: キュー
-  Size: サイズ
-  Actions: アクション
-  NextRetry: 再試行
-  RetryCount: 再試行
-  RetryNow: 今すぐ再試行
-  LastRetry: 再試行履歴
-  OriginallyFailed: 失敗
-  AreYouSure: いいですか？
+  Arguments: 引数
+  Batches: バッチ
+  Busy: ビジー
+  Class: クラス
+  Connections: 接続
+  CurrentMessagesInQueue: <span class='title'>%{queue}</span>に メッセージがあります
+  Dashboard: ダッシュボード
+  Dead: 死亡
+  DeadJobs: 死亡したジョブ
+  Delete: 削除
   DeleteAll: 全て削除
-  RetryAll: 全て再試行
-  NoRetriesFound: 再試行できません
+  Enqueued: 待機状態
   Error: エラー
+  ErrorBacktrace: エラーバックトレース
   ErrorClass: クラスエラー
   ErrorMessage: エラーメッセージ
-  ErrorBacktrace: エラーバックトレース
-  GoBack: ← 戻る
-  NoScheduledFound: 予定したジョブはありません
-  When: いつ
-  ScheduledJobs: 予定したジョブ
-  idle: アイドル
-  active: アクティブ
-  Version: バージョン
-  Connections: 接続
-  MemoryUsage: メモリー容量
-  PeakMemoryUsage: 最大メモリー容量
-  Uptime: Uptime (days)
-  OneWeek: 1 週
-  OneMonth: 1 ヶ月
-  ThreeMonths: 3 ヶ月
-  SixMonths: 6 ヶ月
-  Batches: バッチ
+  Extras: エクストラ
+  Failed: 失敗
   Failures: 失敗
-  DeadJobs: 死亡したジョブ
+  GoBack: ← 戻る
+  History: 履歴
+  idle: アイドル
+  Job: ジョブ
+  Jobs: ジョブ
+  LastRetry: 再試行履歴
+  LivePoll: ポーリング開始
+  MemoryUsage: メモリー容量
+  Namespace: ネームスペース
+  NextRetry: 再試行
   NoDeadJobsFound: 死亡したジョブはありません
-  Dead: 死亡
+  NoRetriesFound: 再試行できません
+  NoScheduledFound: 予定したジョブはありません
+  OneMonth: 1 ヶ月
+  OneWeek: 1 週
+  OriginallyFailed: 失敗
+  PeakMemoryUsage: 最大メモリー容量
+  Processed: 処理完了
   Processes: プロセス
+  Queue: キュー
+  Queues: キュー
+  Realtime: リアルタイム
+  Retries: 再試行
+  RetryAll: 全て再試行
+  RetryCount: 再試行
+  RetryNow: 今すぐ再試行
+  Scheduled: 予定
+  ScheduledJobs: 予定したジョブ
+  ShowAll: 全て見せる
+  SixMonths: 6 ヶ月
+  Size: サイズ
+  Started: 開始
+  Status: 状態
+  StopPolling: ポーリング停止
   Thread: スレッド
   Threads: スレッド
-  Jobs: ジョブ
+  ThreeMonths: 3 ヶ月
+  Time: 時間
+  Uptime: Uptime (days)
+  Version: バージョン
+  When: いつ
+  Worker: 動作中の作業

--- a/web/locales/ko.yml
+++ b/web/locales/ko.yml
@@ -1,68 +1,68 @@
 # elements like %{queue} are variables and should not be translated
 ko:
-  Dashboard: 대시보드
-  Status: 상태
-  Time: 시간
-  Namespace: 네임스페이스
-  Realtime: 실시간
-  History: 히스토리
-  Busy: 작동
-  Processed: 처리완료
-  Failed: 실패
-  Scheduled: 예약
-  Retries: 재시도
-  Enqueued: 대기 중
-  Worker: 워커
-  LivePoll: 폴링 시작
-  StopPolling: 폴링 중단
-  Queue: 큐
-  Class: 클래스
-  Job: 작업
-  Arguments: 인자
-  Started: 시작
-  ShowAll: 모두 보기
-  CurrentMessagesInQueue: <span class='title'>%{queue}</span>에 대기 중인 메시지
-  Delete: 삭제
+  Actions: 동작
+  active: 동작 중
   AddToQueue: 큐 추가
+  AreYouSure: 정말입니까?
   AreYouSureDeleteJob: 이 작업을 삭제하시겠습니까?
   AreYouSureDeleteQueue: 이 %{queue} 큐를 삭제하시겠습니까?
-  Queues: 큐
-  Size: 크기
-  Actions: 동작
-  NextRetry: 다음 재시도
-  RetryCount: 재시도 횟수
-  RetryNow: 지금 재시도
-  LastRetry: 최근 재시도
-  OriginallyFailed: 실패
-  AreYouSure: 정말입니까?
+  Arguments: 인자
+  Batches: 배치
+  Busy: 작동
+  Class: 클래스
+  Connections: 커넥션
+  CurrentMessagesInQueue: <span class='title'>%{queue}</span>에 대기 중인 메시지
+  Dashboard: 대시보드
+  Dead: 죽음
+  DeadJobs: 죽은 작업
+  Delete: 삭제
   DeleteAll: 모두 삭제
-  RetryAll: 모두 재시도
-  NoRetriesFound: 재시도 내역이 없습니다
+  Enqueued: 대기 중
   Error: 에러
+  ErrorBacktrace: 에러 Backtrace
   ErrorClass: 에러 클래스
   ErrorMessage: 에러 메시지
-  ErrorBacktrace: 에러 Backtrace
-  GoBack: ← 뒤로
-  NoScheduledFound: 예약된 작업이 없습니다
-  When: 언제
-  ScheduledJobs: 예약된 작업
-  idle: 대기 중
-  active: 동작 중
-  Version: 버전
-  Connections: 커넥션
-  MemoryUsage: 메모리 사용량
-  PeakMemoryUsage: 최대 메모리 사용량
-  Uptime: 업타임 (일)
-  OneWeek: 1 주
-  OneMonth: 1 달
-  ThreeMonths: 3 달
-  SixMonths: 6 달
-  Batches: 배치
+  Failed: 실패
   Failures: 실패
-  DeadJobs: 죽은 작업
+  GoBack: ← 뒤로
+  History: 히스토리
+  idle: 대기 중
+  Job: 작업
+  Jobs: 작업
+  LastRetry: 최근 재시도
+  LivePoll: 폴링 시작
+  MemoryUsage: 메모리 사용량
+  Namespace: 네임스페이스
+  NextRetry: 다음 재시도
   NoDeadJobsFound: 죽은 작업이 없습니다
-  Dead: 죽음
+  NoRetriesFound: 재시도 내역이 없습니다
+  NoScheduledFound: 예약된 작업이 없습니다
+  OneMonth: 1 달
+  OneWeek: 1 주
+  OriginallyFailed: 실패
+  PeakMemoryUsage: 최대 메모리 사용량
+  Processed: 처리완료
   Processes: 프로세스
+  Queue: 큐
+  Queues: 큐
+  Realtime: 실시간
+  Retries: 재시도
+  RetryAll: 모두 재시도
+  RetryCount: 재시도 횟수
+  RetryNow: 지금 재시도
+  Scheduled: 예약
+  ScheduledJobs: 예약된 작업
+  ShowAll: 모두 보기
+  SixMonths: 6 달
+  Size: 크기
+  Started: 시작
+  Status: 상태
+  StopPolling: 폴링 중단
   Thread: 스레드
   Threads: 스레드
-  Jobs: 작업
+  ThreeMonths: 3 달
+  Time: 시간
+  Uptime: 업타임 (일)
+  Version: 버전
+  When: 언제
+  Worker: 워커

--- a/web/locales/nl.yml
+++ b/web/locales/nl.yml
@@ -1,68 +1,68 @@
 # elements like %{queue} are variables and should not be translated
 nl:
-  Dashboard: Dashboard
-  Status: Status
-  Time: Tijd
-  Namespace: Namespace
-  Realtime: Real-time
-  History: Geschiedenis
-  Busy: Bezet
-  Processed: Verwerkt
-  Failed: Mislukt
-  Scheduled: Gepland
-  Retries: Opnieuw proberen
-  Enqueued: In de wachtrij
-  Worker: Werker
-  LivePoll: Live bijwerken
-  StopPolling: Stop live bijwerken
-  Queue: Wachtrij
-  Class: Klasse
-  Job: Taak
-  Arguments: Argumenten
-  Extras: Extra's
-  Started: Gestart
-  ShowAll: Toon alle
-  CurrentMessagesInQueue: Aantal berichten in <span class='title'>%{queue}</span>
-  Delete: Verwijderen
+  Actions: Acties
+  active: actief
   AddToQueue: Toevoegen aan wachtrij
+  AreYouSure: Weet u het zeker?
   AreYouSureDeleteJob: Weet u zeker dat u deze taak wilt verwijderen?
   AreYouSureDeleteQueue: Weet u zeker dat u wachtrij %{queue} wilt verwijderen?
-  Queues: Wachtrijen
-  Size: Grootte
-  Actions: Acties
-  NextRetry: Volgende opnieuw proberen
-  RetryCount: Aantal opnieuw geprobeerd
-  RetryNow: Nu opnieuw proberen
-  LastRetry: Laatste poging
-  OriginallyFailed: Oorspronkelijk mislukt
-  AreYouSure: Weet u het zeker?
+  Arguments: Argumenten
+  Busy: Bezet
+  Class: Klasse
+  Connections: Verbindingen
+  CurrentMessagesInQueue: Aantal berichten in <span class='title'>%{queue}</span>
+  Dashboard: Dashboard
+  Dead: Overleden
+  DeadJobs: Overleden taken
+  Delete: Verwijderen
   DeleteAll: Alle verwijderen
-  RetryAll: Alle opnieuw proberen
-  NoRetriesFound: Geen opnieuw te proberen taken gevonden
+  Enqueued: In de wachtrij
   Error: Fout
+  ErrorBacktrace: Fout Backtrace
   ErrorClass: Fout Klasse
   ErrorMessage: Foutmelding
-  ErrorBacktrace: Fout Backtrace
-  GoBack: ← Terug
-  NoScheduledFound: Geen geplande taken gevonden
-  When: Wanneer
-  ScheduledJobs: Geplande taken
-  idle: inactief
-  active: actief
-  Version: Versie
-  Connections: Verbindingen
-  MemoryUsage: Geheugengebruik
-  PeakMemoryUsage: Piek geheugengebruik
-  Uptime: Looptijd (dagen)
-  OneWeek: 1 week
-  OneMonth: 1 maand
-  ThreeMonths: 3 maanden
-  SixMonths: 6 maanden
+  Extras: Extra's
+  Failed: Mislukt
   Failures: Mislukt
-  DeadJobs: Overleden taken
+  GoBack: ← Terug
+  History: Geschiedenis
+  idle: inactief
+  Job: Taak
+  Jobs: Taken
+  LastRetry: Laatste poging
+  LivePoll: Live bijwerken
+  MemoryUsage: Geheugengebruik
+  Namespace: Namespace
+  NextRetry: Volgende opnieuw proberen
   NoDeadJobsFound: Geen overleden taken gevonden
-  Dead: Overleden
+  NoRetriesFound: Geen opnieuw te proberen taken gevonden
+  NoScheduledFound: Geen geplande taken gevonden
+  OneMonth: 1 maand
+  OneWeek: 1 week
+  OriginallyFailed: Oorspronkelijk mislukt
+  PeakMemoryUsage: Piek geheugengebruik
+  Processed: Verwerkt
   Processes: Processen
+  Queue: Wachtrij
+  Queues: Wachtrijen
+  Realtime: Real-time
+  Retries: Opnieuw proberen
+  RetryAll: Alle opnieuw proberen
+  RetryCount: Aantal opnieuw geprobeerd
+  RetryNow: Nu opnieuw proberen
+  Scheduled: Gepland
+  ScheduledJobs: Geplande taken
+  ShowAll: Toon alle
+  SixMonths: 6 maanden
+  Size: Grootte
+  Started: Gestart
+  Status: Status
+  StopPolling: Stop live bijwerken
   Thread: Thread
   Threads: Threads
-  Jobs: Taken
+  ThreeMonths: 3 maanden
+  Time: Tijd
+  Uptime: Looptijd (dagen)
+  Version: Versie
+  When: Wanneer
+  Worker: Werker

--- a/web/locales/no.yml
+++ b/web/locales/no.yml
@@ -1,69 +1,69 @@
 # elements like %{queue} are variables and should not be translated
 no:
-  Dashboard: Oversikt
-  Status: Status
-  Time: Tid
-  Namespace: Navnerom
-  Realtime: Sanntid
-  History: Historikk
-  Busy: Opptatt
-  Processed: Prosessert
-  Failed: Mislykket
-  Scheduled: Planlagt
-  Retries: Forsøk
-  Enqueued: I kø
-  Worker: Arbeider
-  LivePoll: Automatisk oppdatering
-  StopPolling: Stopp automatisk oppdatering
-  Queue: Kø
-  Class: Klasse
-  Job: Jobb
-  Arguments: Argumenter
-  Extras: Ekstra
-  Started: Startet
-  ShowAll: Vis alle
-  CurrentMessagesInQueue: Nåværende melding i <span class='title'>%{queue}</span>
-  Delete: Slett
+  Actions: Handlinger
+  active: aktiv
   AddToQueue: Legg til i kø
+  AreYouSure: Er du sikker?
   AreYouSureDeleteJob: Er du sikker på at du vil slette denne jobben?
   AreYouSureDeleteQueue: Er du sikker på at du vil slette køen %{queue}?
-  Queues: Køer
-  Size: Størrelse
-  Actions: Handlinger
-  NextRetry: Neste forsøk
-  RetryCount: Antall forsøk
-  RetryNow: Forsøk igjen nå
-  LastRetry: Forrige forsøk
-  OriginallyFailed: Feilet opprinnelig
-  AreYouSure: Er du sikker?
+  Arguments: Argumenter
+  Batches: Samlinger
+  Busy: Opptatt
+  Class: Klasse
+  Connections: Tilkoblinger
+  CurrentMessagesInQueue: Nåværende melding i <span class='title'>%{queue}</span>
+  Dashboard: Oversikt
+  Dead: Død
+  DeadJobs: Døde jobber
+  Delete: Slett
   DeleteAll: Slett alle
-  RetryAll: Forsøk alle på nytt
-  NoRetriesFound: Ingen forsøk funnet
+  Enqueued: I kø
   Error: Feil
+  ErrorBacktrace: Feilbakgrunn
   ErrorClass: Feilklasse
   ErrorMessage: Feilmelding
-  ErrorBacktrace: Feilbakgrunn
-  GoBack: ← Tilbake
-  NoScheduledFound: Ingen planlagte jobber funnet
-  When: Når
-  ScheduledJobs: Planlagte jobber
-  idle: uvirksom
-  active: aktiv
-  Version: Versjon
-  Connections: Tilkoblinger
-  MemoryUsage: Minneforbruk
-  PeakMemoryUsage: Høyeste minneforbruk
-  Uptime: Oppetid (dager)
-  OneWeek: 1 uke
-  OneMonth: 1 måned
-  ThreeMonths: 3 måneder
-  SixMonths: 6 måneder
-  Batches: Samlinger
+  Extras: Ekstra
+  Failed: Mislykket
   Failures: Feil
-  DeadJobs: Døde jobber
+  GoBack: ← Tilbake
+  History: Historikk
+  idle: uvirksom
+  Job: Jobb
+  Jobs: Jobber
+  LastRetry: Forrige forsøk
+  LivePoll: Automatisk oppdatering
+  MemoryUsage: Minneforbruk
+  Namespace: Navnerom
+  NextRetry: Neste forsøk
   NoDeadJobsFound: Ingen døde jobber funnet
-  Dead: Død
+  NoRetriesFound: Ingen forsøk funnet
+  NoScheduledFound: Ingen planlagte jobber funnet
+  OneMonth: 1 måned
+  OneWeek: 1 uke
+  OriginallyFailed: Feilet opprinnelig
+  PeakMemoryUsage: Høyeste minneforbruk
+  Processed: Prosessert
   Processes: Prosesser
+  Queue: Kø
+  Queues: Køer
+  Realtime: Sanntid
+  Retries: Forsøk
+  RetryAll: Forsøk alle på nytt
+  RetryCount: Antall forsøk
+  RetryNow: Forsøk igjen nå
+  Scheduled: Planlagt
+  ScheduledJobs: Planlagte jobber
+  ShowAll: Vis alle
+  SixMonths: 6 måneder
+  Size: Størrelse
+  Started: Startet
+  Status: Status
+  StopPolling: Stopp automatisk oppdatering
   Thread: Tråd
   Threads: Tråder
-  Jobs: Jobber
+  ThreeMonths: 3 måneder
+  Time: Tid
+  Uptime: Oppetid (dager)
+  Version: Versjon
+  When: Når
+  Worker: Arbeider

--- a/web/locales/pl.yml
+++ b/web/locales/pl.yml
@@ -1,59 +1,59 @@
 # elements like %{queue} are variables and should not be translated
 pl:
-  Dashboard: Kokpit
-  Status: Status
-  Time: Czas
-  Namespace: Przestrzeń nazw
-  Realtime: Czas rzeczywisty
-  History: Historia
-  Busy: Zajęte
-  Processed: Ukończone
-  Failed: Nieudane
-  Scheduled: Zaplanowane
-  Retries: Prób
-  Enqueued: Zakolejkowane
-  Worker: Worker
-  LivePoll: Wczytuj na żywo
-  StopPolling: Zatrzymaj wczytywanie na żywo
-  Queue: Kolejka
-  Class: Klasa
-  Job: Zadanie
-  Arguments: Argumenty
-  Started: Rozpoczęte
-  ShowAll: Pokaż wszystko
-  CurrentMessagesInQueue: Aktualne wiadomości w kolejce <span class='title'>%{queue}</span>
-  Delete: Usuń
+  Actions: Akcje
+  active: aktywne
   AddToQueue: dodaj do kolejki
+  AreYouSure: Na pewno?
   AreYouSureDeleteJob: Czy na pewno usunąć to zadanie?
   AreYouSureDeleteQueue: Czy na pewno usunąć kolejkę %{queue}?
-  Queues: Kolejki
-  Size: Rozmiar
-  Actions: Akcje
-  NextRetry: Kolejna próba
-  RetryCount: Liczba prób
-  RetryNow: Ponów teraz
-  LastRetry: Ostatnie ponowienie
-  OriginallyFailed: Ostatnio nieudane
-  AreYouSure: Na pewno?
+  Arguments: Argumenty
+  Busy: Zajęte
+  Class: Klasa
+  Connections: Połączenia
+  CurrentMessagesInQueue: Aktualne wiadomości w kolejce <span class='title'>%{queue}</span>
+  Dashboard: Kokpit
+  Delete: Usuń
   DeleteAll: Usuń wszystko
-  RetryAll: Powtórz wszystko
-  NoRetriesFound: Brak powtórzeń
+  Enqueued: Zakolejkowane
   Error: Błąd
+  ErrorBacktrace: Wyjście błędu
   ErrorClass: Klasa błędu
   ErrorMessage: Wiadomosć błędu
-  ErrorBacktrace: Wyjście błędu
+  Failed: Nieudane
   GoBack: ← Wróć
-  NoScheduledFound: Brak zaplanowanych zadań
-  When: Kiedy
-  ScheduledJobs: Zaplanowane zadania
+  History: Historia
   idle: bezczynne
-  active: aktywne
-  Version: Wersja
-  Connections: Połączenia
+  Job: Zadanie
+  LastRetry: Ostatnie ponowienie
+  LivePoll: Wczytuj na żywo
   MemoryUsage: Wykorzystanie pamięci
-  PeakMemoryUsage: Największe wykorzystanie pamięci
-  Uptime: Uptime (dni)
-  OneWeek: 1 tydzień
+  Namespace: Przestrzeń nazw
+  NextRetry: Kolejna próba
+  NoRetriesFound: Brak powtórzeń
+  NoScheduledFound: Brak zaplanowanych zadań
   OneMonth: 1 miesiąc
-  ThreeMonths: 3 miesiące
+  OneWeek: 1 tydzień
+  OriginallyFailed: Ostatnio nieudane
+  PeakMemoryUsage: Największe wykorzystanie pamięci
+  Processed: Ukończone
+  Queue: Kolejka
+  Queues: Kolejki
+  Realtime: Czas rzeczywisty
+  Retries: Prób
+  RetryAll: Powtórz wszystko
+  RetryCount: Liczba prób
+  RetryNow: Ponów teraz
+  Scheduled: Zaplanowane
+  ScheduledJobs: Zaplanowane zadania
+  ShowAll: Pokaż wszystko
   SixMonths: 6 miesięcy
+  Size: Rozmiar
+  Started: Rozpoczęte
+  Status: Status
+  StopPolling: Zatrzymaj wczytywanie na żywo
+  ThreeMonths: 3 miesiące
+  Time: Czas
+  Uptime: Uptime (dni)
+  Version: Wersja
+  When: Kiedy
+  Worker: Worker

--- a/web/locales/pt-br.yml
+++ b/web/locales/pt-br.yml
@@ -1,68 +1,68 @@
 # elements like %{queue} are variables and should not be translated
 "pt-br":
-  Dashboard: Painel
-  Status: Status
-  Time: Tempo
-  Namespace: Namespace
-  Realtime: Tempo real
-  History: Histórico
-  Busy: Ocupados
-  Processed: Processados
-  Failed: Falhas
-  Scheduled: Agendados
-  Retries: Tentativas
-  Enqueued: Na fila
-  Worker: Trabalhador
-  LivePoll: Live Poll
-  StopPolling: Parar Polling
-  Queue: Fila
-  Class: Classe
-  Job: Tarefa
-  Arguments: Argumentos
-  Extras: Extras
-  Started: Iniciados
-  ShowAll: Mostrar todos
-  CurrentMessagesInQueue: Mensagens atualmente na <span class='title'>%{queue}</span>
-  Delete: Apagar
+  Actions: Ações
+  active: ativo
   AddToQueue: Adicionar à fila
+  AreYouSure: Tem certeza?
   AreYouSureDeleteJob: Deseja deletar esta tarefa?
   AreYouSureDeleteQueue: Deseja deletar a %{queue} fila?
-  Queues: Filas
-  Size: Tamanho
-  Actions: Ações
-  NextRetry: Próxima Tentativa
-  RetryCount: Número de Tentativas
-  RetryNow: Tentar novamente agora
-  LastRetry: Última tentativa
-  OriginallyFailed: Falhou originalmente
-  AreYouSure: Tem certeza?
+  Arguments: Argumentos
+  Busy: Ocupados
+  Class: Classe
+  Connections: Conexões
+  CurrentMessagesInQueue: Mensagens atualmente na <span class='title'>%{queue}</span>
+  Dashboard: Painel
+  Dead : Morta
+  DeadJobs : Tarefas mortas
+  Delete: Apagar
   DeleteAll: Apagar tudo
-  RetryAll: Tentar tudo novamente
-  NoRetriesFound: Nenhuma tentativa encontrada
+  Enqueued: Na fila
   Error: Erro
+  ErrorBacktrace: Rastreamento do erro
   ErrorClass: Classe de erro
   ErrorMessage: Mensagem de erro
-  ErrorBacktrace: Rastreamento do erro
-  GoBack: ← Voltar
-  NoScheduledFound: Nenhuma tarefa agendada foi encontrada
-  When: Quando
-  ScheduledJobs: Tarefas agendadas
-  idle: ocioso
-  active: ativo
-  Version: Versão
-  Connections: Conexões
-  MemoryUsage: Uso de memória
-  PeakMemoryUsage: Pico de uso de memória
-  Uptime: Dias rodando
-  OneWeek: 1 semana
-  OneMonth: 1 mês
-  ThreeMonths: 3 meses
-  SixMonths: 6 meses
+  Extras: Extras
+  Failed: Falhas
   Failures : Falhas
-  DeadJobs : Tarefas mortas
+  GoBack: ← Voltar
+  History: Histórico
+  idle: ocioso
+  Job: Tarefa
+  Jobs : Tarefas
+  LastRetry: Última tentativa
+  LivePoll: Live Poll
+  MemoryUsage: Uso de memória
+  Namespace: Namespace
+  NextRetry: Próxima Tentativa
   NoDeadJobsFound : Nenhuma tarefa morta foi encontrada
-  Dead : Morta
+  NoRetriesFound: Nenhuma tentativa encontrada
+  NoScheduledFound: Nenhuma tarefa agendada foi encontrada
+  OneMonth: 1 mês
+  OneWeek: 1 semana
+  OriginallyFailed: Falhou originalmente
+  PeakMemoryUsage: Pico de uso de memória
+  Processed: Processados
   Processes : Processos
+  Queue: Fila
+  Queues: Filas
+  Realtime: Tempo real
+  Retries: Tentativas
+  RetryAll: Tentar tudo novamente
+  RetryCount: Número de Tentativas
+  RetryNow: Tentar novamente agora
+  Scheduled: Agendados
+  ScheduledJobs: Tarefas agendadas
+  ShowAll: Mostrar todos
+  SixMonths: 6 meses
+  Size: Tamanho
+  Started: Iniciados
+  Status: Status
+  StopPolling: Parar Polling
   Thread : Thread
   Threads : Threads
-  Jobs : Tarefas
+  ThreeMonths: 3 meses
+  Time: Tempo
+  Uptime: Dias rodando
+  Version: Versão
+  When: Quando
+  Worker: Trabalhador

--- a/web/locales/pt.yml
+++ b/web/locales/pt.yml
@@ -1,67 +1,67 @@
 # elements like %{queue} are variables and should not be translated
 pt:
-  Dashboard: Dashboard
-  Status: Estado
-  Time: Tempo
-  Namespace: Namespace
-  Realtime: Tempo real
-  History: Histórico
-  Busy: Ocupado
-  Processed: Processados
-  Failed: Falhados
-  Scheduled: Agendados
-  Retries: Tentativas
-  Enqueued: Em espera
-  Worker: Worker
-  LivePoll: Live Poll
-  StopPolling: Desactivar Live Poll
-  Queue: Fila
-  Class: Classe
-  Job: Tarefa
-  Arguments: Argumentos
-  Started: Iniciados
-  ShowAll: Mostrar todos
-  CurrentMessagesInQueue: Mensagens na fila <span class='title'>%{queue}</span>
-  Delete: Apagar
+  Actions: Acções
+  active: activo
   AddToQueue: Adicionar à fila
+  AreYouSure: Tem a certeza?
   AreYouSureDeleteJob: Tem a certeza que deseja eliminar esta tarefa?
   AreYouSureDeleteQueue: Tem a certeza que deseja eliminar a fila %{queue}?
-  Queues: Filas
-  Size: Tamanho
-  Actions: Acções
-  NextRetry: Próxima Tentativa
-  RetryCount: Tentativas efectuadas
-  RetryNow: Tentar novamente
-  LastRetry: Última Tentativa
-  OriginallyFailed: Falhou inicialmente
-  AreYouSure: Tem a certeza?
+  Arguments: Argumentos
+  Busy: Ocupado
+  Class: Classe
+  Connections: Conexões
+  CurrentMessagesInQueue: Mensagens na fila <span class='title'>%{queue}</span>
+  Dashboard: Dashboard
+  Dead: Morto
+  DeadJobs: Tarefas mortas
+  Delete: Apagar
   DeleteAll: Eliminar todos
-  RetryAll: Tentar tudo novamente
-  NoRetriesFound: Não foram encontradas tentativas
+  Enqueued: Em espera
   Error: Erro
+  ErrorBacktrace: Backtrace do Erro
   ErrorClass: Classe de Erro
   ErrorMessage: Mensagem de erro
-  ErrorBacktrace: Backtrace do Erro
-  GoBack: ← Voltar
-  NoScheduledFound: Não foram encontradas tarefas agendadas
-  When: Quando
-  ScheduledJobs: Tarefas agendadas
-  idle: livre
-  active: activo
-  Version: Versão
-  Connections: Conexões
-  MemoryUsage: Utilização de Memória
-  PeakMemoryUsage: Pico de utilização de memória
-  Uptime: Uptime (em dias)
-  OneWeek: 1 semana
-  OneMonth: 1 mês
-  ThreeMonths: 3 meses
-  SixMonths: 6 meses
+  Failed: Falhados
   Failures: Falhas
-  DeadJobs: Tarefas mortas
+  GoBack: ← Voltar
+  History: Histórico
+  idle: livre
+  Job: Tarefa
+  Jobs: Tarefas
+  LastRetry: Última Tentativa
+  LivePoll: Live Poll
+  MemoryUsage: Utilização de Memória
+  Namespace: Namespace
+  NextRetry: Próxima Tentativa
   NoDeadJobsFound: Não foram encontradas tarefas mortas
-  Dead: Morto
+  NoRetriesFound: Não foram encontradas tentativas
+  NoScheduledFound: Não foram encontradas tarefas agendadas
+  OneMonth: 1 mês
+  OneWeek: 1 semana
+  OriginallyFailed: Falhou inicialmente
+  PeakMemoryUsage: Pico de utilização de memória
+  Processed: Processados
   Processes: Processos
+  Queue: Fila
+  Queues: Filas
+  Realtime: Tempo real
+  Retries: Tentativas
+  RetryAll: Tentar tudo novamente
+  RetryCount: Tentativas efectuadas
+  RetryNow: Tentar novamente
+  Scheduled: Agendados
+  ScheduledJobs: Tarefas agendadas
+  ShowAll: Mostrar todos
+  SixMonths: 6 meses
+  Size: Tamanho
+  Started: Iniciados
+  Status: Estado
+  StopPolling: Desactivar Live Poll
   Thread: Thread
   Threads: Threads
-  Jobs: Tarefas
+  ThreeMonths: 3 meses
+  Time: Tempo
+  Uptime: Uptime (em dias)
+  Version: Versão
+  When: Quando
+  Worker: Worker

--- a/web/locales/ru.yml
+++ b/web/locales/ru.yml
@@ -1,74 +1,75 @@
+# такие элементы как %{queue} являются переменными и не переводятся
 ru:
-  Dashboard: Панель управления
-  Status: Статус
-  Time: Время
-  Namespace: Пространоство имен
-  Realtime: Сейчас
-  History: История
-  Busy: Занят
-  Processed: Обработано
-  Failed: Провалено
-  Scheduled: Запланировано
-  Retries: Попытки
-  Enqueued: В очереди
-  Worker: Обработчик
-  LivePoll: Постоянный опрос
-  StopPolling: Остановить опрос
-  Queue: Очередь
-  Class: Класс
-  Job: Задача
-  Arguments: Аргументы
-  Extras: Дополнительно
-  Started: Запущено
-  ShowAll: Показать все
-  CurrentMessagesInQueue: Текущие задачи в очереди <span class='title'>%{queue}</span>
-  Delete: Удалить
+  Actions: Действия
+  active: активен
   AddToQueue: Добавить в очередь
+  AreYouSure: Вы уверены?
   AreYouSureDeleteJob: Вы уверены, что хотите удалить эту задачу?
   AreYouSureDeleteQueue: Вы уверены, что хотите удалить очередь %{queue}?
-  Queues: Очереди
-  Size: Размер
-  Actions: Действия
-  NextRetry: Следующая попытка
-  RetryCount: Кол-во попыток
-  RetryNow: Повторить сейчас
-  Kill: Убиваем
-  LastRetry: Последняя попытка
-  OriginallyFailed: Первый провал
-  AreYouSure: Вы уверены?
+  Arguments: Аргументы
+  Busy: Занят
+  Class: Класс
+  Connections: Соединения
+  CurrentMessagesInQueue: Текущие задачи в очереди <span class='title'>%{queue}</span>
+  Dashboard: Панель управления
+  Dead: Убито
+  DeadJobs: Убитые задачи
+  Delete: Удалить
   DeleteAll: Удалить все
-  RetryAll: Повторить все
-  NoRetriesFound: Нет попыток
+  Enqueued: В очереди
   Error: Ошибка
+  ErrorBacktrace: Трассировка ошибки
   ErrorClass: Класс ошибки
   ErrorMessage: Сообщение об ошибке
-  ErrorBacktrace: Трассировка ошибки
-  GoBack: ← Назад
-  NoScheduledFound: Нет запланированных задач
-  When: Когда
-  ScheduledJobs: Запланированные задачи
-  idle: отдыхает
-  active: активен
-  Version: Версия
-  Connections: Соединения
-  MemoryUsage: Использование памяти
-  PeakMemoryUsage: Максимальный расход памяти
-  Uptime: Дня(ей) бесперебойной работы
-  OneWeek: 1 неделя
-  OneMonth: 1 месяц
-  ThreeMonths: 3 месяца
-  SixMonths: 6 месяцев
+  Extras: Дополнительно
+  Failed: Провалено
   Failures: Провалы
-  DeadJobs: Убитые задачи
+  GoBack: ← Назад
+  History: История
+  idle: отдыхает
+  Job: Задача
+  Jobs: Задачи
+  Kill: Убиваем
+  LastRetry: Последняя попытка
+  LivePoll: Постоянный опрос
+  MemoryUsage: Использование памяти
+  Namespace: Пространство имен
+  NextRetry: Следующая попытка
   NoDeadJobsFound: Нет убитых задач
-  Dead: Убито
+  NoRetriesFound: Нет попыток
+  NoScheduledFound: Нет запланированных задач
+  OneMonth: 1 месяц
+  OneWeek: 1 неделя
+  OriginallyFailed: Первый провал
+  Paused: Приостановлено
+  PeakMemoryUsage: Максимальный расход памяти
+  PollingInterval: Интервал опроса
+  Processed: Обработано
   Processes: Процессы
+  Queue: Очередь
+  Queues: Очереди
+  Quiet: Отдыхать
+  QuietAll: Отдыхать всем
+  Realtime: Сейчас
+  Retries: Попытки
+  RetryAll: Повторить все
+  RetryCount: Кол-во попыток
+  RetryNow: Повторить сейчас
+  Scheduled: Запланировано
+  ScheduledJobs: Запланированные задачи
+  ShowAll: Показать все
+  SixMonths: 6 месяцев
+  Size: Размер
+  Started: Запущено
+  Status: Статус
+  Stop: Остановить
+  StopAll: Остановить все
+  StopPolling: Остановить опрос
   Thread: Поток
   Threads: Потоки
-  Jobs: Задачи
-  Paused: Приостановлено
-  Stop: Остановить
-  Quiet: Отдыхать
-  StopAll: Остановить все
-  QuietAll: Отдыхать всем
-  PollingInterval: Интервал опроса
+  ThreeMonths: 3 месяца
+  Time: Время
+  Uptime: Дня(ей) бесперебойной работы
+  Version: Версия
+  When: Когда
+  Worker: Обработчик

--- a/web/locales/sv.yml
+++ b/web/locales/sv.yml
@@ -1,68 +1,68 @@
 # elements like %{queue} are variables and should not be translated
 sv: # <---- change this to your locale code
-  Dashboard: Panel
-  Status: Status
-  Time: Tid
-  Namespace: Namnrymd
-  Realtime: Realtid
-  History: Historik
-  Busy: Upptagen
-  Processed: Processerad
-  Failed: Misslyckad
-  Scheduled: Schemalagd
-  Retries: Försök
-  Enqueued: Köad
-  Worker: Worker
-  LivePoll: Live poll
-  StopPolling: Stoppa polling
-  Queue: Kö
-  Class: Klass
-  Job: Jobb
-  Arguments: Argument
-  Extras: Extra
-  Started: Startad
-  ShowAll: Visa alla
-  CurrentMessagesInQueue: Jobb i <span class='title'>%{queue}</span>
-  Delete: Ta bort
+  Actions: Åtgärder
+  active: aktiv
   AddToQueue: Lägg till i kö
+  AreYouSure: Är du säker?
   AreYouSureDeleteJob: Är du säker på att du vill ta bort detta jobb?
   AreYouSureDeleteQueue: Är du säker på att du vill ta bort kön %{queue}?
-  Queues: Köer
-  Size: Storlek
-  Actions: Åtgärder
-  NextRetry: Nästa försök
-  RetryCount: Antal försök
-  RetryNow: Försök nu
-  LastRetry: Senaste försök
-  OriginallyFailed: Misslyckades ursprungligen
-  AreYouSure: Är du säker?
+  Arguments: Argument
+  Busy: Upptagen
+  Class: Klass
+  Connections: Anslutningar
+  CurrentMessagesInQueue: Jobb i <span class='title'>%{queue}</span>
+  Dashboard: Panel
+  Dead: Död
+  DeadJobs: Döda jobb
+  Delete: Ta bort
   DeleteAll: Ta bort alla
-  RetryAll: Försök alla igen
-  NoRetriesFound: Inga försök hittades
+  Enqueued: Köad
   Error: Fel
+  ErrorBacktrace: Backtrace för fel
   ErrorClass: Felklass
   ErrorMessage: Felmeddelande
-  ErrorBacktrace: Backtrace för fel
-  GoBack: ← Bakåt
-  NoScheduledFound: Inga schemalagda jobb hittades
-  When: När
-  ScheduledJobs: Schemalagda jobb
-  idle: avvaktande
-  active: aktiv
-  Version: Version
-  Connections: Anslutningar
-  MemoryUsage: Minnesanvändning
-  PeakMemoryUsage: Minnesanvändning (peak)
-  Uptime: Upptid (dagar)
-  OneWeek: 1 vecka
-  OneMonth: 1 månad
-  ThreeMonths: 3 månader
-  SixMonths: 6 månader
+  Extras: Extra
+  Failed: Misslyckad
   Failures: Failures
-  DeadJobs: Döda jobb
+  GoBack: ← Bakåt
+  History: Historik
+  idle: avvaktande
+  Job: Jobb
+  Jobs: Jobb
+  LastRetry: Senaste försök
+  LivePoll: Live poll
+  MemoryUsage: Minnesanvändning
+  Namespace: Namnrymd
+  NextRetry: Nästa försök
   NoDeadJobsFound: Inga döda jobb hittades
-  Dead: Död
+  NoRetriesFound: Inga försök hittades
+  NoScheduledFound: Inga schemalagda jobb hittades
+  OneMonth: 1 månad
+  OneWeek: 1 vecka
+  OriginallyFailed: Misslyckades ursprungligen
+  PeakMemoryUsage: Minnesanvändning (peak)
+  Processed: Processerad
   Processes: Processer
+  Queue: Kö
+  Queues: Köer
+  Realtime: Realtid
+  Retries: Försök
+  RetryAll: Försök alla igen
+  RetryCount: Antal försök
+  RetryNow: Försök nu
+  Scheduled: Schemalagd
+  ScheduledJobs: Schemalagda jobb
+  ShowAll: Visa alla
+  SixMonths: 6 månader
+  Size: Storlek
+  Started: Startad
+  Status: Status
+  StopPolling: Stoppa polling
   Thread: Tråd
   Threads: Trådar
-  Jobs: Jobb
+  ThreeMonths: 3 månader
+  Time: Tid
+  Uptime: Upptid (dagar)
+  Version: Version
+  When: När
+  Worker: Worker

--- a/web/locales/zh-cn.yml
+++ b/web/locales/zh-cn.yml
@@ -1,68 +1,68 @@
 # elements like %{queue} are variables and should not be translated
 zh-cn: # <---- change this to your locale code
-  Dashboard: 信息板
-  Status: 状态
-  Time: 时间
-  Namespace: 命名空间
-  Realtime: 实时
-  History: 历史记录
-  Busy: 执行中
-  Processed: 已处理
-  Failed: 已失败
-  Scheduled: 已计划
-  Retries: 重试
-  Enqueued: 已进入队列
-  Worker: 工人
-  LivePoll: 实时轮询
-  StopPolling: 停止轮询
-  Queue: 队列
-  Class: 类别
-  Job: 作业
-  Arguments: 参数
-  Extras: 额外的
-  Started: 已开始
-  ShowAll: 显示全部
-  CurrentMessagesInQueue: 目前在<span class='title'>%{queue}</span>的作业
-  Delete: 删除
+  Actions: 动作
+  active: 活动中
   AddToQueue: 添加至队列
+  AreYouSure: 你确定？
   AreYouSureDeleteJob: 你确定要删除这个作业么？
   AreYouSureDeleteQueue: 你确定要删除%{queue}这个队列？
-  Queues: 队列
-  Size: 容量
-  Actions: 动作
-  NextRetry: 下次重试
-  RetryCount: 重试次數
-  RetryNow: 现在重试
-  LastRetry: 最后一次重试
-  OriginallyFailed: 原本已失败
-  AreYouSure: 你确定？
+  Arguments: 参数
+  Busy: 执行中
+  Class: 类别
+  Connections: 连接
+  CurrentMessagesInQueue: 目前在<span class='title'>%{queue}</span>的作业
+  Dashboard: 信息板
+  Dead: 已停滞
+  DeadJobs: 已停滞作业
+  Delete: 删除
   DeleteAll: 删除全部
-  RetryAll: 重试全部
-  NoRetriesFound: 沒有发现可重试
+  Enqueued: 已进入队列
   Error: 错误
+  ErrorBacktrace: 错误的回调追踪
   ErrorClass: 错误类别
   ErrorMessage: 错误消息
-  ErrorBacktrace: 错误的回调追踪
-  GoBack: ← 返回
-  NoScheduledFound: 沒有发现计划作业
-  When: 当
-  ScheduledJobs: 计划作业
-  idle: 闲置
-  active: 活动中
-  Version: 版本
-  Connections: 连接
-  MemoryUsage: 内存占用
-  PeakMemoryUsage: 内存占用峰值
-  Uptime: 上线时间 (天数)
-  OneWeek: 一周
-  OneMonth: 一个月
-  ThreeMonths: 三个月
-  SixMonths: 六个月
+  Extras: 额外的
+  Failed: 已失败
   Failures: 失败
-  DeadJobs: 已停滞作业
+  GoBack: ← 返回
+  History: 历史记录
+  idle: 闲置
+  Job: 作业
+  Jobs: 作业
+  LastRetry: 最后一次重试
+  LivePoll: 实时轮询
+  MemoryUsage: 内存占用
+  Namespace: 命名空间
+  NextRetry: 下次重试
   NoDeadJobsFound: 沒有发现任何已停滞的作业
-  Dead: 已停滞
+  NoRetriesFound: 沒有发现可重试
+  NoScheduledFound: 沒有发现计划作业
+  OneMonth: 一个月
+  OneWeek: 一周
+  OriginallyFailed: 原本已失败
+  PeakMemoryUsage: 内存占用峰值
+  Processed: 已处理
   Processes: 处理中
+  Queue: 队列
+  Queues: 队列
+  Realtime: 实时
+  Retries: 重试
+  RetryAll: 重试全部
+  RetryCount: 重试次數
+  RetryNow: 现在重试
+  Scheduled: 已计划
+  ScheduledJobs: 计划作业
+  ShowAll: 显示全部
+  SixMonths: 六个月
+  Size: 容量
+  Started: 已开始
+  Status: 状态
+  StopPolling: 停止轮询
   Thread: 线程
   Threads: 线程
-  Jobs: 作业
+  ThreeMonths: 三个月
+  Time: 时间
+  Uptime: 上线时间 (天数)
+  Version: 版本
+  When: 当
+  Worker: 工人

--- a/web/locales/zh-tw.yml
+++ b/web/locales/zh-tw.yml
@@ -1,68 +1,68 @@
 # elements like %{queue} are variables and should not be translated
 zh-tw: # <---- change this to your locale code
-  Dashboard: 資訊主頁
-  Status: 狀態
-  Time: 時間
-  Namespace: 命名空間
-  Realtime: 即時
-  History: 歷史資料
-  Busy: 忙碌
-  Processed: 已處理
-  Failed: 已失敗
-  Scheduled: 已排程
-  Retries: 重試
-  Enqueued: 已佇列
-  Worker: 工人
-  LivePoll: 即時輪詢
-  StopPolling: 停止輪詢
-  Queue: 佇列
-  Class: 類別
-  Job: 工作
-  Arguments: 參數
-  Extras: 額外的
-  Started: 已開始
-  ShowAll: 顯示全部
-  CurrentMessagesInQueue: 目前在<span class='title'>%{queue}</span>的工作
-  Delete: 刪除
+  Actions: 動作
+  active: 活動中
   AddToQueue: 增加至佇列
+  AreYouSure: 你確定？
   AreYouSureDeleteJob: 你確定要刪除這個工作嗎？
   AreYouSureDeleteQueue: 你確定要刪除%{queue}這個佇列？
-  Queues: 佇列
-  Size: 容量
-  Actions: 動作
-  NextRetry: 下次重試
-  RetryCount: 重試次數
-  RetryNow: 馬上重試
-  LastRetry: 最後一次重試
-  OriginallyFailed: 原本已失敗
-  AreYouSure: 你確定？
+  Arguments: 參數
+  Busy: 忙碌
+  Class: 類別
+  Connections: 連線
+  CurrentMessagesInQueue: 目前在<span class='title'>%{queue}</span>的工作
+  Dashboard: 資訊主頁
+  Dead: 停滯
+  DeadJobs: 停滯工作
+  Delete: 刪除
   DeleteAll: 刪除全部
-  RetryAll: 重試全部
-  NoRetriesFound: 沒有發現可重試
+  Enqueued: 已佇列
   Error: 錯誤
+  ErrorBacktrace: 錯誤的回調追踨
   ErrorClass: 錯誤類別
   ErrorMessage: 錯誤訊息
-  ErrorBacktrace: 錯誤的回調追踨
-  GoBack: ← 返回
-  NoScheduledFound: 沒有發現已排程的工作
-  When: 當
-  ScheduledJobs: 已排程的工作
-  idle: 閒置
-  active: 活動中
-  Version: 版本
-  Connections: 連線
-  MemoryUsage: 記憶體使用量
-  PeakMemoryUsage: 尖峰記憶體使用量
-  Uptime: 上線時間 (天數)
-  OneWeek: 一週
-  OneMonth: 一個月
-  ThreeMonths: 三個月
-  SixMonths: 六個月
+  Extras: 額外的
+  Failed: 已失敗
   Failures: 失敗
-  DeadJobs: 停滯工作
+  GoBack: ← 返回
+  History: 歷史資料
+  idle: 閒置
+  Job: 工作
+  Jobs: 工作
+  LastRetry: 最後一次重試
+  LivePoll: 即時輪詢
+  MemoryUsage: 記憶體使用量
+  Namespace: 命名空間
+  NextRetry: 下次重試
   NoDeadJobsFound: 沒有發現任何停滯的工作
-  Dead: 停滯
+  NoRetriesFound: 沒有發現可重試
+  NoScheduledFound: 沒有發現已排程的工作
+  OneMonth: 一個月
+  OneWeek: 一週
+  OriginallyFailed: 原本已失敗
+  PeakMemoryUsage: 尖峰記憶體使用量
+  Processed: 已處理
   Processes: 處理中
+  Queue: 佇列
+  Queues: 佇列
+  Realtime: 即時
+  Retries: 重試
+  RetryAll: 重試全部
+  RetryCount: 重試次數
+  RetryNow: 馬上重試
+  Scheduled: 已排程
+  ScheduledJobs: 已排程的工作
+  ShowAll: 顯示全部
+  SixMonths: 六個月
+  Size: 容量
+  Started: 已開始
+  Status: 狀態
+  StopPolling: 停止輪詢
   Thread: 執行緒
   Threads: 執行緒
-  Jobs: 工作
+  ThreeMonths: 三個月
+  Time: 時間
+  Uptime: 上線時間 (天數)
+  Version: 版本
+  When: 當
+  Worker: 工人


### PR DESCRIPTION
I decide to check Russian locale on errors and missing keys and realized that its pretty hard to compare two files then keys have a random sort

This PR had sorted all keys for all locales for more convinient and faster translating