### PR TITLE
Changed &block method argument to yield construction

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -240,7 +240,7 @@ module Sidekiq
     end
 
     def find_job(jid)
-      self.detect { |j| j.jid == jid }
+      detect { |j| j.jid == jid }
     end
 
     def clear

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -218,7 +218,7 @@ module Sidekiq
       Time.now.to_f - Sidekiq.load_json(entry)['enqueued_at']
     end
 
-    def each(&block)
+    def each
       initial_size = size
       deleted_size = 0
       page = 0
@@ -233,7 +233,7 @@ module Sidekiq
         break if entries.empty?
         page += 1
         entries.each do |entry|
-          block.call Job.new(entry, @name)
+          yield Job.new(entry, @name)
         end
         deleted_size = initial_size - size
       end
@@ -474,7 +474,7 @@ module Sidekiq
       end
     end
 
-    def each(&block)
+    def each
       initial_size = @_size
       offset_size = 0
       page = -1
@@ -489,7 +489,7 @@ module Sidekiq
         break if elements.empty?
         page -= 1
         elements.each do |element, score|
-          block.call SortedEntry.new(self, score, element)
+          yield SortedEntry.new(self, score, element)
         end
         offset_size = initial_size - @_size
       end
@@ -651,7 +651,7 @@ module Sidekiq
       count
     end
 
-    def each(&block)
+    def each
       procs = Sidekiq.redis { |conn| conn.smembers('processes') }.sort
 
       Sidekiq.redis do |conn|
@@ -760,7 +760,7 @@ module Sidekiq
   class Workers
     include Enumerable
 
-    def each(&block)
+    def each
       Sidekiq.redis do |conn|
         procs = conn.smembers('processes')
         procs.sort.each do |key|

--- a/lib/sidekiq/middleware/chain.rb
+++ b/lib/sidekiq/middleware/chain.rb
@@ -120,11 +120,11 @@ module Sidekiq
         entries.clear
       end
 
-      def invoke(*args, &final_action)
+      def invoke(*args)
         chain = retrieve.dup
         traverse_chain = lambda do
           if chain.empty?
-            final_action.call
+            yield
           else
             chain.shift.call(*args, &traverse_chain)
           end


### PR DESCRIPTION
Hi,
As you may know `yield` construction more faster than `&block` in arguments (with `block.call`).
For example, for me `yield` faster than `block` to 5 times (ruby 2.1.5; *you can see benchmark below*).
And because that i changed `&block` method arguments on `yield` construction in all methods where `block` isn't need in other methods call.


### Benchmarks
*(all developers love benchmarks :smiley:)*

#### Code for compare yield and block
``` ruby
require 'benchmark/ips'

def yield_proc
  yield
end

def block_proc(&block)
  block.call
end

Benchmark.ips do |x|
  x.report('yield'){ yield_proc{ 1 + 1 } }
  x.report('block'){ block_proc{ 1 + 1 } }
end
```

#### Results
```
Calculating -------------------------------------
               yield   128.265k i/100ms
               block    62.716k i/100ms
-------------------------------------------------
               yield      5.821M (± 5.0%) i/s -     29.116M
               block      1.079M (±24.0%) i/s -      5.143M
```