### PR TITLE
Change relative_time method behaviour

### DIFF
--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -146,7 +146,7 @@ module Sidekiq
     end
 
     def relative_time(time)
-      %{<time datetime="#{time.getutc.iso8601}">#{time}</time>}
+      %{<time datetime="#{time.getutc.iso8601}">#{time.to_formatted_s(:long)}</time>}
     end
 
     def job_params(job, score)

--- a/test/test_web_helpers.rb
+++ b/test/test_web_helpers.rb
@@ -50,4 +50,9 @@ class TestWebHelpers < Sidekiq::Test
     obj = Helpers.new('HTTP_ACCEPT_LANGUAGE' => '*')
     assert_equal 'en', obj.locale
   end
+
+  def test_relative_time
+    obj = Helpers.new
+    assert_equal "<time datetime=\"2026-01-20T14:22:39Z\">January 20, 2026 14:22</time>", obj.relative_time(Time.new(2026, 1, 20, 14, 22, 39))
+  end
 end


### PR DESCRIPTION
This commit updates the `relative_method` on `Sidekiq::WebHelpers` so that it responds with something more specific rather than a Rails-y style *"3 years from now"* as it seems to do now (although, only sometimes?) I'm guessing there's some magic in the Rails Time class which overrides the `to_s` method in certain circumstances?
![screen shot 2016-01-20 at 14 29 51](https://cloud.githubusercontent.com/assets/690977/12451597/4c5c3e54-bf82-11e5-8617-cb469e6545d0.png)

It also adds a test for this method as there weren't any before.