### PR TITLE
Refactor pulsing beacon

### DIFF
--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -227,14 +227,8 @@ var updateRedisStats = function(data) {
 }
 
 var pulseBeacon = function(){
-  $beacon = $('.beacon')
-  $beacon.find('.dot').addClass('pulse').delay(1000).queue(function(){
-    $(this).removeClass('pulse');
-    $(this).dequeue();
-  });
-  $beacon.find('.ring').addClass('pulse').delay(1000).queue(function(){
-    $(this).removeClass('pulse');
-    $(this).dequeue();
+  $('.beacon').addClass('pulse').delay(1000).queue(function(){
+    $(this).removeClass('pulse').dequeue();
   });
 }
 

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -490,7 +490,7 @@ div.interval-slider input {
   z-index: 10;
 }
 
-.beacon .dot.pulse {
+.beacon.pulse .dot {
   -webkit-animation: beacon-dot-pulse 1s ease-out;
   -moz-animation: beacon-dot-pulse 1s ease-out;
   animation: beacon-dot-pulse 1s ease-out;
@@ -573,7 +573,7 @@ div.interval-slider input {
   z-index: 5;
 }
 
-.beacon .ring.pulse {
+.beacon.pulse .ring {
   -webkit-animation: beacon-ring-pulse 1s;
   -moz-animation: beacon-ring-pulse 1s;
   animation: beacon-ring-pulse 1s;


### PR DESCRIPTION
Hi,

Here's a fix for a not very efficient use of the `pulse` class in the dashboard. Instead of updating two elements, updating only `.beacon`, which simplifies JS a bit.