### PR TITLE
Automatically check for sidekiq.yml.erb filename

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -346,7 +346,11 @@ module Sidekiq
         die 1
       end
       @parser.parse!(argv)
-      opts[:config_file] ||= 'config/sidekiq.yml' if File.exist?('config/sidekiq.yml')
+
+      %w[config/sidekiq.yml config/sidekiq.yml.erb].each do |filename|
+        opts[:config_file] ||= filename if File.exist?(filename)
+      end
+
       opts
     end
 


### PR DESCRIPTION
Sidekiq performs ERB parsing on its config file, but it only checks for the existence of `sidekiq.yml`, not `sidekiq.yml.erb`.  Technically, this is a `.yml.erb` file, so Sidekiq should check for it.

The benefit of this change is that editors won't highlight the `sidekiq.yml` file as containing errors since it includes ERB but is not an ERB file.