### PR TITLE
Ensure comparison between strings

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -130,7 +130,7 @@ module Sidekiq
     #
     class << self
       def [](queue)
-        jobs[queue]
+        jobs[queue.to_s]
       end
 
       def jobs
@@ -203,7 +203,7 @@ module Sidekiq
 
       # Queue for this worker
       def queue
-        self.sidekiq_options["queue"]
+        self.sidekiq_options["queue"].to_s
       end
 
       # Jobs queued for this worker


### PR DESCRIPTION
Fixes the issue with comparing symbol to strings caused by #2659

I have a lot of symbols in my code and so do others. This pull request ensure that testing queus and jobs (just like production) are only ever compared as strings.