### PR TITLE
Revert using #each_key in Hash class

### DIFF
--- a/lib/sidekiq/core_ext.rb
+++ b/lib/sidekiq/core_ext.rb
@@ -54,14 +54,14 @@ begin
 rescue LoadError
   class Hash
     def stringify_keys
-      each_key do |key|
+      keys.each do |key|
         self[key.to_s] = delete(key)
       end
       self
     end if !{}.respond_to?(:stringify_keys)
 
     def symbolize_keys
-      each_key do |key|
+      keys.each do |key|
         self[(key.to_sym rescue key) || key] = delete(key)
       end
       self


### PR DESCRIPTION
I found that my changes in Hash class (#2287) are working incorrect in ruby 1.9+ ([travis](https://travis-ci.org/davydovanton/sidekiq-history/builds/58011536)). :disappointed_relieved: This is due to the fact that with version 1.9, you have only read-only access to hash during iteration.
Same problem was in mperham/bayes_motel#1.
I'm sorry :cry:
