### PR TITLE
Web: Revert overflow for `redis-url` and `redis-namespace` to `hidden`

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -743,7 +743,7 @@ div.interval-slider input {
 }
 
 .redis-url, .redis-namespace {
-  overflow: scroll;
+  overflow: hidden;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Looks like this was mistakenly? changed to `scroll` in 542b995