### PR TITLE
Add middleware stack to Testing

### DIFF
--- a/test/test_testing_fake.rb
+++ b/test/test_testing_fake.rb
@@ -267,5 +267,43 @@ class TestTesting < Sidekiq::Test
       worker.expect(:perform, nil, [1, 2, 3])
       DirectWorker.execute_job(worker, [1, 2, 3])
     end
+
+    describe 'with middleware' do
+      class AttributeWorker
+        include Sidekiq::Worker
+        class_attribute :count
+        self.count = 0
+        attr_accessor :foo
+
+        def perform
+          self.class.count += 1 if foo == :bar
+        end
+      end
+
+      class AttributeMiddleware
+        def call(worker, msg, queue)
+          worker.foo = :bar if worker.respond_to?(:foo=)
+          yield
+        end
+      end
+
+      before do
+        Sidekiq::Testing.server_middleware do |chain|
+          chain.add AttributeMiddleware
+        end
+      end
+
+      after do
+        Sidekiq::Testing.server_middleware do |chain|
+          chain.clear
+        end
+      end
+
+      it 'wraps the inlined worker with middleware' do
+        AttributeWorker.perform_async
+        AttributeWorker.perform_one
+        assert_equal 1, AttributeWorker.count
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a middleware stack to `Testing` that simulates the server side stack.  This is useful for all server middleware that doesn't rely on the job structure in redis.