### PR TITLE
Change typo in German translation

### DIFF
--- a/web/locales/de.yml
+++ b/web/locales/de.yml
@@ -47,7 +47,7 @@ de:
   GoBack: ← Zurück
   NoScheduledFound: Keine geplanten Jobs gefunden
   When: Wann
-  ScheduledJobs: Jobs in Wartschlange
+  ScheduledJobs: Jobs in der Warteschlange
   idle: inaktiv
   active: aktiv
   Version: Version


### PR DESCRIPTION
Fixes a small typo and a missing german article in the translation for Germans.