### PR TITLE
Improve ActiveJob integration

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,8 @@
 HEAD
 -----------
 
+- **Improve ActiveJob integration** - Web UI now shows ActiveJobs in a
+  nicer format and job logging shows the actual class name [#2248, #2259]
 - Add Sidekiq::Process#dump\_threads API to trigger TTIN output [#2247]
 
 3.3.3

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -283,7 +283,7 @@ module Sidekiq
                      "#{target}.#{method}"
                    end
                  when "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
-                   args[0]
+                   @item['wrapped'] || args[0]
                  else
                    klass
                  end
@@ -297,7 +297,7 @@ module Sidekiq
                     arg
                   end
                 when "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
-                  args[1..-1]
+                  @item['wrapped'] ? args[0]["arguments"] : []
                 else
                   args
                 end

--- a/lib/sidekiq/middleware/server/logging.rb
+++ b/lib/sidekiq/middleware/server/logging.rb
@@ -4,7 +4,11 @@ module Sidekiq
       class Logging
 
         def call(worker, item, queue)
-          Sidekiq::Logging.with_context("#{worker.class.to_s} JID-#{item['jid']}#{" BID-#{item['bid']}" if item['bid']}") do
+          # If we're using a wrapper class, like ActiveJob, use the "wrapped"
+          # attribute to expose the underlying thing.
+          klass = item['wrapped'] || worker.class.to_s
+
+          Sidekiq::Logging.with_context("#{klass} JID-#{item['jid']}#{" BID-#{item['bid']}" if item['bid']}") do
             begin
               start = Time.now
               logger.info { "start" }

--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -129,7 +129,7 @@ module Sidekiq
     RETRY_JOB_KEYS = Set.new(%w(
       queue class args retry_count retried_at failed_at
       jid error_message error_class backtrace
-      error_backtrace enqueued_at retry
+      error_backtrace enqueued_at retry wrapped
     ))
 
     def retry_extra_items(retry_job)


### PR DESCRIPTION
In addition to #2248, it would be nice if the Web UI were a little smarter about showing ActiveJobs.

Before:
![before](https://cloud.githubusercontent.com/assets/2911/6813718/fd862cbc-d234-11e4-864d-a1bd0c2ae962.png)

After:
![screen shot 2015-03-24 at 14 49 02](https://cloud.githubusercontent.com/assets/2911/6813721/01bcdc72-d235-11e4-88fc-32b75a828b49.png)
