### PR TITLE
Centered text in footer navbar [tablet view]

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -644,6 +644,7 @@ div.interval-slider input {
   .navbar-text {
     float:none;
     line-height: 30px;
+    margin: 15px auto;
   }
 }
 


### PR DESCRIPTION
Hello!
I found ui bug with text in footer navbar. If you open sidekiq web page on ipad or other tablet you can see something like as:
![screenshot 2015-03-24 23 45 57](https://cloud.githubusercontent.com/assets/1147484/6812524/94d0bdb2-d280-11e4-833a-7dcb8bf0fdf2.jpg)

In my branch this looks like this:
![screenshot 2015-03-24 23 45 41](https://cloud.githubusercontent.com/assets/1147484/6812544/b3c76bee-d280-11e4-9db0-aee8f5d6182e.jpg)

_**P.S.: also I want to suggest hide header navbar on mobile or tablet screen size as well as in the [bootstrap](http://getbootstrap.com/components/#navbar)**_
![screenshot 2015-03-24 23 56 07](https://cloud.githubusercontent.com/assets/1147484/6812754/ee3611e4-d281-11e4-99e5-e8779cd2f75c.jpg)
