### PR TITLE
Remove nil qparams to avoid extra & in url generation

### DIFF
--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -160,7 +160,7 @@ module Sidekiq
       options = options.stringify_keys
       params.merge(options).map do |key, value|
         SAFE_QPARAMS.include?(key) ? "#{key}=#{value}" : next
-      end.join("&")
+      end.compact.join("&")
     end
 
     def truncate(text, truncate_after_chars = 2000)


### PR DESCRIPTION
<img width="651" alt="screen shot 2015-11-15 at 10 04 11 pm" src="https://cloud.githubusercontent.com/assets/1060/11171390/f54663a2-8be6-11e5-9cf1-7fa992a3e4c8.png">

I noticed that there were multiple `&` showing up when clicking on pagination links in the web interface, this pr compacts all the nil params before joining by `&` to avoid that happening anymore.