### PR TITLE
Load only required locale files

### DIFF
--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require_relative 'helper'
 require 'sidekiq'
 require 'sidekiq/web'
@@ -27,6 +28,18 @@ class TestWeb < Sidekiq::Test
       def perform(a, b)
         a + b
       end
+    end
+
+    it 'can show text with any locales' do
+      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'ru,en'}
+      get '/', {}, rackenv
+      assert_match(/Панель управления/, last_response.body)
+      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'es,en'}
+      get '/', {}, rackenv
+      assert_match(/Panel de Control/, last_response.body)
+      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'en-us'}
+      get '/', {}, rackenv
+      assert_match(/Dashboard/, last_response.body)
     end
 
     describe 'busy' do


### PR DESCRIPTION
Fixed #2295
Also I check `get_locale` web helper with `memory_profiler`. For this I use this code:
``` ruby
MemoryProfiler.report{ 100.times { get_locale } }.pretty_print
```

### Before
```
Total allocated 17626
Total retained 3145

allocated memory by gem
-----------------------------------
   3033634  ruby-2.2.0/lib
     12942  sidekiq
      5040  other
```

### After
```
Total allocated 1220
Total retained 182

allocated memory by gem
-----------------------------------
    143025  ruby-2.2.0/lib
     87608  sidekiq
       240  other
```

![gif](https://psv4.vk.me/c612021/u2000025499/docs/adb8edcea363/file.gif?extra=4Rg_jH6iloPtt9mBXAiYqpDbTlMWSrXnpmEgeKFGJ_4bu42c9fqEA6ZCDLH3xuGK8XpDdpFoowmv3G9lhghWcE4B1l9Lrw)