### PR TITLE
Use Hash#each_key instead of Hash#keys.each

### DIFF
--- a/lib/sidekiq/core_ext.rb
+++ b/lib/sidekiq/core_ext.rb
@@ -54,14 +54,14 @@ begin
 rescue LoadError
   class Hash
     def stringify_keys
-      keys.each do |key|
+      each_key do |key|
         self[key.to_s] = delete(key)
       end
       self
     end if !{}.respond_to?(:stringify_keys)
 
     def symbolize_keys
-      keys.each do |key|
+      each_key do |key|
         self[(key.to_sym rescue key) || key] = delete(key)
       end
       self


### PR DESCRIPTION
`Hash#keys.each` allocates an array of keys but `Hash#each_key` iterates through the
keys without allocating a new array.