### PR TITLE
prevent invalid concurrency from causing hard to debug problems

### DIFF
--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -27,6 +27,7 @@ module Sidekiq
       logger.debug { options.inspect }
       @options = options
       @count = options[:concurrency] || 25
+      raise ArgumentError, "Concurrency of #{@count} is not supported" if @count < 1
       @done_callback = nil
       @finished = condvar
 

--- a/test/test_manager.rb
+++ b/test/test_manager.rb
@@ -88,6 +88,11 @@ class TestManager < Sidekiq::Test
       fetcher.verify
     end
 
+    it 'does not support invalid concurrency' do
+      assert_raises(ArgumentError) { new_manager(concurrency: 0) }
+      assert_raises(ArgumentError) { new_manager(concurrency: -1) }
+    end
+
     describe 'heartbeat' do
       before do
         uow = Object.new


### PR DESCRIPTION
cocurrency 0 makes the manager just sit there and do nothing,
which is hard to debug / understand without knowing what to look for

we were passing concurrency via an ENV variable, so it was not obvious that this was the problem,
looked into queues / redis trouble first before realizing this ... since I think there is no valid usecase for 0 / negative concurrency, this would be a nice fix to prevent this in the future ...

@mperham 
@melvinram