### PR TITLE
Footer style fix #2205

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -738,14 +738,36 @@ div.interval-slider input {
   }
 }
 
-.redis-url
-{
-    max-width: 400px;
-    overflow: hidden;
+.redis-url, .redis-namespace {
+  overflow: scroll;
+  white-space: nowrap;
 }
 
-.redis-namespace
-{
-    max-width: 250px;
-    overflow: hidden;
+@media (min-width: 768px) {
+  .redis-url {
+    max-width: 200px;
+  }
+
+  .redis-namespace {
+    max-width: 150px;
+  }
+}
+
+@media (min-width: 992px) {
+  .redis-url {
+    max-width: 340px;
+  }
+
+  .redis-namespace {
+    max-width: 350px;
+  }
+}
+@media (min-width: 1200px) {
+  .redis-url {
+    max-width: 540px;
+  }
+
+  .redis-namespace {
+    max-width: 350px;
+  }
 }


### PR DESCRIPTION
After looking into the footer again found that it did not take responsive into account. Here is a update to that as well as a fix to make the overflow respond to scroll so even if it gets cut off the screen you can still read what is in the footer or copy and past it onto a document that has more room.

[JSfiddle link to example fix](http://jsfiddle.net/newdark/2u1kxy55/8/)