### PR TITLE
Remove Sidekiq::Client.default since memoization can break sharding with batches

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -119,16 +119,12 @@ module Sidekiq
 
     class << self
 
-      def default
-        @default ||= new
-      end
-
       def push(item)
-        default.push(item)
+        new.push(item)
       end
 
       def push_bulk(items)
-        default.push_bulk(items)
+        new.push_bulk(items)
       end
 
       # Resque compatibility helpers.  Note all helpers


### PR DESCRIPTION
I think this is a fairly subtle bug. Basically, in our code, the only time `Sidekiq::Client.push` gets called is from batch callbacks. I think that the memoization of the pool is causing issues. This is really subtle, I believe it has happened to 1 out of thousands of batches for me, but here's a conceptual idea of how it could happen.

```ruby
# Sets the default client, will be fixed to shard 1
Sidekiq::Client.default

# Change my pool to be shard 2 (perhaps in an initializer)
Sidekiq.redis = shard_2_pool

b = Sidekiq::Batch.new
b.on(:success, DoSomething)
b.jobs { MyWorker.perform_async }
```

Then the batch callback may run on shard 1 if this worker runs the final job, because the batch callbacks use `Sidekiq::Client.push` which uses the memoized `default`. This will then fail with "no such batch" because the batch lives on shard 2.

Basically, `default` is now dangerous because `Sidekiq::Client`'s pool can be changed.