### PR TITLE
Add percent change to queues when polling

### DIFF
--- a/web/assets/javascripts/queues.js
+++ b/web/assets/javascripts/queues.js
@@ -1,0 +1,40 @@
+var getQueueSizes = function() {
+  return $('table.queues tbody tr').map(function(index, item) {
+    return parseInt(item.cells[1].innerHTML.match(/[0-9,]+/, '')[0].replace(',', ''), 10);
+  });
+};
+
+var updateQueueChange = function(queueSizes) {
+  $('table.queues tbody tr').map(function(index, item) {
+    var $cell = $(item.cells[1]),
+        count = parseInt(item.cells[1].innerHTML.replace(/\D/g, ''), 10),
+        diff = count - queueSizes[index],
+        percent, span;
+
+    queueSizes[index] = count;
+
+    if (diff === 0) { return; }
+
+    percent = (Math.round(diff / queueSizes[index] * 1000) / 10);
+    span  = '<span class="queue-change" style="color: ' + (diff > 0 ? '#AC1203' : '#7c9b27') + ';">';
+    span += '(' + diff + ' ' + (diff > 0 ? '&#9650; ' : '&#9660; ') + percent + '%)</span>';
+    span += '</span>';
+
+    $cell.width($cell.width());
+    item.cells[1].innerHTML = item.cells[1].innerHTML + span;
+  });
+};
+
+$(function(){
+  var currentQueueSizes = getQueueSizes();
+
+  $(document).ajaxComplete(function(event, jqxhr, settings) {
+    if (window.location.pathname != '/sidekiq/queues') { return; }
+    if (settings.url != '/sidekiq/queues') { return; }
+
+    window.setTimeout(function() {
+      updateQueueChange(currentQueueSizes);
+      currentQueueSizes = getQueueSizes();
+    }, 0);
+  });
+});

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -1,3 +1,4 @@
+<script type="text/javascript" src="<%= root_path %>javascripts/queues.js"></script>
 <h3><%= t('Queues') %></h3>
 
 <div class="table_container">


### PR DESCRIPTION
When polling is enabled on `/queues` this adds a percent change to each queue size. It's helpful to get an at-a-glance idea for how various queues are changing or to help determine rate of change. Some future work could be adding average change size over time.

<img width="228" alt="screen shot 2015-08-31 at 9 34 07 am" src="https://cloud.githubusercontent.com/assets/847027/9587030/437d6988-4fee-11e5-9e0a-fc9339df26f0.png">