### PR TITLE
Use created_at for the time schedule jobs are scheduled

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,10 @@
+3.3.5
+-----------
+
+- Set a created_at attribute when jobs are created, and the enqueued_at only
+  when they go into the queue. Aims to help with latency, specially for
+  scheduled jobs. [#2373, mrsimo]
+
 3.3.4
 -----------
 

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -315,12 +315,16 @@ module Sidekiq
       Time.at(@item['enqueued_at'] || 0).utc
     end
 
+    def created_at
+      Time.at(@item['created_at'] || @item['enqueued_at'] || 0).utc
+    end
+
     def queue
       @queue
     end
 
     def latency
-      Time.now.to_f - @item['enqueued_at']
+      Time.now.to_f - (@item['enqueued_at'] || @item['created_at'])
     end
 
     ##

--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -191,7 +191,10 @@ module Sidekiq
         end)
       else
         q = payloads.first['queue']
-        to_push = payloads.map { |entry| Sidekiq.dump_json(entry) }
+        to_push = payloads.map do |entry|
+          entry['enqueued_at'.freeze] ||= Time.now.to_f
+          Sidekiq.dump_json(entry)
+        end
         conn.sadd('queues'.freeze, q)
         conn.lpush("queue:#{q}", to_push)
       end
@@ -217,7 +220,7 @@ module Sidekiq
       item['class'.freeze] = item['class'.freeze].to_s
       item['queue'.freeze] = item['queue'.freeze].to_s
       item['jid'.freeze] ||= SecureRandom.hex(12)
-      item['enqueued_at'.freeze] ||= Time.now.to_f
+      item['created_at'.freeze] ||= Time.now.to_f
       item
     end
 


### PR DESCRIPTION
Based on the discussion in https://github.com/mperham/sidekiq/issues/2373, wanted to give this a try.

When a job is scheduled, it should have a `created_at` time, and get an `enqueued_at` when it's actually enqueued back into a queue.