### PR TITLE
Add "quiet" label to UI when process is quieted"

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -738,6 +738,10 @@ module Sidekiq
     def dump_threads
       signal('TTIN')
     end
+    
+    def stopping?
+      self['stopping']
+    end
 
     private
 

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -674,13 +674,13 @@ module Sidekiq
         # you'll be happier this way
         result = conn.pipelined do
           procs.each do |key|
-            conn.hmget(key, 'info', 'busy', 'beat')
+            conn.hmget(key, 'info', 'busy', 'beat', 'quiet')
           end
         end
 
-        result.each do |info, busy, at_s|
+        result.each do |info, busy, at_s, quiet|
           hash = Sidekiq.load_json(info)
-          yield Process.new(hash.merge('busy' => busy.to_i, 'beat' => at_s.to_f))
+          yield Process.new(hash.merge('busy' => busy.to_i, 'beat' => at_s.to_f, 'quiet' => quiet))
         end
       end
 
@@ -738,9 +738,9 @@ module Sidekiq
     def dump_threads
       signal('TTIN')
     end
-    
+
     def stopping?
-      self['stopping']
+      self['quiet'] == 'true'
     end
 
     private

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -128,6 +128,7 @@ module Sidekiq
         'queues' => @options[:queues].uniq,
         'labels' => @options[:labels],
         'identity' => k,
+        'stopping' => @done
       }
       # this data doesn't change so dump it to a string
       # now so we don't need to dump it every heartbeat.

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -95,7 +95,7 @@ module Sidekiq
         _, _, _, msg = Sidekiq.redis do |conn|
           conn.pipelined do
             conn.sadd('processes', key)
-            conn.hmset(key, 'info', json, 'busy', Processor::WORKER_STATE.size, 'beat', Time.now.to_f)
+            conn.hmset(key, 'info', json, 'busy', Processor::WORKER_STATE.size, 'beat', Time.now.to_f, 'quiet', @done)
             conn.expire(key, 60)
             conn.rpop("#{key}-signals")
           end
@@ -127,8 +127,7 @@ module Sidekiq
         'concurrency' => @options[:concurrency],
         'queues' => @options[:queues].uniq,
         'labels' => @options[:labels],
-        'identity' => k,
-        'stopping' => @done
+        'identity' => k
       }
       # this data doesn't change so dump it to a string
       # now so we don't need to dump it every heartbeat.

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -31,8 +31,8 @@
             <span class="label label-info"><%= label %></span>
           <% end %>
           <% if process.stopping? %>
-		  	    <span class="label label-danger">Quiet</span>
-		      <% end %>
+            <span class="label label-danger">Quiet</span>
+          <% end %>
           <br>
           <b><%= "#{t('Queues')}: " %></b>
           <%= process['queues'] * ", " %>

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -30,6 +30,9 @@
           <% process.labels.each do |label| %>
             <span class="label label-info"><%= label %></span>
           <% end %>
+		  <% if process.stopping? %>
+		  	<span class="label label-danger">Quiet</span>
+		  <% end %>
           <br>
           <b><%= "#{t('Queues')}: " %></b>
           <%= process['queues'] * ", " %>
@@ -42,7 +45,9 @@
             <form method="POST">
               <%= csrf_tag %>
               <input type="hidden" name="identity" value="<%= process['identity'] %>"/>
-              <button class="btn btn-warn" type="submit" name="quiet" value="1"><%= t('Quiet') %></button>
+              <% unless process.stopping? %>
+			  	<button class="btn btn-warn" type="submit" name="quiet" value="1"><%= t('Quiet') %></button>
+			  <% end %>
               <button class="btn btn-danger" type="submit" name="stop" value="1"><%= t('Stop') %></button>
             </form>
           </div>

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -30,9 +30,9 @@
           <% process.labels.each do |label| %>
             <span class="label label-info"><%= label %></span>
           <% end %>
-		  <% if process.stopping? %>
-		  	<span class="label label-danger">Quiet</span>
-		  <% end %>
+          <% if process.stopping? %>
+		  	    <span class="label label-danger">Quiet</span>
+		      <% end %>
           <br>
           <b><%= "#{t('Queues')}: " %></b>
           <%= process['queues'] * ", " %>
@@ -46,8 +46,8 @@
               <%= csrf_tag %>
               <input type="hidden" name="identity" value="<%= process['identity'] %>"/>
               <% unless process.stopping? %>
-			  	<button class="btn btn-warn" type="submit" name="quiet" value="1"><%= t('Quiet') %></button>
-			  <% end %>
+                <button class="btn btn-warn" type="submit" name="quiet" value="1"><%= t('Quiet') %></button>
+              <% end %>
               <button class="btn btn-danger" type="submit" name="stop" value="1"><%= t('Stop') %></button>
             </form>
           </div>


### PR DESCRIPTION
I'd like to see a visual indicator in the web UI when a process has been quieted (or is stopping).

Our shop uses a blue/green deployment strategy, so the inactive processes are "quieted" after a deployment, but they continue to heartbeat and appear in the web UI. We'd like to be able to easily identify and confirm that they are "quiet".