### PR TITLE
Fix Japanese translation for `NoRetriesFound`

### DIFF
--- a/web/locales/ja.yml
+++ b/web/locales/ja.yml
@@ -38,7 +38,7 @@ ja:
   AreYouSure: いいですか？
   DeleteAll: 全て削除
   RetryAll: 全て再試行
-  NoRetriesFound: 再試行できません
+  NoRetriesFound: 再試行するジョブはありません
   Error: エラー
   ErrorClass: クラスエラー
   ErrorMessage: エラーメッセージ


### PR DESCRIPTION
"再試行できません" means "It can not be retried.", so it has negative (or dangerous) nuance.

"再試行するジョブはありません" is better, it means "There is no jobs to be retried."