### PR TITLE
Strip retry exceptions when a job is requeued

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -92,7 +92,7 @@ module Sidekiq
   end
 
   def self.client_middleware
-    @client_chain ||= Middleware::Chain.new
+    @client_chain ||= Processor.default_client_middleware
     yield @client_chain if block_given?
     @client_chain
   end

--- a/lib/sidekiq/middleware/retry_job_cleaner.rb
+++ b/lib/sidekiq/middleware/retry_job_cleaner.rb
@@ -1,0 +1,18 @@
+#
+# Middleware to clean retry job exceptions when they are requeued.
+module Sidekiq
+  module Middleware
+    module Client
+      class RetryJobCleaner
+        def call(worker_class, msg, queue, redis_pool)
+          msg.delete('error_message')
+          msg.delete('error_class')
+          msg.delete('error_backtrace')
+
+          yield
+        end
+      end
+    end
+  end
+end
+

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -17,6 +17,12 @@ module Sidekiq
     include Util
     include Actor
 
+    def self.default_client_middleware
+      Middleware::Chain.new do |m|
+        m.add Middleware::Client::RetryJobCleaner
+      end
+    end
+
     def self.default_middleware
       Middleware::Chain.new do |m|
         m.add Middleware::Server::Logging


### PR DESCRIPTION
Thoughts? Will add tests based on what you think. I tried to do a client middleware to make it consistent with how Sidekiq works, rather than just patching it into `normalize_items`.

If you enable backtrace logging, whenever a job fails it logs a trace. In a Rails app, it can be pretty big. It can effectively double/triple the payload size. As best I can tell, that persists even when the job is requeued, so you can end up in a situation like this (pseudonumbers):

100 jobs - 100 bytes used
5 jobs run, they all fail and go into the retry queue, 105 bytes used (5 more for the failure log)
5 jobs are requeued
another 10 jobs are run, none of them are the original failed jobs, they fail as well, 115 bytes are now used

Repeat until we run out of memory or the jobs process.

Because we add with `lpush` and remove with `brpop`, these retries are going to be processed last. Normally, this isn't a problem. If you say, queue 50,000 jobs and your DB goes down, network is slow/timing out/etc, you can end up having your memory balloon significantly without adding new jobs.

Given `backtrace` is disabled by default, this isn't exactly a critical issue since you can also limit how many records you store. I think it's better to not store a lot of redundant data though if it can be avoided.

 

