### PR TITLE
Fix threads leak

### DIFF
--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -132,7 +132,7 @@ module Sidekiq
     # get handle to the underlying thread performing work for a processor
     # so we have it call us and tell us.
     def real_thread(proxy_id, thr)
-      @threads[proxy_id] = thr
+      @threads[proxy_id] = thr if thr.alive?
     end
 
     PROCTITLES = [


### PR DESCRIPTION
Together with my colleague @brainopia we continue to search for memory leaks in our application,
as previous issue (https://gist.github.com/gazay/3b518f72266b5a7e88ff) still wasn't the reason of many memory peaks.

And we've found an another leak, this time in Sidekiq itself, and this leak caused a number of problems.

Here is a problem:
```ruby
# https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/manager.rb#L135
def real_thread(proxy_id, thr)
  @threads[proxy_id] = thr
end
```

Before starting to execute the task, Processor does an async call to Manager (`real_thread` method) to add processor's thread to `@threads` hash in Manager.
After that, if work crashes – `trap_exit` calls `processor_died` method where the thread of processor
should be deleted from hash – so all links to this thread are gone, and it can be cleaned by GC. 
If something goes wrong – for example, the manager needs to execute many calls about 
processor crash – then there will be a race condition, 
and `processor_died` method will be finished before `real_thread`.
Celluloid doesn't allow to execute async calls without order,
but actor crash is a system event, which has the highest priority and goes to very beginning of the queue.
As a result, `@threads` hash now has a dead thread with all the things it holds.

You can reproduce this problem pretty easily with quite severe restrictions (100% of errors on 10-20 workers).
I've reproduced it also on lighter restrictions like 10% of errors and 100 workers, but it is very non-deterministic.

Another important moment is that if task takes a long time to execute enough before failing,
or can be retried (which is a pretty long operation – to put retry info back to Redis) –
most of events will be proceeded in right order.
It can be reproduced by adding magic `sleep 0.126` before raise.

You can reproduce this behavior with my script (https://gist.github.com/gazay/a106917e3adb74a11d50)
or by running `bin/sidekiqload` form this PR with `$TEST_THREADS=true`.

Here is output of my script. I don't start to count threads before finish because
it can hold threads some milliseconds and affect results of the test:

`concurency: 10, errors: 100%, tasks: 10_000, retry: 0`

`sidekiq v3.5.0, celluloid v0.17.2`

```bash
1001: 44MB
2000: 45MB
3000: 47MB
4000: 55MB
5001: 60MB
6001: 71MB
7000: 80MB
8001: 91MB
9001: 97MB
10000: 106MB
10000: 104MB (Fibers: 1200/2367, Threads: 18/1185)
```
`finished tasks: rss (Fibers: alive/total, Threads: alive/total)`

Here is output from `bin/sidekiqload` script, which is executed without latency to redis – 
this is a pretty common case for one-server applications, 
which have their redis on the same server. 

What is going on here – first 500 jobs finished without exception to heat up process. 
Then 2500 jobs raise an exception and after another 1000 tasks we start to track threads count – 
this way we don't affect test results by holding dead threads when we count them.

```
1:sidekiq:[fix_leaking ✗]$ bundle exec bin/sidekiqload
0.17.2
2015-10-09T17:28:13.758Z 32154 TID-ovok08cho INFO: Booting Sidekiq 3.5.1 with redis options {:db=>13, :port=>6380, :url=>nil}
2015-10-09T17:28:16.432Z 32154 TID-ovok08cho ERROR: Created 100000 jobs
2015-10-09T17:28:18.444Z 32154 TID-ovoka787o ERROR: RSS: 75792 Pending: 98683
2015-10-09T17:28:20.458Z 32154 TID-ovoka787o ERROR: RSS: 92140 Pending: 97693
2015-10-09T17:28:22.471Z 32154 TID-ovoka787o ERROR: RSS: 105100 Pending: 96573
2015-10-09T17:28:24.482Z 32154 TID-ovoka787o ERROR: RSS: 108484 Pending: 94582
2015-10-09T17:28:26.491Z 32154 TID-ovoka787o ERROR: RSS: 105508 Pending: 92607
2015-10-09T17:28:28.534Z 32154 TID-ovoka787o ERROR: RSS: 109308 Pending: 90569, Threads: 35/871
```

I understand that the situation when you have 10k failed jobs in one row is not exactly normal, but it still can happen. 
For example, in our application it happened when Facebook API wasn't available 
for couple hours couple times in last month. 
Our application runs hundreds of thousands of jobs using Facebook API,
and those are not so important jobs, as they just collect data every n-minutes.
We've rescued API-specific problems in those jobs, but we haven't rescued Network errors.
As result we had couple of OOM server restarts.

This PR fixes this problem