### PR TITLE
Add a flag to disable errors until retries are exhausted

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -133,7 +133,9 @@ module Sidekiq
             retries_exhausted(worker, msg)
           end
 
-          raise exception
+          if !msg['raise_on_dead'] || count >= max_retry_attempts
+            raise exception
+          end
         end
 
         def retries_exhausted(worker, msg)


### PR DESCRIPTION
A common pattern we run into, is that we want to suppress some jobs errors until they have exhausted retries. For example, a job that makes HTTP calls to another service and logs events. It's not helpful to see 1-2 exceptions for transient HTTP errors when it just retries successfully.

This adds a flag that disables raising until retries are exhausted, which is disabled by default to preserve existing functionality.