### PR TITLE
Add average_queue_poll_interval option

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -22,6 +22,7 @@ module Sidekiq
     timeout: 8,
     poll_interval_average: nil,
     average_scheduled_poll_interval: 15,
+    average_queue_poll_interval: 5,
     error_handlers: [],
     lifecycle_events: {
       startup: [],
@@ -156,6 +157,15 @@ module Sidekiq
   # See sidekiq/scheduled.rb for an in-depth explanation of this value
   def self.average_scheduled_poll_interval=(interval)
     self.options[:average_scheduled_poll_interval] = interval
+  end
+
+  # How frequently Redis should be checked by a random Sidekiq process for
+  # queued jobs. Each individual process will take turns by  waiting some
+  # multiple of this value.
+  #
+  # See sidekiq/fetch.rb for how this value is used
+  def self.average_queue_poll_interval=(interval)
+    self.options[:average_queue_poll_interval] = interval
   end
 
   # Register a proc to handle any error which occurs within the Sidekiq process.


### PR DESCRIPTION
The worker polls redis for the next work unit. If there is no work in the queues the worker repeats the call without any delay. This is the equivalent of busy wait loop. A large number of workers, all connecting to the same Redis, can easily kill redis performance. Enqueueing new jobs becomes painfully slow. We observe this behaviour in our production where we have 60+ workers running. To make matter worse we also use the sidekiq-limit_fetch plugin. This plugin runs Lua script embedded in Redis. This script is not fast either. With this patch we decrease the Redis load from 300K ops/s to 10K ops/s.

This patch adds a (configurable) delay to the loop. If there is no work in the queues, the worker waits a little before polling Redis again.

Sidekiq already does something like this for scheduled and retried jobs. I borrow the code from there to do the same for regular queued jobs.