### PR TITLE
Validate parameters in config file

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -277,14 +277,14 @@ module Sidekiq
         unless options[option].is_a? Integer
           raise(
             ArgumentError,
-            %{Configuration parameter "#{option}": "#{options[option]}" is not a valid integer}
+            %{"#{option}": "#{options[option]}" is not a valid integer}
           )
         end
 
         if options[option] <= 0
           raise(
             ArgumentError,
-            %{Configuration parameter "#{option}": must be > 0 (current value: #{options[option]})}
+            %{"#{option}": must be > 0 (current value: #{options[option]})}
           )
         end
       end

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -270,21 +270,18 @@ module Sidekiq
         die(1)
       end
 
-      errors = []
-
       # Ensure numeric option values are numbers and fall in reasonable ranges
       [:concurrency, :timeout].each do |option|
         next unless options.has_key?(option)
 
         unless options[option].is_a? Integer
-          errors.push(%{parameter "#{option}": "#{options[option]}" is not a valid integer})
-          next
+          raise(%{Configuration file parameter "#{option}": "#{options[option]}" is not a valid integer})
         end
 
-        errors.push(%{parameter "#{option}": "#{options[option]}" must be > 0}) if options[option] <= 0
+        if options[option] <= 0
+          raise(%{Configuration file parameter "#{option}": "#{options[option]}" must be > 0})
+        end
       end
-
-      raise("Invalid values found in configuration file settings: " + errors.join(", ")) unless errors.empty?
     end
 
     def parse_options(argv)

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -275,11 +275,17 @@ module Sidekiq
         next unless options.has_key?(option)
 
         unless options[option].is_a? Integer
-          raise(%{Configuration file parameter "#{option}": "#{options[option]}" is not a valid integer})
+          raise(
+            ArgumentError,
+            %{Configuration parameter "#{option}": "#{options[option]}" is not a valid integer}
+          )
         end
 
         if options[option] <= 0
-          raise(%{Configuration file parameter "#{option}": must be > 0 (current value: #{options[option]})})
+          raise(
+            ArgumentError,
+            %{Configuration parameter "#{option}": must be > 0 (current value: #{options[option]})}
+          )
         end
       end
     end

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -271,17 +271,25 @@ module Sidekiq
       end
 
       errors = []
-      [:concurrency, :index, :timeout].each do |arg|
-        if options.has_key? arg
-          Integer(options[arg]) rescue errors.push("#{arg.to_s} must be an integer")
+
+      # Ensure numeric option values are numbers and fall in reasonable ranges
+      [:concurrency, :timeout].each do |option|
+        next unless options.has_key?(option)
+
+        unless options[option].is_a? Integer
+          errors.push(%{parameter "#{option}": "#{options[option]}" is not a valid integer})
+          next
         end
+
+        errors.push(%{parameter "#{option}": "#{options[option]}" must be > 0}) if options[option] <= 0
       end
+
       if options.has_key? :verbose
         val = options[:verbose]
-        errors.push("verbose must be true or false") unless val == true || val == false
+        errors.push(%{parameter "verbose" must be set to true or false}) unless val == true || val == false
       end
-      raise("Invalid configuration found: " + errors.join(", ")) unless errors.empty?
 
+      raise("Invalid values found in configuration file settings: " + errors.join(", ")) unless errors.empty?
     end
 
     def parse_options(argv)

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -279,7 +279,7 @@ module Sidekiq
         end
 
         if options[option] <= 0
-          raise(%{Configuration file parameter "#{option}": "#{options[option]}" must be > 0})
+          raise(%{Configuration file parameter "#{option}": must be > 0 (current value: #{options[option]})})
         end
       end
     end

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -269,6 +269,19 @@ module Sidekiq
         logger.info @parser
         die(1)
       end
+
+      errors = []
+      [:concurrency, :index, :timeout].each do |arg|
+        if options.has_key? arg
+          Integer(options[arg]) rescue errors.push("#{arg.to_s} must be an integer")
+        end
+      end
+      if options.has_key? :verbose
+        val = options[:verbose]
+        errors.push("verbose must be true or false") unless val == true || val == false
+      end
+      raise("Invalid configuration found: " + errors.join(", ")) unless errors.empty?
+
     end
 
     def parse_options(argv)

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -284,11 +284,6 @@ module Sidekiq
         errors.push(%{parameter "#{option}": "#{options[option]}" must be > 0}) if options[option] <= 0
       end
 
-      if options.has_key? :verbose
-        val = options[:verbose]
-        errors.push(%{parameter "verbose" must be set to true or false}) unless val == true || val == false
-      end
-
       raise("Invalid values found in configuration file settings: " + errors.join(", ")) unless errors.empty?
     end
 


### PR DESCRIPTION
The command line parser validates that parameters that require integer options are integers, the configuration file validator was not doing this same type of validation.

* Ensure verbose is either true or false
* Ensure integer parameters are valid integers