### PR TITLE
Use minitest 5 parent class

### DIFF
--- a/lib/generators/sidekiq/templates/worker_test.rb.erb
+++ b/lib/generators/sidekiq/templates/worker_test.rb.erb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 <% module_namespacing do -%>
-class <%= class_name %>WorkerTest < MiniTest::Unit::TestCase
+class <%= class_name %>WorkerTest < <% if defined? Minitest::Test %>Minitest::Test<% else %>MiniTest::Unit::TestCase<% end %>
   def test_example
     skip "add some examples to (or delete) #{__FILE__}"
   end


### PR DESCRIPTION
On Minitest 5+ we should be extending Minitest::Test instead.
see https://github.com/seattlerb/minitest/blob/7b387128ef2de8dadf5947a02e1eb448df51c92a/lib/minitest/unit.rb#L26