### PR TITLE
Added helper which provide ability to add your html to <head> tag

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@ HEAD
 
 - **Improve ActiveJob integration** - Web UI now shows ActiveJobs in a
   nicer format and job logging shows the actual class name [#2248, #2259]
+- Added helper which provide ability to add your html code to page `<head>` tag [#2270]
 - Web UI polling now uses Ajax to avoid page reload [#2266]
 - Add Sidekiq::Process#dump\_threads API to trigger TTIN output [#2247]
 

--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -20,6 +20,31 @@ module Sidekiq
     def filtering(*)
     end
 
+    # This view helper provide ability display you html code in
+    # to head of page. Example:
+    #
+    #   <% add_to_head do %>
+    #     <link rel="stylesheet" .../>
+    #     <meta .../>
+    #   <% end %>
+    #
+    def add_to_head(&block)
+      @head_html ||= []
+      @head_html << block if block_given?
+    end
+
+    def display_custom_head
+      return unless @head_html
+      @head_html.map { |block| capture(&block) }.join
+    end
+
+    # Simple capture method for erb templates. The origin was
+    # capture method from sinatra-contrib library.
+    def capture(&block)
+      block.call
+      eval('', block.binding)
+    end
+
     def locale
       lang = (request.env["HTTP_ACCEPT_LANGUAGE"] || 'en').split(',')[0].downcase
       strings[lang] ? lang : 'en'

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -8,6 +8,7 @@
     <script type="text/javascript" src="<%= root_path %>javascripts/application.js"></script>
     <script type="text/javascript" src="<%= root_path %>javascripts/locales/jquery.timeago.<%= locale %>.js"></script>
     <meta name="google" content="notranslate" />
+    <%= display_custom_head %>
   </head>
   <body class="admin">
     <%= erb :_nav %>


### PR DESCRIPTION
### Why this needed?
These changes will allow easily define custom tags for page `<head>` in any sidekiq plugins.

### Use case
``` erb
# in view
<% add_to_head do %>
  <link rel="stylesheet" href="/plugin.css" />
<% end %>
```
``` ruby
# in web extention
app.get '/plugin.css' do
  custom_css ['/sidekiq/plugin.css']

  # you page code here
end
```