### PR TITLE
Set redis-namespace gem as dev dependency

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Sidekiq::VERSION
   gem.add_dependency                  'redis', '~> 3.2', '>= 3.2.1'
-  gem.add_dependency                  'redis-namespace', '~> 1.5', '>= 1.5.2'
   gem.add_dependency                  'connection_pool', '~> 2.2', '>= 2.2.0'
   gem.add_dependency                  'json', '~> 1.0'
   gem.add_dependency                  'concurrent-ruby', '~> 1.0.0.pre5'
+  gem.add_development_dependency      'redis-namespace', '~> 1.5', '>= 1.5.2'
   gem.add_development_dependency      'sinatra', '~> 1.4', '>= 1.4.6'
   gem.add_development_dependency      'minitest', '~> 5.7', '>= 5.7.0'
   gem.add_development_dependency      'rake', '~> 10.0'


### PR DESCRIPTION
Actually redis-namespace is still a dependency, move it dev dependency

* `redis-namespace` has been removed from Sidekiq's gem dependencies. If
  you want to use namespacing ([and I strongly urge you not to](http://www.mikeperham.com/2015/09/24/storing-data-with-redis/)), you'll need to add the gem to your Gemfile:
```ruby
gem 'redis-namespace'