### PR TITLE
Grab the "created at" time as the "enqueued" time for scheduled jobs,…

### DIFF
--- a/web/views/_job_info.erb
+++ b/web/views/_job_info.erb
@@ -34,7 +34,7 @@
       </tr>
       <tr>
         <th><%= t('Enqueued') %></th>
-        <td><%= relative_time(job.enqueued_at) %></td>
+        <td><%= relative_time(job.enqueued_at || job.created_at) %></td>
       </tr>
       <% unless retry_extra_items(job).empty? %>
         <tr>


### PR DESCRIPTION
… since enqueued_at only gets set when jobs are put into queues, not when they are scheduled (from #2376).

---

After upgrading to the latest gems, doing

```ruby
MyWorker.perform_in(10.minutes)
```

looks like it was enqueued 46 years ago in the dashboard:

![image](https://cloud.githubusercontent.com/assets/832655/8878714/956d2178-31fa-11e5-82b2-d75b10abab97.png)
