### PR TITLE
Sidekiq::Worker.drain_all loops endlessly when queue name is symbolized

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -170,7 +170,7 @@ module Sidekiq
       end
 
       def delete_for(jid, queue, klass)
-        jobs_by_queue[queue].delete_if { |job| job["jid"] == jid }
+        jobs_by_queue[queue.to_s].delete_if { |job| job["jid"] == jid }
         jobs_by_worker[klass].delete_if { |job| job["jid"] == jid }
       end
 

--- a/test/test_testing_fake.rb
+++ b/test/test_testing_fake.rb
@@ -261,6 +261,16 @@ class TestTesting < Sidekiq::Test
       assert_equal 1, SecondWorker.count
     end
 
+    it 'drains jobs of workers with symbolized queue names' do
+      Sidekiq::Worker.jobs.clear
+
+      AltQueueWorker.perform_async(5,6)
+      assert_equal 1, AltQueueWorker.jobs.size
+
+      Sidekiq::Worker.drain_all
+      assert_equal 0, AltQueueWorker.jobs.size
+    end
+
     it 'can execute a job' do
       DirectWorker.execute_job(DirectWorker.new, [2, 3])
     end


### PR DESCRIPTION
The queue-based testing hash (@jobs_by_queue) stores the queue name as a string. Therefore, when a worker is given a symbol as queue name, deleting the job from the @jobs_by_queue silently fails, leaving the job in @jobs_by_queue (even though deleting succeded from the @jobs_by_worker). 

Sidekiq::Worker.drain_all gets the jobs through @jobs_by_queue, but since the jobs are never removed from the queue-based hash, calling drain_all will result in an endless loop.

Without my patch in Queues.delete_for, my added test will result in the described endless loop. If my suggested patch/test needs more work, please let me know, i'm more than happy to do that.

thanks!