### PR TITLE
Do not perform redundant job look-up on delete for SortedEntry

### DIFF
--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -340,14 +340,12 @@ class TestApi < Sidekiq::Test
       assert_in_delta Time.now.to_f, retri.at.to_f, 0.02
     end
 
-    it 'can delete multiple retries from score' do
-      same_time = Time.now.to_f
-      add_retry('bob1', same_time)
-      add_retry('bob2', same_time)
-      r = Sidekiq::RetrySet.new
-      assert_equal 2, r.size
-      Sidekiq::RetrySet.new.delete(same_time)
-      assert_equal 0, r.size
+    it 'requires a jid to delete an entry' do
+      start_time = Time.now.to_f
+      add_retry('bob2', Time.now.to_f)
+      assert_raises(ArgumentError) do
+        Sidekiq::RetrySet.new.delete(start_time)
+      end
     end
 
     it 'can delete a single retry from score and jid' do


### PR DESCRIPTION
#2472  

So I've done a number of things to the SortedEntry delete. 
a) Use `zrem` right away if we already have the `@value` for the job by-passing a redundant lookup.
b) Seperated SortedEntry into delete_by_jid and delete_by_score, properly the former could be a LUA Script, but Sidekiq states support for Redis > 2.4 so I didn't do that in this PR. 

I separated the single delete into `delete_by_jid`, `delete_by_score`, and `delete_by_value`. One concern is as I mentioned that a single monolithic method that does potentially different things is hard to hook into, another plus is that unlike the old `delete` -  `delete_by_score` can take a range. 

One thing I'm really not sure about is whether `delete_by_value` should be on SortedEntry or on SortedSet, although I opted for the later because SortedEntry doesn't have access to `@_size` atm. 

An equivalent of the old `delete` is kept on SortedSet for backwards compatibility.

c) Switched to using the return value of `zrem` / `zremrangebyscore` instead of zcard, as far as I understand this should always be equivalent to setting @_size with zcard and will save an extra redis call. 

