### PR TITLE
Processor is not required as needed

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -154,4 +154,5 @@ end
 require 'sidekiq/extensions/class_methods'
 require 'sidekiq/extensions/action_mailer'
 require 'sidekiq/extensions/active_record'
+require 'sidekiq/processor'
 require 'sidekiq/rails' if defined?(::Rails::Engine)


### PR DESCRIPTION
Calling Sidekiq.server_middleware will actually cause it to crash; This requires it earlier so that doesn't happen, but not late enough that we can't include it.