### PR TITLE
Add an environment variable for backtrace depth:

### DIFF
--- a/lib/sidekiq/exception_handler.rb
+++ b/lib/sidekiq/exception_handler.rb
@@ -2,12 +2,12 @@ require 'sidekiq'
 
 module Sidekiq
   module ExceptionHandler
-
     class Logger
       def call(ex, ctxHash)
+        exception_backtrace_depth = ENV.fetch("SIDEKIQ_EXCEPTION_BACKTRACE_DEPTH", -1).to_i
         Sidekiq.logger.warn(ctxHash) if !ctxHash.empty?
         Sidekiq.logger.warn ex
-        Sidekiq.logger.warn ex.backtrace.join("\n") unless ex.backtrace.nil?
+        Sidekiq.logger.warn ex.backtrace[0..exception_backtrace_depth].join("\n") unless ex.backtrace.nil?
       end
 
       # Set up default handler which just logs the error


### PR DESCRIPTION
We use exceptions for handing exceptional cases in our pipeline. We're seeing our papertrail logs fill up with spam from framework-level backtrace ; this adds an environment variable to cut that down to fewer lines.