### PR TITLE
Prevent the footer from covering the delete and retry buttons.

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -258,31 +258,6 @@ table .table-checkbox label {
   display: none;
 }
 
-.navbar-footer .navbar ul.nav {
-  text-align: center;
-  float: none;
-}
-.navbar-footer .navbar ul.nav a {
-  font-weight: 700;
-  font-size: 16px;
-  padding: 15px;
-}
-
-.navbar-footer .navbar ul.nav a.navbar-brand {
-  font-weight: 400;
-  padding: 0 15px 0 0;
-}
-
-.navbar-footer .navbar ul.nav li {
-  display: inline-block;
-  float: none;
-}
-.navbar-footer .navbar.affix {
-  top: 0;
-  width: 100%;
-  z-index: 10;
-}
-
 img.smallogo {
   width: 30px;
   margin: 0 0 6px 0;
@@ -712,6 +687,11 @@ div.interval-slider input {
   .navbar-fixed-top, .navbar-fixed-bottom {
     position: relative;
     top: auto;
+  }
+}
+@media (min-width: 768px) {
+  .navbar-fixed-bottom {
+    max-height: 50px;
   }
 }
 


### PR DESCRIPTION
If the Redis URL or namespace is too long, the footer will creep up and cover the delete and retry buttons. This change will hide the namespace in this case, rather than hide the buttons.

Before:
<img width="1316" alt="screen shot 2015-12-08 at 12 55 22 am" src="https://cloud.githubusercontent.com/assets/587537/11651600/ea7182e2-9d46-11e5-904c-2b2bec0bccc1.png">

After:
<img width="1315" alt="screen shot 2015-12-08 at 12 58 52 am" src="https://cloud.githubusercontent.com/assets/587537/11651603/efbb68bc-9d46-11e5-9604-30f2a9111843.png">

Also delete some unused CSS.