### PR TITLE
Add the possibility to configure a different Manager

### DIFF
--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -18,7 +18,7 @@ module Sidekiq
 
     def initialize(options)
       @condvar = Celluloid::Condition.new
-      @manager = Sidekiq::Manager.new_link(@condvar, options)
+      @manager = Sidekiq::Manager.strategy.new_link(@condvar, options)
       @poller = Sidekiq::Scheduled::Poller.new_link
       @fetcher = Sidekiq::Fetcher.new_link(@manager, options)
       @manager.fetcher = @fetcher

--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -147,6 +147,10 @@ module Sidekiq
       end
     end
 
+    def self.strategy
+      Sidekiq.options[:manager] || Manager
+    end
+
     private
 
     def ❤(key, json)


### PR DESCRIPTION
Hi,

There's a lot of plugins and others works based in sidekiq trying to customize some aspect of its concurrency model.

But there a lot of strange things, like plugins pulling again and again and again items to queue and some with lot of complex things to try control concurrency.

Sidekiq already allow Fetcher customization. So I thought: Why we cannot write a custom Manager too?

This will allow a new level of customizations through plugins. For example, I can write a Manager that keep a variable pool of workers. Or dedicated workers for queues - this can solve a lot of concurrency problems that some plugins try to solve. Even the Sidekiq Pro can build custom managers to maximize reliability, resource usage or performance.

Maybe I'm been naive. And It's highly likely this change is incomplete. But I just want to open a discussion around this.

I followed the same pattern used in the Fetcher customization. So I think it's a tiny, simple and harmless yet powerfull pull request.

What do you think?