### PR TITLE
Make pry-byebug available on ruby 2.2.2 too

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ platforms :ruby do
   gem 'sqlite3'
 end
 
-platforms :mri_21 do
+platforms :mri do
   gem 'pry-byebug'
 end
 


### PR DESCRIPTION
Hopefully a simple one. `pry-byebug` also works under mri 2.2.