### PR TITLE
Fix object allocation and cpu usage for each web request

### DIFF
--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -18,7 +18,7 @@ module Sidekiq
     end
 
     def locale_files
-      @@locale_files = settings.locales.flat_map do |path|
+      @@locale_files ||= settings.locales.flat_map do |path|
         Dir["#{path}/*.yml"]
       end
     end


### PR DESCRIPTION
:tada: 

#### before:
```
==================================
  Mode: cpu(1000)
  Samples: 510 (100.00% miss rate)
  GC: 47 (9.22%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
.............................. 
       16   (3.1%)          16   (3.1%)     block in Sidekiq::WebHelpers#locale_files
..............................
 ```

#### after:
stackprof doesn't show `Sidekiq::Web Helpers#locale_files` in output information