### PR TITLE
Fixed 'Getting Started' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Installation
 Getting Started
 -----------------
 
-See the [sidekiq home page](http://sidekiq.org) for the simple 3-step process.
+See the [Getting Started wiki page](https://github.com/mperham/sidekiq/wiki/Getting-Started) and follow the simple setup process.
 You can watch [Railscast #366](http://railscasts.com/episodes/366-sidekiq) to see Sidekiq in action.  If you do everything right, you should see this:
 
 ![Web UI](https://github.com/mperham/sidekiq/raw/master/examples/web-ui.png)


### PR DESCRIPTION
The Sidekiq homepage no longer(?) contains the setup process. Instead this link should go directly to the Getting Started wiki page.

Also, it's technically a 4-step process which sounds weird and more complicated than it actually is. Replaced '3-step' with 'setup'