### PR TITLE
Fix Styling Issues on Busy page

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -181,6 +181,10 @@ form .btn {
   margin-right: 5px;
 }
 
+form .btn-group .btn {
+  margin-right: 1px;
+}
+
 td form {
   margin-bottom: 0;
 }

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -12,7 +12,6 @@
     </form>
   </div>
 </div>
-</div>
 
 <div class="table_container">
   <table class="processes table table-hover table-bordered table-striped table-white">


### PR DESCRIPTION
I noticed bit weird layout in Busy page and I figured out there was redundant `div` enclosing tag that was messing up the html structure. I removed it.

Also, I fixed margin on form button groups that looked bit bad because of 5px margin. It just bothered me.