### PR TITLE
Latest concurrent-ruby release.

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency                  'redis-namespace', '~> 1.5', '>= 1.5.2'
   gem.add_dependency                  'connection_pool', '~> 2.2', '>= 2.2.0'
   gem.add_dependency                  'json', '~> 1.0'
-  gem.add_dependency                  'concurrent-ruby', '1.0.0.pre4'
+  gem.add_dependency                  'concurrent-ruby', '~> 1.0.0.pre5'
   gem.add_development_dependency      'sinatra', '~> 1.4', '>= 1.4.6'
   gem.add_development_dependency      'minitest', '~> 5.7', '>= 5.7.0'
   gem.add_development_dependency      'rake', '~> 10.0'


### PR DESCRIPTION
Last night I released concurrent-ruby 1.0.0.pre5. This is the last planned pre-release. Rails began using pre5 last night. There is nothing in this release that should affect Sidekiq. It's mainly performance improvements and a few small bug fixes (not related to the tools used here). We don't have any more work planned for 1.0. We're basically just waiting for Rails, Sidekiq, and a few others to upgrade to pre5 and run with it for a little bit. Please let me know ASAP if you discover any problems or bugs.