### PR TITLE
make `enqueued_at` be accessible from worker

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -46,6 +46,7 @@ module Sidekiq
         klass  = msg['class'].constantize
         worker = klass.new
         worker.jid = msg['jid']
+        worker.enqueued_at = msg['enqueued_at']
 
         stats(worker, msg, queue) do
           Sidekiq.server_middleware.invoke(worker, msg, queue) do

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -21,7 +21,7 @@ module Sidekiq
   #
   # Note that perform_async is a class method, perform is an instance method.
   module Worker
-    attr_accessor :jid
+    attr_accessor :jid, :enqueued_at
 
     def self.included(base)
       base.extend(ClassMethods)


### PR DESCRIPTION
I wanted to know the time at enqueued from my worker codes. 
This patch allows to make `enqueued_at` be accessible from worker codes.