### PR TITLE
fix xss vulnerability in display class

### DIFF
--- a/web/views/queue.erb
+++ b/web/views/queue.erb
@@ -19,7 +19,7 @@
   </thead>
   <% @messages.each_with_index do |msg, index| %>
     <tr>
-      <td><%= msg.display_class %></td>
+      <td><%= h(msg.display_class) %></td>
       <td>
         <% a = msg.display_args.inspect %>
         <% if a.size > 100 %>


### PR DESCRIPTION
If any of the job args contain a script tag it will execute when you view: `/admin/sidekiq/queues/default`

To reproduce:
`Job.perform_later("aldfkjaf", "<script> alert('hi');</script>")`

![screen shot 2015-04-21 at 2 26 20 pm](https://cloud.githubusercontent.com/assets/22493/7262962/72c337be-e832-11e4-86dc-95c75958468c.png)