### PR TITLE
Better pt-BR locales in web UI

### DIFF
--- a/web/assets/javascripts/locales/jquery.timeago.pt-br.js
+++ b/web/assets/javascripts/locales/jquery.timeago.pt-br.js
@@ -1,16 +1,16 @@
-// Brazilian Portuguese 
+// Brasilian Portuguese
 jQuery.timeago.settings.strings = {
    suffixAgo: "atrás",
-   suffixFromNow: "nesse momento",
-   seconds: "alguns segundos",
-   minute: "há um minuto",
-   minutes: "há %d minutos",
-   hour: "há uma hora",
-   hours: "há %d horas",
-   day: "há um dia",
-   days: "há %d dias",
-   month: "há um mês",
-   months: "há %d meses",
-   year: "há um ano",
-   years: "há %d anos"
+   suffixFromNow: "a partir de agora",
+   seconds: "menos de um minuto",
+   minute: "cerca de um minuto",
+   minutes: "%d minutos",
+   hour: "cerca de uma hora",
+   hours: "cerca de %d horas",
+   day: "um dia",
+   days: "%d dias",
+   month: "cerca de um mês",
+   months: "%d meses",
+   year: "cerca de um ano",
+   years: "%d anos"
 };


### PR DESCRIPTION
As a `Portuguese` native speaker I've always found a little bit weird the messages in the locale UI. Digging into the code, I could see that the same `pt-PT` locale matches perfectly with `pt-BR`. It is closer than the `English` version and gramatically correct.

The way it was before, e.g: `há uma hora nesse momento` (meaning `one hour from now on`) is grammatically incorrect because `há` is used only in the past and not for future sentences. `nesse momento` means more `right now` than `from now` (changed now to `a partir de agora`).

Any portuguese speaker here? :smile: 

**before**
<img width="1234" alt="bildschirmfoto 2015-07-22 um 15 11 14" src="https://cloud.githubusercontent.com/assets/356881/8833584/e86d954a-3085-11e5-8b5b-70b9556ecf92.png">
<img width="1190" alt="bildschirmfoto 2015-07-22 um 15 27 06" src="https://cloud.githubusercontent.com/assets/356881/8833627/258c298c-3086-11e5-9e97-9474a16e7cb5.png">
<img width="1186" alt="bildschirmfoto 2015-07-22 um 15 27 12" src="https://cloud.githubusercontent.com/assets/356881/8833628/258cbc3a-3086-11e5-8378-1b0852c66dd6.png">

_________________________________________________________________________________

**after**
<img width="1225" alt="bildschirmfoto 2015-07-22 um 15 19 14" src="https://cloud.githubusercontent.com/assets/356881/8833586/ed56e16a-3085-11e5-9251-8b71ae1c101a.png">
<img width="1182" alt="bildschirmfoto 2015-07-22 um 15 26 55" src="https://cloud.githubusercontent.com/assets/356881/8833631/2c4d5660-3086-11e5-858b-d26d1b36c891.png">
<img width="1198" alt="bildschirmfoto 2015-07-22 um 15 26 48" src="https://cloud.githubusercontent.com/assets/356881/8833632/2c6c0fe2-3086-11e5-90ec-6e3c363c834a.png">

**PS.** Since I'm here, is there any particular reason that in `English` we have: `about %d minutes`, `about %d hours`, and just `%d months` and `%d years`?

```javascript
// English (Template)
jQuery.timeago.settings.strings = {
  prefixAgo: null,
  prefixFromNow: null,
  suffixAgo: "ago",
  suffixFromNow: "from now",
  seconds: "less than a minute",
  minute: "about a minute",
  minutes: "%d minutes",
  hour: "about an hour",
  hours: "about %d hours",
  day: "a day",
  days: "%d days",
  month: "about a month",
  months: "%d months",
  year: "about a year",
  years: "%d years",
  wordSeparator: " ",
  numbers: []
};
```

Thanks :smiley: 