### PR TITLE
gemspec celluloid ~> 0.17 to match rails5 dependency

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency                  'redis', '~> 3.2', '>= 3.2.1'
   gem.add_dependency                  'redis-namespace', '~> 1.5', '>= 1.5.2'
   gem.add_dependency                  'connection_pool', '~> 2.2', '>= 2.2.0'
-  gem.add_dependency                  'celluloid', '~> 0.16.0'
+  gem.add_dependency                  'celluloid', '~> 0.17.0'
   gem.add_dependency                  'json', '~> 1.0'
   gem.add_development_dependency      'sinatra', '~> 1.4', '>= 1.4.6'
   gem.add_development_dependency      'minitest', '~> 5.7', '>= 5.7.0'


### PR DESCRIPTION
updated celluloid gem dependency to match rails 5.0.0.beta1 dependency (from actioncable which depends on celluloid ~> 0.17.2) 