### PR TITLE
Avoid recomputing range_size everytime in API

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -227,7 +227,7 @@ module Sidekiq
 
       while true do
         range_start = page * page_size - deleted_size
-        range_end   = page * page_size - deleted_size + (page_size - 1)
+        range_end   = range_start + (page_size - 1)
         entries = Sidekiq.redis do |conn|
           conn.lrange @rname, range_start, range_end
         end


### PR DESCRIPTION
This PR is a minor optimization in the API.

We should avoid recomputing the range size 2 times as we already computed it for range_start.

Thanks!