### PR TITLE
Change the deprecated serve_static_assets to serve_static_files configs

### DIFF
--- a/myapp/config/environments/production.rb
+++ b/myapp/config/environments/production.rb
@@ -9,7 +9,7 @@ Myapp::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/myapp/config/environments/test.rb
+++ b/myapp/config/environments/test.rb
@@ -8,7 +8,7 @@ Myapp::Application.configure do
   config.cache_classes = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   config.eager_load = false


### PR DESCRIPTION
In the Rails 5 `#serve_static_assets` will be deprecated in favour of `#serve_static_files`.