### PR TITLE
Hide redis url if url length more than 40 characters

### DIFF
--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -80,4 +80,12 @@ $(function() {
     $('[data-navbar="custom-tab"]').hide()
     $('[data-navbar="dropdown"]').show()
   }
+
+  $(document).on('click', '.redis-url button', function () {
+    $('.redis-url button').toggle()
+  })
+
+  if ($('.redis-url__text').text().length > 40) {
+    $('.redis-url button').toggle()
+  }
 });

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -742,9 +742,22 @@ div.interval-slider input {
   }
 }
 
-.redis-url, .redis-namespace {
+.redis-namespace {
   overflow: hidden;
   white-space: nowrap;
+}
+
+.redis-url button {
+  background: transparent;
+  border: 0;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  color: #999;
+  padding: 0;
+}
+
+.redis-url__show {
+  display: none;
 }
 
 @media (min-width: 768px) {

--- a/web/views/_footer.erb
+++ b/web/views/_footer.erb
@@ -6,7 +6,11 @@
             <p class="navbar-text" style="color:white;"><%= product_version %></p>
           </li>
           <li>
-            <p class="navbar-text redis-url">Redis: <%= redis_connection %></p>
+            <p class="navbar-text redis-url">
+              Redis:
+              <button class="redis-url__text"><%= redis_connection %></button>
+              <button class="redis-url__show">(show)</button>
+            </p>
           </li>
           <li>
             <p class="navbar-text"><%= t('Time') %>: <%= Time.now.utc.strftime('%H:%M:%S UTC') %></p>


### PR DESCRIPTION
Refer to #2411 
I think that best way to display redis url is hide this url if it's length more than 40 (or may be more?) characters.
Therefore I created toggle button with redis url and `(show)` text (also may be is better to translate this text for each locale file?).

### gif:
![hfmvk16xaq](https://cloud.githubusercontent.com/assets/1147484/8406044/8b7c0280-1e61-11e5-82d1-01f8860b8474.gif)