### PR TITLE
exponential sleep and increase retries for retry_and_suppress_exceptions

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -132,7 +132,7 @@ module Sidekiq
 
     # If an exception occurs in the block passed to this method, that block will be retried up to max_retries times.
     # All exceptions will be swallowed and logged.
-    def retry_and_suppress_exceptions(max_retries = 2)
+    def retry_and_suppress_exceptions(max_retries = 5)
       retry_count = 0
       begin
         yield

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -132,7 +132,7 @@ module Sidekiq
 
     # If an exception occurs in the block passed to this method, that block will be retried up to max_retries times.
     # All exceptions will be swallowed and logged.
-    def retry_and_suppress_exceptions(max_retries = 2)
+    def retry_and_suppress_exceptions(max_retries = 5)
       retry_count = 0
       begin
         yield
@@ -140,7 +140,7 @@ module Sidekiq
         retry_count += 1
         if retry_count <= max_retries
           Sidekiq.logger.debug {"Suppressing and retrying error: #{e.inspect}"}
-          sleep(1)
+          sleep(retry_count * retry_count)
           retry
         else
           handle_exception(e, { :message => "Exhausted #{max_retries} retries"})

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -132,7 +132,7 @@ module Sidekiq
 
     # If an exception occurs in the block passed to this method, that block will be retried up to max_retries times.
     # All exceptions will be swallowed and logged.
-    def retry_and_suppress_exceptions(max_retries = 5)
+    def retry_and_suppress_exceptions(max_retries = 2)
       retry_count = 0
       begin
         yield
@@ -140,12 +140,16 @@ module Sidekiq
         retry_count += 1
         if retry_count <= max_retries
           Sidekiq.logger.debug {"Suppressing and retrying error: #{e.inspect}"}
-          sleep(retry_count * retry_count)
+          sleep_retry_count(retry_count)
           retry
         else
           handle_exception(e, { :message => "Exhausted #{max_retries} retries"})
         end
       end
+    end
+
+    def sleep_retry_count(retry_count)
+      sleep(retry_count)
     end
   end
 end


### PR DESCRIPTION
when i am testing SideKiq + Pro and Redis sentinels setup. i am experiencing "Error connecting to Redis on 127.0.0.1:6377 (Errno::ECONNREFUSED)" during a master failover. it will cause SideKiq admin to report the wrong stats due to exceptions in workers.

I have a proposed temp fix for the problem. i want to get SideKiq team's opinions on how to resolve the issue better.