### PR TITLE
Wait after KILL signal

### DIFF
--- a/bin/sidekiqctl
+++ b/bin/sidekiqctl
@@ -64,19 +64,18 @@ class Sidekiqctl
   end
 
   def stop
-    Process.kill(:TERM, pid)
-    kill_timeout.times do
-      begin
-        Process.getpgid(pid)
-      rescue Errno::ESRCH
-        FileUtils.rm_f pidfile
-        done 'Sidekiq shut down gracefully.'
+    %i(TERM KILL).each do |signal|
+      Process.kill(signal, pid)
+      kill_timeout.times do
+        begin
+          Process.getpgid(pid)
+        rescue Errno::ESRCH
+          FileUtils.rm_f pidfile
+          done "Sidekiq shut down #{signal == :TERM ? 'gracefully' : 'forcefully'}."
+        end
+        sleep 1
       end
-      sleep 1
     end
-    Process.kill(:KILL, pid)
-    FileUtils.rm_f pidfile
-    done 'Sidekiq shut down forcefully.'
   end
   alias_method :shutdown, :stop
 end


### PR DESCRIPTION
Initializer
------------

```ruby
Sidekiq.configure_server do |config|
        config.redis = { url: ENV['REDIS_URL'] }
end
```

Versions
-----------

- Ruby : 2.1.6
- Rails : 4.1.5
- Sidekiq : 3.4.1
- OS : ubuntu 14.04 

There's no backtrace.
Before when I was deploying my rails application with capistrano-sidekiq, sidekiq didn't start.
Because a pid file existed, so sidekiq didn't start.
So I want to check process running after sending KILL signal.
 