### PR TITLE
Queue Testing API

### DIFF
--- a/4.0-Upgrade.md
+++ b/4.0-Upgrade.md
@@ -25,6 +25,16 @@ gem 'redis-namespace'
   `concurrency + 2` connections in your pool or Sidekiq will exit.
   When in doubt, let Sidekiq size the connection pool for you.
 
+* There's a new testing API based off the `Sidekiq::Queues` namespace. All
+  assertions made against the Worker class still work as expected.
+```ruby
+assert_equal 0, Sidekiq::Queues["default"].size
+HardWorker.perform_async("log")
+assert_equal 1, Sidekiq::Queues["default"].size
+assert_equal "log", Sidekiq::Queues["default"].first['args'][0]
+Sidekiq::Queues.clear_all
+```
+
 ## Upgrade
 
 First, make sure you are using Redis 2.8 or greater. Next:

--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,16 @@
   and to remove dependencies.  This has resulted in major speedups, as
   [detailed on my blog](http://www.mikeperham.com/2015/10/14/optimizing-sidekiq/).
 - See the [4.0 upgrade notes](4.0-Upgrade.md) for more detail.
+- There's a new testing API based off the `Sidekiq::Queues` namespace. All
+  assertions made against the Worker class still work as expected.
+  [#2659, brandonhilkert]
+```ruby
+assert_equal 0, Sidekiq::Queues["default"].size
+HardWorker.perform_async("log")
+assert_equal 1, Sidekiq::Queues["default"].size
+assert_equal "log", Sidekiq::Queues["default"].first['args'][0]
+Sidekiq::Queues.clear_all
+```
 
 3.5.3
 -----------

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,19 @@
 # Sidekiq Changes
 
+4.0.2
+-----------
+
+- There's a new testing API based off the `Sidekiq::Queues` namespace. All
+  assertions made against the Worker class still work as expected.
+  [#2676, brandonhilkert]
+```ruby
+assert_equal 0, Sidekiq::Queues["default"].size
+HardWorker.perform_async("log")
+assert_equal 1, Sidekiq::Queues["default"].size
+assert_equal "log", Sidekiq::Queues["default"].first['args'][0]
+Sidekiq::Queues.clear_all
+```
+
 4.0.1
 -----------
 
@@ -13,16 +27,6 @@
   and to remove dependencies.  This has resulted in major speedups, as
   [detailed on my blog](http://www.mikeperham.com/2015/10/14/optimizing-sidekiq/).
 - See the [4.0 upgrade notes](4.0-Upgrade.md) for more detail.
-- There's a new testing API based off the `Sidekiq::Queues` namespace. All
-  assertions made against the Worker class still work as expected.
-  [#2659, brandonhilkert]
-```ruby
-assert_equal 0, Sidekiq::Queues["default"].size
-HardWorker.perform_async("log")
-assert_equal 1, Sidekiq::Queues["default"].size
-assert_equal "log", Sidekiq::Queues["default"].first['args'][0]
-Sidekiq::Queues.clear_all
-```
 
 3.5.3
 -----------

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -68,19 +68,77 @@ module Sidekiq
     def raw_push(payloads)
       if Sidekiq::Testing.fake?
         payloads.each do |job|
-          job['class'].constantize.jobs << Sidekiq.load_json(Sidekiq.dump_json(job))
+          Queues.jobs[job['queue']] << Sidekiq.load_json(Sidekiq.dump_json(job))
         end
         true
       elsif Sidekiq::Testing.inline?
         payloads.each do |job|
-          job['jid'] ||= SecureRandom.hex(12)
           klass = job['class'].constantize
-          klass.jobs.unshift Sidekiq.load_json(Sidekiq.dump_json(job))
-          klass.perform_one
+          job['id'] ||= SecureRandom.hex(12)
+          job_hash = Sidekiq.load_json(Sidekiq.dump_json(job))
+          klass.process_job(job_hash)
         end
         true
       else
         raw_push_real(payloads)
+      end
+    end
+  end
+
+  module Queues
+    ##
+    # The Queues class is only for testing the fake queue implementation.
+    # The data is structured as a hash with queue name as hash key and array
+    # of job data as the value.
+    #
+    # {
+    #   "default"=>[
+    #     {
+    #       "class"=>"TestTesting::QueueWorker",
+    #       "args"=>[1, 2],
+    #       "retry"=>true,
+    #       "queue"=>"default",
+    #       "jid"=>"abc5b065c5c4b27fc1102833",
+    #       "created_at"=>1447445554.419934
+    #     }
+    #   ]
+    # }
+    #
+    # Example:
+    #
+    #   require 'sidekiq/testing'
+    #
+    #   assert_equal 0, Sidekiq::Queues["default"].size
+    #   HardWorker.perform_async(:something)
+    #   assert_equal 1, Sidekiq::Queues["default"].size
+    #   assert_equal :something, Sidekiq::Queues["default"].first['args'][0]
+    #
+    # You can also clear all workers' jobs:
+    #
+    #   assert_equal 0, Sidekiq::Queues["default"].size
+    #   HardWorker.perform_async(:something)
+    #   Sidekiq::Queues.clear_all
+    #   assert_equal 0, Sidekiq::Queues["default"].size
+    #
+    # This can be useful to make sure jobs don't linger between tests:
+    #
+    #   RSpec.configure do |config|
+    #     config.before(:each) do
+    #       Sidekiq::Queues.clear_all
+    #     end
+    #   end
+    #
+    class << self
+      def [](queue)
+        jobs[queue]
+      end
+
+      def jobs
+        @jobs ||= Hash.new { |hash, key| hash[key] = [] }
+      end
+
+      def clear_all
+        jobs.clear
       end
     end
   end
@@ -143,28 +201,36 @@ module Sidekiq
     #
     module ClassMethods
 
+      # Queue for this worker
+      def queue
+        self.sidekiq_options["queue"]
+      end
+
       # Jobs queued for this worker
       def jobs
-        Worker.jobs[self]
+        Queues.jobs[queue].select { |job| job["class"] == self.to_s }
       end
 
       # Clear all jobs for this worker
       def clear
-        jobs.clear
+        Queues.jobs[queue].clear
       end
 
       # Drain and run all jobs for this worker
       def drain
-        while job = jobs.shift do
-          process_job(job)
+        while jobs.any?
+          next_job = jobs.first
+          Queues.jobs[queue].delete_if { |job| job["jid"] == next_job["jid"] }
+          process_job(next_job)
         end
       end
 
       # Pop out a single job and perform it
       def perform_one
         raise(EmptyQueueError, "perform_one called with empty job queue") if jobs.empty?
-        job = jobs.shift
-        process_job(job)
+        next_job = jobs.first
+        Queues.jobs[queue].delete_if { |job| job["jid"] == next_job["jid"] }
+        process_job(next_job)
       end
 
       def process_job(job)
@@ -183,18 +249,22 @@ module Sidekiq
 
     class << self
       def jobs # :nodoc:
-        @jobs ||= Hash.new { |hash, key| hash[key] = [] }
+        Queues.jobs.values.flatten
       end
 
       # Clear all queued jobs across all workers
       def clear_all
-        jobs.clear
+        Queues.clear_all
       end
 
       # Drain all queued jobs across all workers
       def drain_all
-        until jobs.values.all?(&:empty?) do
-          jobs.keys.each(&:drain)
+        while jobs.any?
+          worker_classes = jobs.map { |job| job["class"] }.uniq
+
+          worker_classes.each do |worker_class|
+            worker_class.constantize.drain
+          end
         end
       end
     end

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -88,11 +88,34 @@ module Sidekiq
   module Queues
     ##
     # The Queues class is only for testing the fake queue implementation.
-    # The data is structured as a hash with queue name as hash key and array
-    # of job data as the value.
+    # There are 2 data structures involved in tandem. This is due to the
+    # Rspec syntax of change(QueueWorker.jobs, :size). It keeps a reference
+    # to the array. Because the array was dervied from a filter of the total
+    # jobs enqueued, it appeared as though the array didn't change.
+    #
+    # To solve this, we'll keep 2 hashes containing the jobs. One with keys based
+    # on the queue, and another with keys of the worker names, so the array for
+    # QueueWorker.jobs is a straight reference to a real array.
+    #
+    # Queue-based hash:
     #
     # {
     #   "default"=>[
+    #     {
+    #       "class"=>"TestTesting::QueueWorker",
+    #       "args"=>[1, 2],
+    #       "retry"=>true,
+    #       "queue"=>"default",
+    #       "jid"=>"abc5b065c5c4b27fc1102833",
+    #       "created_at"=>1447445554.419934
+    #     }
+    #   ]
+    # }
+    #
+    # Worker-based hash:
+    #
+    # {
+    #   "TestTesting::QueueWorker"=>[
     #     {
     #       "class"=>"TestTesting::QueueWorker",
     #       "args"=>[1, 2],

--- a/test/test_testing_fake.rb
+++ b/test/test_testing_fake.rb
@@ -54,6 +54,7 @@ class TestTesting < Sidekiq::Test
 
     after do
       Sidekiq::Testing.disable!
+      Sidekiq::Queues.clear_all
     end
 
     it 'stubs the async call' do
@@ -93,7 +94,7 @@ class TestTesting < Sidekiq::Test
     it 'stubs the enqueue_to call' do
       assert_equal 0, EnqueuedWorker.jobs.size
       assert Sidekiq::Client.enqueue_to('someq', EnqueuedWorker, 1, 2)
-      assert_equal 1, EnqueuedWorker.jobs.size
+      assert_equal 1, Sidekiq::Queues['someq'].size
     end
 
     it 'executes all stored jobs' do
@@ -263,6 +264,68 @@ class TestTesting < Sidekiq::Test
     it 'can execute a job' do
       DirectWorker.execute_job(DirectWorker.new, [2, 3])
     end
+  end
 
+  describe 'queue testing' do
+    before do
+      require 'sidekiq/testing'
+      Sidekiq::Testing.fake!
+    end
+
+    after do
+      Sidekiq::Testing.disable!
+      Sidekiq::Queues.clear_all
+    end
+
+    class QueueWorker
+      include Sidekiq::Worker
+      def perform(a, b)
+        a + b
+      end
+    end
+
+    class AltQueueWorker
+      include Sidekiq::Worker
+      sidekiq_options queue: :alt
+      def perform(a, b)
+        a + b
+      end
+    end
+
+    it 'finds enqueued jobs' do
+      assert_equal 0, Sidekiq::Queues["default"].size
+
+      QueueWorker.perform_async(1, 2)
+      QueueWorker.perform_async(1, 2)
+      AltQueueWorker.perform_async(1, 2)
+
+      assert_equal 2, Sidekiq::Queues["default"].size
+      assert_equal [1, 2], Sidekiq::Queues["default"].first["args"]
+
+      assert_equal 1, Sidekiq::Queues["alt"].size
+    end
+
+    it 'clears out all queues' do
+      assert_equal 0, Sidekiq::Queues["default"].size
+
+      QueueWorker.perform_async(1, 2)
+      QueueWorker.perform_async(1, 2)
+      AltQueueWorker.perform_async(1, 2)
+
+      Sidekiq::Queues.clear_all
+
+      assert_equal 0, Sidekiq::Queues["default"].size
+      assert_equal 0, Sidekiq::Queues["alt"].size
+    end
+
+    it 'finds jobs enqueued by client' do
+      Sidekiq::Client.push(
+        'class' => 'NonExistentWorker',
+        'queue' => 'missing',
+        'args' => [1]
+      )
+
+      assert_equal 1, Sidekiq::Queues["missing"].size
+    end
   end
 end


### PR DESCRIPTION
When using the Sidekiq::Client API to push jobs on to the queue, it's
not ideal to assert the size of the queue from the perspective of a
worker because the worker may not exist in the application.

This API implements a testing API from the perspective of a queue. The
existing Worker-based testing API remains unchanged, but leverages the
job hash implemented through the Sidekiq::Queues class.

Examples:

    assert_equal 1, Sidekiq::Queues["default"].size
    assert_equal "SpecialWorker", Sidekiq::Queues["default"].first["class"]
    Sidekiq::Queues["default"].clear
    Sidekiq::Queues.clear_all

ref: https://github.com/mperham/sidekiq/issues/2562

There was a [regression](https://github.com/mperham/sidekiq/issues/2663) involving the `Rspec` syntax `change(Queueworker.jobs, :size).by(1)` . This has been solved keeping a reference to a real array based on the original fake implementation. 

I created a test Rails app and [added a test to verify the issue is fixed](https://github.com/brandonhilkert/sidekiq-queue-rails/blob/master/spec/controllers/posts_controller_spec.rb#L21). This test fails with the original code and passes with the latest changes include here in this PR.

Additionally, a test was added to attempt to simulate what Rspec is doing under the hood: https://github.com/mperham/sidekiq/commit/c4330cb32628627045287b22442cf71600218108#diff-db88da5a19a4fee1b469d961e1d38a81R333

When I ran this test WITHOUT the fix, i get:

```
[10:14:46] bhilkert [~/Dropbox/code/sidekiq] (old-queue-api) $ be rake
Run options: --seed 26376

# Running:

................................................................................................................................................................................................................................F...................................

   1) respects underlying array changes
      Expected: 1
        Actual: 0
      # test/test_testing_fake.rb:343

Finished in 1.545262s, 168.2563 runs/s, 477.5889 assertions/s.
260 runs, 738 assertions, 1 failure, no errors, no skips
```

With the changes here, that test now passes. 

Thoughts?