### PR TITLE
Test against latest stable version of ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 rvm:
   - 2.1
   - 2.0.0
-  - 2.2
+  - 2.2.3
   - jruby
   - jruby-head
   - rbx-2


### PR DESCRIPTION
Ruby 2.2 was released nearly [a year ago](https://www.ruby-lang.org/en/news/2014/12/25/ruby-2-2-0-released/). Let's test against the current stable, 2.2.3. 