### PR TITLE
gracefully handle connection errors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,8 @@
-Next
+HEAD
 -----------
 
-- Add middleware stack to testing harness; see [wiki documentation](https://github.com/mperham/sidekiq/wiki/Testing#testing-server-middleware) [#2534, ryansch]
+- Disconnect and retry Redis operations if we see a READONLY error [#2550]
+- Add server middleware testing harness; see [wiki](https://github.com/mperham/sidekiq/wiki/Testing#testing-server-middleware) [#2534, ryansch]
 
 3.5.0
 -----------


### PR DESCRIPTION
ref: https://github.com/redis/redis-rb/issues/543

When AWS ElastiCache fails over from one node to another node, redis clients can be left connected to the original node which is now read-only. Sidekiq will then be unable to continue accepting or processing jobs until the connections are reset.

It seems that the best place to handle the exception would be within the sidekiq code as there are reasons why a general redis client might want to continue holding a connection to a read-only redis slave.

the specific error raised when this happens is:
`Redis::CommandErrorREADONLY You can't write against a read only slave.`

Ideally when this type of error occurs, sidekiq should drop the redis connection and retry the operation.