### PR TITLE
Reduce object allocations in to 1/3 times

### DIFF
--- a/lib/sidekiq/fetch.rb
+++ b/lib/sidekiq/fetch.rb
@@ -12,7 +12,7 @@ module Sidekiq
       end
 
       def queue_name
-        queue.gsub(/.*queue:/, ''.freeze)
+        queue.sub(/.*queue:/, ''.freeze)
       end
 
       def requeue


### PR DESCRIPTION
#### Before
```
==================================
  Mode: object(1)
  Samples: 17460412 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
............... 
   600001   (3.4%)      600001   (3.4%)     Sidekiq::BasicFetch::UnitOfWork#queue_name
 ..............
```

#### After
```
==================================
  Mode: object(1)
  Samples: 17366353 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
................. 
   400001   (2.3%)      400001   (2.3%)     Sidekiq::BasicFetch::UnitOfWork#queue_name
................. 
```

:tada: 