### PR TITLE
Stringify keys

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -211,6 +211,9 @@ module Sidekiq
 
     def normalize_item(item)
       raise(ArgumentError, "Message must be a Hash of the form: { 'class' => SomeWorker, 'args' => ['bob', 1, :foo => 'bar'] }") unless item.is_a?(Hash)
+
+      item = stringify_keys(item)
+
       raise(ArgumentError, "Message must include a class and set of arguments: #{item.inspect}") if !item['class'] || !item['args']
       raise(ArgumentError, "Message args must be an Array") unless item['args'].is_a?(Array)
       raise(ArgumentError, "Message class must be either a Class or String representation of the class name") unless item['class'].is_a?(Class) || item['class'].is_a?(String)
@@ -231,6 +234,14 @@ module Sidekiq
         item_class.get_sidekiq_options
       else
         Sidekiq.default_worker_options
+      end
+    end
+
+    def stringify_keys(hash)
+      hash.tap do |h|
+        h.keys.each do |key|
+          h[key.to_s] = h.delete(key)
+        end
       end
     end
   end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -90,6 +90,30 @@ class TestClient < Sidekiq::Test
       @redis.verify
     end
 
+    it 'pushes messages to redis using a symbol for the queue parameter' do
+      @redis.expect :lpush, 1, ['queue:foo', Array]
+      pushed = Sidekiq::Client.push(queue: 'foo', 'class' => 'MyWorker', 'args' => [1, 2])
+      assert pushed
+      assert_equal 24, pushed.size
+      @redis.verify
+    end
+
+    it 'pushes messages to redis using a symbol for the class parameter' do
+      @redis.expect :lpush, 1, ['queue:foo', Array]
+      pushed = Sidekiq::Client.push('queue' => 'foo', class: 'MyWorker', 'args' => [1, 2])
+      assert pushed
+      assert_equal 24, pushed.size
+      @redis.verify
+    end
+
+    it 'pushes messages to redis using a symbol for the args parameter' do
+      @redis.expect :lpush, 1, ['queue:foo', Array]
+      pushed = Sidekiq::Client.push('queue' => 'foo', 'class' => 'MyWorker', args: [1, 2])
+      assert pushed
+      assert_equal 24, pushed.size
+      @redis.verify
+    end
+
     class MyWorker
       include Sidekiq::Worker
     end


### PR DESCRIPTION
Convert hash keys to strings in the following scenario:

```ruby
Sidekiq.push(class: 'MyClass', args: [])
```

Note that the parameter to `push` is a `Hash` whose keys are `Symbol`s, not `String`s. Sidekiq only checks for `String`s, so we convert them.

This happened to me and took me a while to figure out what was wrong.