### PR TITLE
Change current navbar to collapsed navbar

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -101,11 +101,6 @@ header.row .pagination {
 .poll-wrapper {
     margin: 9px;
 }
-.nav #live-poll {
-  height: 25px;
-  line-height: 25px;
-  width: 195px;
-}
 #live-poll.active {
   background-color: #009300;
 }
@@ -206,6 +201,36 @@ table .table-checkbox label {
 
 .navbar .navbar-brand .status {
   color: #585454;
+}
+
+@media (max-width: 768px) {
+  .navbar .navbar-header .navbar-livereload {
+    border: none;
+    margin: 9px 10px 0;
+    padding: 0;
+  }
+
+  .navbar .navbar-collapse .navbar-livereload {
+    display: none;
+  }
+
+  .navbar.navbar-fixed-top ul {
+    margin-right: -15px!important;
+  }
+
+  .navbar .nav a {
+    text-align: center;
+  }
+}
+
+@media (width: 768px) {
+  .navbar .navbar-collapse .navbar-livereload {
+    display: block;
+  }
+
+  .navbar .poll-wrapper {
+    margin: 4px 4px 0 0;
+  }
 }
 
 .navbar-footer .navbar ul.nav {
@@ -616,12 +641,10 @@ div.interval-slider input {
   }
 
   .navbar.navbar-fixed-top ul {
-    float: none;
     margin-right: 0;
   }
 
   .navbar.navbar-fixed-top li {
-    float: none;
     margin-right: 0;
   }
 

--- a/web/views/_nav.erb
+++ b/web/views/_nav.erb
@@ -1,34 +1,53 @@
 <div class="navbar navbar-default navbar-fixed-top">
-  <div class="navbar-inner">
-    <div class="container-fluid text-center">
-        <a class="navbar-brand" href="<%= root_path %>">
-          <%= Sidekiq::NAME %>
-          <%= erb :_status %>
-        </a>
-        <ul class="nav navbar-nav">
-          <% Sidekiq::Web.default_tabs.each do |title, url| %>
-              <% if url == '' %>
-                  <li class="<%= current_path == url ? 'active' : '' %>">
-                    <a href="<%= root_path %><%= url %>"><%= t(title) %></a>
-                  </li>
-              <% else %>
-                  <li class="<%= current_path.start_with?(url) ? 'active' : '' %>">
-                    <a href="<%= root_path %><%= url %>"><%= t(title) %></a>
-                  </li>
-              <% end %>
-          <% end %>
-          <% Sidekiq::Web.custom_tabs.each do |title, url| %>
-              <li class="<%= current_path.start_with?(url) ? 'active' : '' %>">
-                <a href="<%= root_path %><%= url %>"><%= t(title) %></a>
-              </li>
-          <% end %>
-        </ul>
-    </div>
-    <div class="poll-wrapper pull-right">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-menu">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <div class="navbar-toggle collapsed navbar-livereload">
         <%= erb :_poll %>
         <% if Sidekiq::Web.app_url %>
-            <a class="btn btn-inverse" href="<%= Sidekiq::Web.app_url %>">Back to App</a>
+          <a class="btn btn-inverse" href="<%= Sidekiq::Web.app_url %>">Back to App</a>
         <% end %>
+      </div>
+      <a class="navbar-brand" href="<%= root_path %>">
+        <%= Sidekiq::NAME %>
+        <%= erb :_status %>
+      </a>
+    </div>
+
+    <div class="collapse navbar-collapse" id="navbar-menu">
+      <ul class="nav navbar-nav">
+        <% Sidekiq::Web.default_tabs.each do |title, url| %>
+          <% if url == '' %>
+            <li class="<%= current_path == url ? 'active' : '' %>">
+            <a href="<%= root_path %><%= url %>"><%= t(title) %></a>
+            </li>
+          <% else %>
+            <li class="<%= current_path.start_with?(url) ? 'active' : '' %>">
+            <a href="<%= root_path %><%= url %>"><%= t(title) %></a>
+            </li>
+          <% end %>
+        <% end %>
+        <% Sidekiq::Web.custom_tabs.each do |title, url| %>
+          <li class="<%= current_path.start_with?(url) ? 'active' : '' %>">
+          <a href="<%= root_path %><%= url %>"><%= t(title) %></a>
+          </li>
+        <% end %>
+      </ul>
+      <ul class="nav navbar-nav navbar-right navbar-livereload">
+        <li>
+          <div class="poll-wrapper pull-right">
+            <%= erb :_poll %>
+            <% if Sidekiq::Web.app_url %>
+              <a class="btn btn-inverse" href="<%= Sidekiq::Web.app_url %>">Back to App</a>
+            <% end %>
+          </div>
+        </li>
+      </ul>
     </div>
   </div>
+</div>
 </div>


### PR DESCRIPTION
Change current navbar to standard collapsed navbar by bootstrap *(see #2258 issue for more details)*. Also I test layout in **IPhone 4, 5, 6** and **IPad 2, retina** in iOS simulator tool.
 
**[Live example](http://sidekiq-history-gem.herokuapp.com/sidekiq/)**

### Screenshots (no end)
![screenshot 2015-03-26 15 29 00](https://cloud.githubusercontent.com/assets/1147484/6846279/ea0ba168-d3cd-11e4-98ab-8c14eeec63a8.jpg)
![screenshot 2015-03-26 15 29 45](https://cloud.githubusercontent.com/assets/1147484/6846281/ea31beac-d3cd-11e4-9fa1-8b1904488616.jpg)
![screenshot 2015-03-26 15 30 12](https://cloud.githubusercontent.com/assets/1147484/6846285/ea3bb51a-d3cd-11e4-9f22-1a08ea2e8c7e.jpg)
![screenshot 2015-03-26 15 30 44](https://cloud.githubusercontent.com/assets/1147484/6846282/ea38993e-d3cd-11e4-8ce3-428ca3c94195.jpg)
![screenshot 2015-03-26 15 31 29](https://cloud.githubusercontent.com/assets/1147484/6846284/ea3b771c-d3cd-11e4-99a9-51c2a935abe5.jpg)
![screenshot 2015-03-26 15 32 25](https://cloud.githubusercontent.com/assets/1147484/6846283/ea38b662-d3cd-11e4-87af-c0cab779e6bc.jpg)
![screenshot 2015-03-26 15 32 56](https://cloud.githubusercontent.com/assets/1147484/6846280/ea240e24-d3cd-11e4-81be-85a552aa8c21.jpg)
![screenshot 2015-03-26 15 33 45](https://cloud.githubusercontent.com/assets/1147484/6846286/ea40cbe0-d3cd-11e4-9afb-b01097f84806.jpg)
![screenshot 2015-03-26 15 34 09](https://cloud.githubusercontent.com/assets/1147484/6846287/ea4c7238-d3cd-11e4-9622-df2779ee19b2.jpg)