### PR TITLE
concurrency value should also accept string as value

### DIFF
--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -26,7 +26,7 @@ module Sidekiq
     def initialize(condvar, options={})
       logger.debug { options.inspect }
       @options = options
-      @count = options[:concurrency] || 25
+      @count = (options[:concurrency] || 25).to_i
       raise ArgumentError, "Concurrency of #{@count} is not supported" if @count < 1
       @done_callback = nil
       @finished = condvar


### PR DESCRIPTION
We are sidekiq pro user and we use cloudformation templates to generate our UAT environments on Aws Opsworks. Now the problem is we  pass concurrency value as integer but the json that is generated by cloudformation for opsworks treat it as string and the yml that is generated for the sidekiq is like 

```
---
:index: 0
:concurrency: '12'
:verbose: false
:timeout: 600
:queues:
- default
- queueone
- queuetwo
- queuethree
:logfile: log/sidekiq.log
```

because concurrency value is string it fails to start.