### PR TITLE
Use new proc syntax instead all Proc.new

### DIFF
--- a/3.0-Upgrade.md
+++ b/3.0-Upgrade.md
@@ -60,7 +60,7 @@ if Sidekiq::VERSION < '3'
   end
 else
   Sidekiq.configure_server do |config|
-    config.error_handlers << Proc.new {|ex,context| MyErrorService.notify(ex, context) }
+    config.error_handlers << proc {|ex,context| MyErrorService.notify(ex, context) }
   end
 end
 ```

--- a/Changes.md
+++ b/Changes.md
@@ -213,7 +213,7 @@ end
   occur anywhere within Sidekiq, not just within middleware.
 ```ruby
 Sidekiq.configure_server do |config|
-  config.error_handlers << Proc.new {|ex,ctx| ... }
+  config.error_handlers << proc {|ex,ctx| ... }
 end
 ```
 - **Process Heartbeat** - each Sidekiq process will ping Redis every 5

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -151,7 +151,7 @@ module Sidekiq
   # Register a proc to handle any error which occurs within the Sidekiq process.
   #
   #   Sidekiq.configure_server do |config|
-  #     config.error_handlers << Proc.new {|ex,ctx_hash| MyErrorService.notify(ex, ctx_hash) }
+  #     config.error_handlers << proc {|ex,ctx_hash| MyErrorService.notify(ex, ctx_hash) }
   #   end
   #
   # The default error handler logs errors to Sidekiq.logger.

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -12,8 +12,8 @@ module Sidekiq
     include Sidekiq::Paginator
 
     set :root, File.expand_path(File.dirname(__FILE__) + "/../../web")
-    set :public_folder, Proc.new { "#{root}/assets" }
-    set :views, Proc.new { "#{root}/views" }
+    set :public_folder, proc { "#{root}/assets" }
+    set :views, proc { "#{root}/views" }
     set :locales, ["#{root}/locales"]
 
     helpers WebHelpers

--- a/test/test_manager.rb
+++ b/test/test_manager.rb
@@ -110,7 +110,7 @@ class TestManager < Sidekiq::Test
 
       describe 'when manager is active' do
         before do
-          Sidekiq::Manager::PROCTITLES << Proc.new { "xyz" }
+          Sidekiq::Manager::PROCTITLES << proc { "xyz" }
           @mgr.heartbeat('identity', heartbeat_data, Sidekiq.dump_json(heartbeat_data))
           Sidekiq::Manager::PROCTITLES.pop
         end


### PR DESCRIPTION
In addition to #2381 and #2382.
[Link](https://github.com/bbatsov/ruby-style-guide#proc) from ruby style guides.
