### PR TITLE
Update change log to fix "typo"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@ HEAD
 - Activate sessions in Sinatra for CSRF protection.  See issue #2460
   if you see a Rails error with `ActionDispatch::Request::Session`
   on upgrade.  This is a Rails incompatibility with Rack and not a
-  Sidekiq bug. The issue contains a moneypatch workaround. [#2460]
+  Sidekiq bug. The issue contains a monkeypatch workaround. [#2460]
 
 3.4.2
 -----------


### PR DESCRIPTION
Looks like a typo in the changelog, though I think you may have coined a new term for future use.