### PR TITLE
properly stop sidekiq in upstart one app example

### DIFF
--- a/examples/upstart/manage-one/sidekiq.conf
+++ b/examples/upstart/manage-one/sidekiq.conf
@@ -53,6 +53,28 @@ exec /bin/bash <<'EOT'
   # Logs out to /var/log/upstart/sidekiq.log by default
 
   cd /var/www/app
-  exec bin/sidekiq -i ${index} -e production
+  exec bundle exec sidekiq -i ${index} -e production -P tmp/pids/sidekiq-${index}.pid
+EOT
+end script
+
+pre-stop script
+# this script runs in /bin/sh by default
+# respawn as bash so we can source in rbenv
+exec /bin/bash <<'EOT'
+  # Pick your poison :) Or none if you're using a system wide installed Ruby.
+  # rbenv
+  # source /home/apps/.bash_profile
+  # OR
+  # source /home/apps/.profile
+  # OR system:
+  # source /etc/profile.d/rbenv.sh
+  #
+  # rvm
+  # source /home/apps/.rvm/scripts/rvm
+
+  # Logs out to /var/log/upstart/sidekiq.log by default
+
+  cd /var/www/app
+  exec bundle exec sidekiqctl stop tmp/pids/sidekiq-${index}.pid 2> /dev/null
 EOT
 end script


### PR DESCRIPTION
Hey, I stumbled across this problem when using the upstart example for one app - it seems it is missing the pre-stop hook which actually uses sidekiqctl to stop the workers. Without it, upstart thinks it stops the service but sidekiq continues to run in the background thus piling up the sidekiq workers on each restart - e.g. on each deploy in my case. I saw that the upstart 'many apps' example script had the hook but the 'one app' example did not, thus this pull request. Hope it helps!

Also, it seems the one-app script did not use `bundle exec` to execute the sidekiq bin file which could cause problems on some setups. Fixed it too.