### PR TITLE
Allows configuration of the Dead Job Queue.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+3.3.2 (unreleased)
+-----------
+- Allows configuration of dead job set size and timeout
+
 3.3.1
 -----------
 

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -25,7 +25,9 @@ module Sidekiq
       startup: [],
       quiet: [],
       shutdown: [],
-    }
+    },
+    dead_max_jobs: 10_000,
+    dead_timeout_in_seconds: 180 * 24 * 60 * 60 # 6 months
   }
 
   def self.❨╯°□°❩╯︵┻━┻

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -399,8 +399,8 @@ module Sidekiq
         Sidekiq.redis do |conn|
           conn.multi do
             conn.zadd('dead', now, message)
-            conn.zremrangebyscore('dead', '-inf', now - DeadSet::TIMEOUT)
-            conn.zremrangebyrank('dead', 0, - DeadSet::MAX_JOBS)
+            conn.zremrangebyscore('dead', '-inf', now - DeadSet.timeout)
+            conn.zremrangebyrank('dead', 0, - DeadSet.max_jobs)
           end
         end
       end
@@ -593,9 +593,6 @@ module Sidekiq
   # Allows enumeration of dead jobs within Sidekiq.
   #
   class DeadSet < JobSet
-    TIMEOUT = 180 * 24 * 60 * 60 # 6 months
-    MAX_JOBS = 10_000
-
     def initialize
       super 'dead'
     end
@@ -604,6 +601,14 @@ module Sidekiq
       while size > 0
         each(&:retry)
       end
+    end
+
+    def self.max_jobs
+      Sidekiq.options[:dead_max_jobs]
+    end
+
+    def self.timeout
+      Sidekiq.options[:dead_timeout_in_seconds]
     end
   end
 

--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -156,8 +156,8 @@ module Sidekiq
           Sidekiq.redis do |conn|
             conn.multi do
               conn.zadd('dead', now, payload)
-              conn.zremrangebyscore('dead', '-inf', now - DeadSet::TIMEOUT)
-              conn.zremrangebyrank('dead', 0, -DeadSet::MAX_JOBS)
+              conn.zremrangebyscore('dead', '-inf', now - DeadSet.timeout)
+              conn.zremrangebyrank('dead', 0, -DeadSet.max_jobs)
             end
           end
         end


### PR DESCRIPTION
We're going to start using the dead jobs. 10,000 jobs may be too small for us, I'd like to be able to configure it.

If this pull is merged in, I'll update the wiki.