### PR TITLE
Reduced by one third allocated memory for #perform_async method 

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -30,6 +30,11 @@ module Sidekiq
     dead_timeout_in_seconds: 180 * 24 * 60 * 60 # 6 months
   }
 
+  DEFAULT_WORKER_OPTIONS = {
+    'retry' => true,
+    'queue' => 'default'
+  }
+
   def self.❨╯°□°❩╯︵┻━┻
     puts "Calm down, bro"
   end
@@ -103,7 +108,7 @@ module Sidekiq
   end
 
   def self.default_worker_options
-    defined?(@default_worker_options) ? @default_worker_options : { 'retry' => true, 'queue' => 'default' }
+    defined?(@default_worker_options) ? @default_worker_options : DEFAULT_WORKER_OPTIONS
   end
 
   def self.load_json(string)

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -384,7 +384,7 @@ module Sidekiq
       raise "Retry not available on jobs which have not failed" unless item["failed_at"]
       remove_job do |message|
         msg = Sidekiq.load_json(message)
-        msg['retry_count'] = msg['retry_count'] - 1
+        msg['retry_count'] -= 1
         Sidekiq::Client.push(msg)
       end
     end

--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -7,10 +7,7 @@ module Sidekiq
     class << self
 
       def create(options={})
-        url = options[:url] || determine_redis_provider
-        if url
-          options[:url] = url
-        end
+        options[:url] ||= determine_redis_provider
 
         # need a connection for Fetcher and Retry
         size = options[:size] || (Sidekiq.server? ? (Sidekiq.options[:concurrency] + 2) : 5)

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -64,7 +64,7 @@ module Sidekiq
       #      can be true, false or an integer number of lines to save, default *false*
       #   :pool - use the given Redis connection pool to push this type of job to a given shard.
       def sidekiq_options(opts={})
-        self.sidekiq_options_hash = get_sidekiq_options.merge((opts || {}).stringify_keys)
+        self.sidekiq_options_hash = get_sidekiq_options.merge(opts.stringify_keys)
       end
 
       def sidekiq_retry_in(&block)


### PR DESCRIPTION
I used [memory_profiler](https://github.com/SamSaffron/memory_profiler) gem with this code:
``` ruby
MemoryProfiler.report{ 100.times { HardWorker.perform_async } }.pretty_print
```

#### Before (only for sidekiq)
```
Total allocated 22631
Total retained 886

allocated memory by gem
-----------------------------------
    318864  sidekiq

allocated objects by gem
-----------------------------------
      2416  sidekiq

retained memory by gem
-----------------------------------
      1280  sidekiq

retained objects by gem
-----------------------------------
        11  sidekiq

Allocated String Report
-----------------------------------
       307  "HardWorker"
       200  /Users/anton/work/gems/sidekiq/lib/sidekiq/client.rb:217

       300  "jid"
       200  /Users/anton/work/gems/sidekiq/lib/sidekiq/client.rb:223

       300  "enqueued_at"
       200  /Users/anton/work/gems/sidekiq/lib/sidekiq/client.rb:224

       101  "default"
         1  /Users/anton/work/gems/sidekiq/lib/sidekiq.rb:106

       100  "queue:default"
       100  /Users/anton/work/gems/sidekiq/lib/sidekiq/client.rb:196

       100  "get_sidekiq_options"
       100  /Users/anton/work/gems/sidekiq/lib/sidekiq/client.rb:215
```

#### After (only for sidekiq)
```
Total allocated 21249
Total retained 888

allocated memory by gem
-----------------------------------
    219312  sidekiq

allocated objects by gem
-----------------------------------
      1814  sidekiq

retained memory by gem
-----------------------------------
      1280  sidekiq

retained objects by gem
-----------------------------------
        11  sidekiq

Allocated String Report
-----------------------------------
       307  "HardWorker"
       200  /Users/anton/work/gems/sidekiq/lib/sidekiq/client.rb:217

       100  "queue:default"
       100  /Users/anton/work/gems/sidekiq/lib/sidekiq/client.rb:196
```