### PR TITLE
Travis jruby update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ rvm:
   - 2.1
   - 2.0.0
   - 2.2
-  - jruby-19mode
   - jruby
   - rbx-2
 matrix:
   allow_failures:
     - rvm: rbx-2
-    - rvm: jruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ rvm:
   - 2.0.0
   - 2.2
   - jruby
+  - jruby-head
   - rbx-2
 matrix:
   allow_failures:
     - rvm: rbx-2
+    - rvm: jruby-head


### PR DESCRIPTION
Removed jruby-19mode as this is kind of the default now and added testing with jruby-head (that may fail) to help JRuby get prepped for an awesome 9k release :)