### PR TITLE
Test against latest ruby patch versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ cache: bundler
 services:
   - redis-server
 rvm:
-  - 2.1
+  - 2.1.7
   - 2.0.0
-  - 2.2
+  - 2.2.3
   - jruby
   - jruby-head
   - rbx-2


### PR DESCRIPTION
Closed #2694 since I realized we also need to test against previous stable, 2.1.7. 

Ruby 2.2 was released nearly [a year ago](https://www.ruby-lang.org/en/news/2014/12/25/ruby-2-2-0-released/). Let's test against the current stable, 2.2.3. 

