### PR TITLE
Map retry_in period to integer

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -181,7 +181,7 @@ module Sidekiq
 
         def retry_in(worker, count)
           begin
-            worker.sidekiq_retry_in_block.call(count)
+            worker.sidekiq_retry_in_block.call(count).to_i
           rescue Exception => e
             handle_exception(e, { context: "Failure scheduling retry using the defined `sidekiq_retry_in` in #{worker.class.name}, falling back to default" })
             nil


### PR DESCRIPTION
According to [wiki](https://github.com/mperham/sidekiq/wiki/Error-Handling). The return value of the block must be an integer.

However many users like to use 1.hour / 2.days / 34.seconds syntax from `Activesupport::Duration`.  All Activesupport::Duration instances can be mapped to integer with `to_i` method. Lets map it than!

```
 # The current retry count is yielded. The return value of the block must be 
  # an integer. It is used as the delay, in seconds. 
  sidekiq_retry_in do |count|
    10 * (count + 1) # (i.e. 10, 20, 30, 40)
  end
```