### PR TITLE
[RFC] Reuse worker objects (drop object allocation count)

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -35,6 +35,7 @@ module Sidekiq
       @job = nil
       @thread = nil
       @strategy = (mgr.options[:fetch] || Sidekiq::BasicFetch).new(mgr.options)
+      @reusable_workers = {}
     end
 
     def terminate(wait=false)
@@ -120,7 +121,7 @@ module Sidekiq
       begin
         job = Sidekiq.load_json(jobstr)
         klass  = job['class'.freeze].constantize
-        worker = klass.new
+        worker = worker_object(klass)
         worker.jid = job['jid'.freeze]
 
         stats(worker, job, queue) do
@@ -143,6 +144,14 @@ module Sidekiq
         raise
       ensure
         work.acknowledge if ack
+      end
+    end
+
+    def worker_object(klass)
+      if klass.get_sidekiq_options['reuse']
+        @reusable_workers[klass] ||= klass.new
+      else
+        klass.new
       end
     end
 


### PR DESCRIPTION
Hi 👻

It seems that something like this can help reduce object allocation count, GC pauses, and overall memory usage as well as give a small speed bump in cases where there are very many small jobs to process and the jobs do not become unusable-dirty after the first run.

What do you think?