### PR TITLE
Prevent redundant polling in the web UI

### DIFF
--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -295,6 +295,12 @@ class TestWeb < Sidekiq::Test
       assert_match /#{msg['args'][2]}/, last_response.body
     end
 
+    it 'calls updatePage() once when polling' do
+      get '/busy?poll=true'
+      assert_equal 200, last_response.status
+      assert_equal 1, last_response.body.scan('updatePage(').count
+    end
+
     it 'escape job args and error messages' do
       # on /retries page
       params = add_xss_retry

--- a/web/views/_nav.erb
+++ b/web/views/_nav.erb
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
       </button>
       <div class="navbar-toggle collapsed navbar-livereload">
-        <%= erb :_poll %>
+        <%= erb :_poll_link %>
         <% if Sidekiq::Web.app_url %>
           <a class="btn btn-inverse" href="<%= Sidekiq::Web.app_url %>">Back to App</a>
         <% end %>
@@ -54,7 +54,7 @@
       <ul class="nav navbar-nav navbar-right navbar-livereload" data-navbar="static">
         <li>
           <div class="poll-wrapper pull-right">
-            <%= erb :_poll %>
+            <%= erb :_poll_link %>
             <% if Sidekiq::Web.app_url %>
               <a class="btn btn-inverse" href="<%= Sidekiq::Web.app_url %>">Back to App</a>
             <% end %>

--- a/web/views/_poll_js.erb
+++ b/web/views/_poll_js.erb
@@ -1,0 +1,5 @@
+<% if current_path != '' && params[:poll] %>
+  <script>
+    updatePage('<%= root_path + current_path %>')
+  </script>
+<% end %>

--- a/web/views/_poll_link.erb
+++ b/web/views/_poll_link.erb
@@ -1,8 +1,5 @@
 <% if current_path != '' %>
   <% if params[:poll] %>
-    <script>
-      updatePage('<%= root_path + current_path %>')
-    </script>
     <a id="live-poll" class="btn btn-primary active" href="<%= root_path + current_path %>"><%= t('StopPolling') %></a>
   <% else %>
     <a id="live-poll" class="btn btn-primary" href="<%= root_path + current_path %>?<%= qparams(poll: true) %>"><%= t('LivePoll') %></a>

--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -26,5 +26,6 @@
       </div>
     </div>
     <%=  erb :_footer %>
+    <%= erb :_poll_js %>
   </body>
 </html>


### PR DESCRIPTION
Previously, the JS function `updatePage()` was being called twice when polling is enabled (when the query string is `?poll=true`), creating two `setInterval` timers that each make an HTTP request every second and causing polling updates to look jittery. The polling link was rendered twice in the nav, once for desktop-sized browsers and once for mobile-sized browsers, and the function was called once during each render.

This PR breaks the `_poll` partial into two partials, one for the link and one for the JS, so that the JS can be called only once. I've added a test and have also tested this manually for all views in the web UI. Other solutions exist, too; I'm happy to rewrite this if another solution is preferred.