### PR TITLE
Removed unnecessary to_f invocations

### DIFF
--- a/lib/sidekiq/fetch.rb
+++ b/lib/sidekiq/fetch.rb
@@ -35,7 +35,7 @@ module Sidekiq
 
         begin
           work = @strategy.retrieve_work
-          ::Sidekiq.logger.info("Redis is online, #{Time.now.to_f - @down.to_f} sec downtime") if @down
+          ::Sidekiq.logger.info("Redis is online, #{Time.now - @down} sec downtime") if @down
           @down = nil
 
           if work

--- a/lib/sidekiq/middleware/server/logging.rb
+++ b/lib/sidekiq/middleware/server/logging.rb
@@ -22,7 +22,7 @@ module Sidekiq
         end
 
         def elapsed(start)
-          (Time.now - start).to_f.round(3)
+          (Time.now - start).round(3)
         end
 
         def logger


### PR DESCRIPTION
Hey Mike,

Something I noticed today while browsing through the source - there appears to be 2 times within the code where we're converting with `to_f` unnecessarily (I believe).

In ruby, anytime you do math with time objects it returns a float:

```ruby
[11] pry(main)> a = Time.now
=> 2015-04-01 10:51:21 -0400
[12] pry(main)> Time.now - a
=> 8.249527
[13] pry(main)> (Time.now - a).class
=> Float
```

From what I can tell `@down` will either be nil or a Time object and `start` will always be time object.  If I missed something let me know.  Thanks!