### PR TITLE
Add '/stats/monitor' with useful stats for monitoring systems

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -231,7 +231,7 @@ module Sidekiq
         results.map do |json_info, busy|
           info = Sidekiq.load_json(json_info)
           info['busy'] = busy.to_i
-          info['started_at'] = Time.at(info['started_at'])
+          info['started_at'] = Time.at(info['started_at']).iso8601
           info
         end
       end

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -238,6 +238,34 @@ module Sidekiq
       )
     end
 
+    get '/stats/monitor' do
+      queues = Sidekiq::Queue.all
+      processes = Sidekiq::ProcessSet.new
+
+      queue_metrics = queues.each_with_object({}) do |queue, hash|
+        hash[queue.name] = {
+          backlog: queue.size,
+          latency: queue.latency.to_i
+        }
+      end
+
+      process_metrics = processes.map do |process|
+        {
+          hostname:    process['hostname'],
+          pid:         process['pid'],
+          queues:      process['queues'],
+          concurrency: process['concurrency'],
+          busy:        process['busy']
+        }
+      end
+
+      content_type :json
+      Sidekiq.dump_json(
+        queues:    queue_metrics,
+        processes: process_metrics,
+      )
+    end
+
     private
 
     def retry_or_delete_or_kill job, params

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -239,30 +239,12 @@ module Sidekiq
     end
 
     get '/stats/monitor' do
-      queues = Sidekiq::Queue.all
-      processes = Sidekiq::ProcessSet.new
-
-      queue_metrics = queues.each_with_object({}) do |queue, hash|
-        hash[queue.name] = {
-          backlog: queue.size,
-          latency: queue.latency.to_i
-        }
-      end
-
-      process_metrics = processes.map do |process|
-        {
-          hostname:    process['hostname'],
-          pid:         process['pid'],
-          queues:      process['queues'],
-          concurrency: process['concurrency'],
-          busy:        process['busy']
-        }
-      end
+      monitor_stats = Sidekiq::Monitor.new
 
       content_type :json
       Sidekiq.dump_json(
-        queues:    queue_metrics,
-        processes: process_metrics,
+        queues:    monitor_stats.all_queue_metrics,
+        processes: monitor_stats.all_process_metrics
       )
     end
 

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -472,6 +472,45 @@ class TestWeb < Sidekiq::Test
       end
     end
 
+    describe 'stats/monitor' do
+      include Sidekiq::Util
+
+      before do
+        Sidekiq.redis do |conn|
+          conn.sadd("queues", "default")
+          conn.sadd("queues", "queue2")
+          conn.sadd('processes', 'foo:1234')
+
+          process_stats = {
+            'hostname'    => 'foo',
+            'pid'         => 1234,
+            'started_at'  => Time.now.to_f,
+            'queues'      => ['default'],
+            'concurrency' => 25
+          }
+          conn.hmset('foo:1234', 'info', Sidekiq.dump_json(process_stats), 'at', Time.now.to_f, 'busy', 4)
+        end
+
+        get '/stats/monitor'
+        @response = Sidekiq.load_json(last_response.body)
+      end
+
+      it 'returns backlog and latency for queues' do
+        assert_equal 0, @response["queues"]["default"]["backlog"]
+        assert_equal 0, @response["queues"]["default"]["latency"]
+      end
+
+      it 'returns a list of processes' do
+        process_stats = @response["processes"][0]
+
+        assert_equal "foo",       process_stats["hostname"]
+        assert_equal 1234,        process_stats["pid"]
+        assert_equal ["default"], process_stats["queues"]
+        assert_equal 25,          process_stats["concurrency"]
+        assert_equal 4,           process_stats["busy"]
+      end
+    end
+
     describe 'dead jobs' do
       it 'shows empty index' do
         get 'morgue'


### PR DESCRIPTION
We have a custom endpoint in our application that returns this data and we have a couple of sensu scripts that warn us when the maximum latency gets over a certain threshold, and that records the total concurrency, total busy (of all our processes) and maximum latency in statsd.

I'd like to open source the sensu scripts too, but I'd like to make sure what the format will end up being before doing that. [This is how those scripts look](https://github.com/sensu/sensu-community-plugins/compare/master...mrsimo:sidekiq) right now (ignore the link to harvesthq/sidekiq-stats for now).

I opened the PR with this format since this is what we currently use, but as long as the endpoint lets us know those metrics we'd be happy. I realise this clashes a little with the `/stats/queues` endpoint, so I'd like to know what you think. I have no problem refactoring to match whatever we think is best, or close this PR altogether and release this in gem format.

An alternative would be to enhance the `/stats/queues` to also include the latency (we really like the latency metric over the backlog for monitoring) and create a new endpoint `/stats/processes` with the proper information.

This is how the final json would look:

```json
{
  "queues":{
    "default":{
      "backlog":15,
      "latency":2
    },
    "low":{
      "backlog":533,
      "latency":54
    }
  },
  "processes":[
    {
      "hostname":"kip1.example.com",
      "pid":23324,
      "queues":[
        "high"
      ],
      "concurrency":5,
      "busy":2
    },
    {
      "hostname":"kip2.example.com",
      "pid":23390,
      "queues":[
        "low"
      ],
      "concurrency":5,
      "busy":5
    }
  ]
}
```