### PR TITLE
make the average global poller delay configurable

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -21,7 +21,7 @@ module Sidekiq
     environment: nil,
     timeout: 8,
     poll_interval_average: nil,
-    global_poll_interval_average: 15,
+    average_scheduled_poll_interval: 15,
     error_handlers: [],
     lifecycle_events: {
       startup: [],
@@ -129,14 +129,23 @@ module Sidekiq
     Sidekiq::Logging.logger = log
   end
 
-  # When set, overrides Sidekiq.options[:global_poll_interval_average] and sets the
-  # average interval that this process will delay before checking for scheduled jobs
-  # or job retries that are ready to run.
+  # When set, overrides Sidekiq.options[:average_scheduled_poll_interval] and sets
+  # the average interval that this process will delay before checking for
+  # scheduled jobs or job retries that are ready to run.
   #
   # See sidekiq/scheduled.rb for an in-depth explanation of this value
   def self.poll_interval=(interval)
-    $stderr.puts "DEPRECATION: `Sidekiq.poll_interval = #{interval}` will be removed in Sidekiq 4. Please update to `Sidekiq.options[:global_poll_interval_average] = #{interval}`."
+    $stderr.puts "DEPRECATION: `Sidekiq.poll_interval = #{interval}` will be removed in Sidekiq 4. Please update to `Sidekiq.average_scheduled_poll_interval = #{interval}`."
     self.options[:poll_interval_average] = interval
+  end
+
+  # How frequently Redis should be checked by a random Sidekiq process for
+  # scheduled and retriable jobs. Each individual process will take turns by
+  # waiting some multiple of this value.
+  #
+  # See sidekiq/scheduled.rb for an in-depth explanation of this value
+  def self.average_scheduled_poll_interval=(interval)
+    self.options[:average_scheduled_poll_interval] = interval
   end
 
   # Register a proc to handle any error which occurs within the Sidekiq process.

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -20,6 +20,8 @@ module Sidekiq
     require: '.',
     environment: nil,
     timeout: 8,
+    poll_interval_average: nil,
+    global_poll_interval_average: 15,
     error_handlers: [],
     lifecycle_events: {
       startup: [],
@@ -127,9 +129,13 @@ module Sidekiq
     Sidekiq::Logging.logger = log
   end
 
+  # When set, overrides Sidekiq.options[:global_poll_interval_average] and sets the
+  # average interval that this process will delay before checking for scheduled jobs
+  # or job retries that are ready to run.
+  #
   # See sidekiq/scheduled.rb for an in-depth explanation of this value
   def self.poll_interval=(interval)
-    self.options[:poll_interval] = interval
+    self.options[:poll_interval_average] = interval
   end
 
   # Register a proc to handle any error which occurs within the Sidekiq process.

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -135,6 +135,7 @@ module Sidekiq
   #
   # See sidekiq/scheduled.rb for an in-depth explanation of this value
   def self.poll_interval=(interval)
+    $stderr.puts "DEPRECATION: `Sidekiq.poll_interval = #{interval}` will be removed in Sidekiq 4. Please update to `Sidekiq.options[:global_poll_interval_average] = #{interval}`."
     self.options[:poll_interval_average] = interval
   end
 

--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -94,7 +94,7 @@ module Sidekiq
       def scaled_poll_interval
         pcount = Sidekiq::ProcessSet.new.size
         pcount = 1 if pcount == 0
-        pcount * Sidekiq.options[:global_poll_interval_average]
+        pcount * Sidekiq.options[:average_scheduled_poll_interval]
       end
 
       def initial_wait

--- a/test/test_scheduled.rb
+++ b/test/test_scheduled.rb
@@ -104,7 +104,7 @@ class TestScheduled < Sidekiq::Test
     end
 
     it 'calculates an average poll interval based on the number of known Sidekiq processes' do
-      with_sidekiq_option(:global_poll_interval_average, 10) do
+      with_sidekiq_option(:average_scheduled_poll_interval, 10) do
         3.times do |i|
           Sidekiq.redis do |conn|
             conn.sadd("processes", "process-#{i}")

--- a/test/test_scheduled.rb
+++ b/test/test_scheduled.rb
@@ -105,23 +105,14 @@ class TestScheduled < Sidekiq::Test
 
     it 'calculates an average poll interval based on the number of known Sidekiq processes' do
       with_sidekiq_option(:global_poll_interval_average, 10) do
-        begin
-          3.times do |i|
-            Sidekiq.redis do |conn|
-              conn.sadd("processes", "process-#{i}")
-              conn.hset("process-#{i}", "info", nil)
-            end
-          end
-
-          assert_equal 30, @poller.send(:scaled_poll_interval)
-        ensure
-          3.times do |i|
-            Sidekiq.redis do |conn|
-              conn.srem("processes", "process-#{i}")
-              conn.del("process-#{i}")
-            end
+        3.times do |i|
+          Sidekiq.redis do |conn|
+            conn.sadd("processes", "process-#{i}")
+            conn.hset("process-#{i}", "info", nil)
           end
         end
+
+        assert_equal 30, @poller.send(:scaled_poll_interval)
       end
     end
   end


### PR DESCRIPTION
from https://github.com/mperham/sidekiq/issues/2317

### what do?

Introduces `Sidekiq.options[:global_poll_interval_average]` and begins transitioning `Sidekiq.poll_interval=` to `Sidekiq.options[:poll_interval_average]`. The intended behavior is as follows:

* **global_poll_interval_average**: How frequently Redis should be checked by some random poller for scheduled and retriable jobs
* **poll_interval_average**: How frequently each Poller should check Redis for scheduled and retriable jobs. Will be calculated from `global_poll_interval_average` by default.

### tests

I noticed that the test coverage on Poller seems to prefer testing only the public interface. I confirmed that the logic in question is covered by the existing tests and opted not to add more specific unit coverage. Let me know if this is best practice for Sidekiq? I'm happy to go back and add something.

### questions

* Is `Sidekiq.options[:poll_interval_average]` complementary or redundant to `Sidekiq.options[:global_poll_interval_average]`?
* I'd also like to submit a change to the `poll_interval_average * 2 * rand` logic so that it calculates a random number in a tighter spread (e.g. 0.5 * average ... 1.5 * average). Separate pull request? **update:** https://github.com/mperham/sidekiq/pull/2323