### PR TITLE
Add the ability to have custom retry limits based on the exception

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -85,8 +85,12 @@ module Sidekiq
 
         private
 
+        def max_retries(exception)
+          @max_retries.is_a?(Proc) ? @max_retries.call(exception) : @max_retries
+        end
+
         def attempt_retry(worker, msg, queue, exception)
-          max_retry_attempts = retry_attempts_from(msg['retry'], @max_retries)
+          max_retry_attempts = retry_attempts_from(msg['retry'], max_retries(exception))
 
           msg['queue'] = if msg['retry_queue']
             msg['retry_queue']


### PR DESCRIPTION
This backwards-compatible change is intended to be used with primitives such as OverLimit from the Enterprise version so that retries can be more numerous and frequent for this case.