### PR TITLE
Grab the "created at" time as the "enqueued" time for scheduled jobs,…

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -312,7 +312,7 @@ module Sidekiq
     end
 
     def enqueued_at
-      Time.at(@item['enqueued_at'] || 0).utc
+      Time.at(@item['enqueued_at'] || @item['created_at'] || 0).utc
     end
 
     def created_at


### PR DESCRIPTION
… since enqueued_at only gets set when jobs are put into queues, not when they are scheduled (from #2376).

---

After upgrading to the latest gems, doing

```ruby
MyWorker.perform_in(10.minutes)
```

looks like it was enqueued 46 years ago in the dashboard:

![image](https://cloud.githubusercontent.com/assets/832655/8878714/956d2178-31fa-11e5-82b2-d75b10abab97.png)

---

You can also see it causing problems here:
```
2.2.1 :001 > s = Sidekiq::ScheduledSet.new
2.2.1 :002 > s.to_a.map {|x| x.enqueued_at}
 => [2015-07-23 20:50:03 UTC, 2015-07-17 21:55:03 UTC, 1970-01-01 00:00:00 UTC, 1970-01-01 00:00:00 UTC, 2015-06-08 21:26:34 UTC, 2015-06-19 20:16:43 UTC, 2015-06-22 15:04:19 UTC]
```