### PR TITLE
Resolve Celluloid 0.17.0 compatibility.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,7 @@ HEAD
 -----------
 
 - Safer display of job data in Web UI [#2405]
+- Updated for compatibility with Celluloid `0.17.*`
 
 3.4.1
 -----------

--- a/lib/sidekiq/fetch.rb
+++ b/lib/sidekiq/fetch.rb
@@ -66,7 +66,7 @@ module Sidekiq
       @down ||= Time.now
       pause
       after(0) { fetch }
-    rescue Task::TerminatedError
+    rescue Celluloid::TaskTerminated
       # If redis is down when we try to shut down, all the fetch backlog
       # raises these errors.  Haven't been able to figure out what I'm doing wrong.
     end

--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -104,7 +104,7 @@ module Sidekiq
           # of workers), and 5 random seconds to ensure they don't all hit Redis at the same time.
           sleep(INITIAL_WAIT) unless Sidekiq.options[:poll_interval_average]
           sleep(5 * rand)
-        rescue Celluloid::Task::TerminatedError
+        rescue Celluloid::TaskTerminated
           # Hit Ctrl-C when Sidekiq is finished booting and we have a chance
           # to get here.
         end

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -11,7 +11,9 @@ end
 
 gem 'rails'
 gem 'sidekiq', :path => '..'
-gem 'pry-byebug'
+
+#de Does not work with jruby or rbx:
+#de gem 'pry-byebug'
 
 # sidekiq-web dependencies
 gem 'sinatra'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,7 @@ end
 require 'minitest/autorun'
 require 'minitest/pride'
 
+require 'celluloid/current'
 require 'celluloid/test'
 Celluloid.boot
 require 'sidekiq'


### PR DESCRIPTION
I looked through `sidekiq` and this one line was the only thing holding back all the tests. Otherwise, everything seems correct as it is.

Closes #2397 
Closes #2420

That's happening in that one line, is that the actorsystem is allowed to initialize, which in turn populates the `Tree` who is complaining in the tests. *Then* we can set the global testing flag and go about our business, `boot` etc.