### PR TITLE
Allow for the creation directories when indicating a pidfile

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -344,6 +344,8 @@ module Sidekiq
     def write_pid
       if path = options[:pidfile]
         pidfile = File.expand_path(path)
+        directory = File.dirname(pidfile)
+        FileUtils.mkdir_p(directory)
         File.open(pidfile, 'w') do |f|
           f.puts ::Process.pid
         end


### PR DESCRIPTION
This is useful to avoid failing if indicating a PID file in a folder.