### PR TITLE
Use addressable gem for support with URLs with underscores

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -1,6 +1,6 @@
 require 'connection_pool'
 require 'redis'
-require 'uri'
+require 'addressable/uri'
 
 module Sidekiq
   class RedisConnection
@@ -57,7 +57,7 @@ module Sidekiq
         # Don't log Redis AUTH password
         redacted = "REDACTED"
         scrubbed_options = options.dup
-        if scrubbed_options[:url] && (uri = URI.parse(scrubbed_options[:url])) && uri.password
+        if scrubbed_options[:url] && (uri = Addressable::URI.parse(scrubbed_options[:url])) && uri.password
           uri.password = redacted
           scrubbed_options[:url] = uri.to_s
         end

--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -1,4 +1,4 @@
-require 'uri'
+require 'addressable/uri'
 
 module Sidekiq
   # This is not a public API
@@ -166,7 +166,7 @@ module Sidekiq
     def redirect_with_query(url)
       r = request.referer
       if r && r =~ /\?/
-        ref = URI(r)
+        ref = Addressable::URI.parse(r)
         redirect("#{url}?#{ref.query}")
       else
         redirect url

--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency                  'connection_pool', '>= 2.1.1'
   gem.add_dependency                  'celluloid', '>= 0.16.0'
   gem.add_dependency                  'json'
+  gem.add_dependency                  'addressable'
   gem.add_development_dependency      'sinatra'
   gem.add_development_dependency      'minitest', '~> 5.3.3'
   gem.add_development_dependency      'rake'


### PR DESCRIPTION
The built-in URI class for ruby doesn't properly handle hostnames with underscores in them. See bug at:

https://bugs.ruby-lang.org/issues/8241

This updates to use the addressable gem, which provides better support for current URI standards.
