### PR TITLE
Fix locale definition for testing locale

### DIFF
--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -29,6 +29,8 @@ class TestWeb < Sidekiq::Test
       end
     end
 
+    Sidekiq::Web.settings.locales << File.join(File.dirname(__FILE__), "fixtures")
+
     it 'can show text with any locales' do
       rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'ru,en'}
       get '/', {}, rackenv
@@ -369,7 +371,6 @@ class TestWeb < Sidekiq::Test
       assert_equal 200, last_response.status
     end
 
-    Sidekiq::Web.settings.locales << File.join(File.dirname(__FILE__), "fixtures")
     it 'can show user defined tab with custom locales' do
       begin
         Sidekiq::Web.tabs['Custom Tab'] = '/custom'

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -29,8 +29,6 @@ class TestWeb < Sidekiq::Test
       end
     end
 
-    Sidekiq::Web.settings.locales << File.join(File.dirname(__FILE__), "fixtures")
-
     it 'can show text with any locales' do
       rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'ru,en'}
       get '/', {}, rackenv
@@ -371,18 +369,31 @@ class TestWeb < Sidekiq::Test
       assert_equal 200, last_response.status
     end
 
-    it 'can show user defined tab with custom locales' do
-      begin
-        Sidekiq::Web.tabs['Custom Tab'] = '/custom'
-        Sidekiq::Web.get('/custom') do
+    describe 'with custom locales' do
+      before do
+        custom_locale_file = "#{File.join(File.dirname(__FILE__), "fixtures")}/en.yml"
+        custom_locale = YAML.load(File.open(custom_locale_file))['en']
+
+        app.tabs['Custom Tab'] = '/custom'
+        app.get('/custom') do
+          strings('en').merge! custom_locale
           t('translated_text')
         end
+      end
 
-        get '/custom'
-        assert_match(/Changed text/, last_response.body)
+      after do
+        app.get('/custom') do
+          strings('en').delete 'translated_text'
+        end
+      end
 
-      ensure
-        Sidekiq::Web.tabs.delete 'Custom Tab'
+      it 'can show user defined tab' do
+        begin
+          get '/custom'
+          assert_match(/Changed text/, last_response.body)
+        ensure
+          Sidekiq::Web.tabs.delete 'Custom Tab'
+        end
       end
     end
 


### PR DESCRIPTION
Fixed #2752
I found the bug. It was in locale defenition before running test. If you look to [`locale_files`](https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/web_helpers.rb#L20-L24) method you can find that `@@locale_files` variable cache after first method call. And in test you call this method, and after you update `settings.locales` value.