### PR TITLE
Fix Norwegian Bokmål (nb) translations

### DIFF
--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -39,6 +39,15 @@ class TestWeb < Sidekiq::Test
       rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'en-us'}
       get '/', {}, rackenv
       assert_match(/Dashboard/, last_response.body)
+      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'zh-cn'}
+      get '/', {}, rackenv
+      assert_match(/信息板/, last_response.body)
+      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'zh-tw'}
+      get '/', {}, rackenv
+      assert_match(/資訊主頁/, last_response.body)
+      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'nb'}
+      get '/', {}, rackenv
+      assert_match(/Oversikt/, last_response.body)
     end
 
     describe 'busy' do

--- a/test/test_web_helpers.rb
+++ b/test/test_web_helpers.rb
@@ -41,6 +41,9 @@ class TestWebHelpers < Sidekiq::Test
     obj = Helpers.new('HTTP_ACCEPT_LANGUAGE' => 'zh-CN,zh;q=0.8,en-US;q=0.6,en;q=0.4,ru;q=0.2')
     assert_equal 'zh-cn', obj.locale
 
+    obj = Helpers.new('HTTP_ACCEPT_LANGUAGE' => 'nb-NO,nb;q=0.2')
+    assert_equal 'nb', obj.locale
+
     obj = Helpers.new('HTTP_ACCEPT_LANGUAGE' => 'en-us; *')
     assert_equal 'en', obj.locale
 

--- a/web/locales/nb.yml
+++ b/web/locales/nb.yml
@@ -1,5 +1,5 @@
 # elements like %{queue} are variables and should not be translated
-no:
+nb:
   Dashboard: Oversikt
   Status: Status
   Time: Tid
@@ -33,6 +33,7 @@ no:
   NextRetry: Neste forsøk
   RetryCount: Antall forsøk
   RetryNow: Forsøk igjen nå
+  Kill: Kill
   LastRetry: Forrige forsøk
   OriginallyFailed: Feilet opprinnelig
   AreYouSure: Er du sikker?
@@ -58,7 +59,6 @@ no:
   OneMonth: 1 måned
   ThreeMonths: 3 måneder
   SixMonths: 6 måneder
-  Batches: Samlinger
   Failures: Feil
   DeadJobs: Døde jobber
   NoDeadJobsFound: Ingen døde jobber funnet
@@ -67,3 +67,11 @@ no:
   Thread: Tråd
   Threads: Tråder
   Jobs: Jobber
+  Paused: Pauset
+  Stop: Stopp
+  Quiet: Demp
+  StopAll: Stopp alle
+  QuietAll: Demp alle
+  PollingInterval: Oppdateringsintervall
+  Plugins: Innstikk
+  NotYetEnqueued: Ikke køet enda


### PR DESCRIPTION
Browsers configured to prefer content in Norwegian Bokmål send 'nb-NO,no' in the Accept-Language header.

Updated to match the English translations.