### PR TITLE
Pass exception object to sidekiq_retries_exhausted block

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -130,17 +130,17 @@ module Sidekiq
             end
           else
             # Goodbye dear message, you (re)tried your best I'm sure.
-            retries_exhausted(worker, msg)
+            retries_exhausted(worker, msg, exception)
           end
 
           raise exception
         end
 
-        def retries_exhausted(worker, msg)
+        def retries_exhausted(worker, msg, exception)
           logger.debug { "Dropping message after hitting the retry maximum: #{msg}" }
           begin
             if worker.sidekiq_retries_exhausted_block?
-              worker.sidekiq_retries_exhausted_block.call(msg)
+              worker.sidekiq_retries_exhausted_block.call(msg, exception)
             end
           rescue => e
             handle_exception(e, { context: "Error calling retries_exhausted for #{worker.class}", job: msg })

--- a/test/test_retry_exhausted.rb
+++ b/test/test_retry_exhausted.rb
@@ -1,0 +1,123 @@
+# encoding: utf-8
+require_relative 'helper'
+require 'sidekiq/middleware/server/retry_jobs'
+
+class TestRetryExhausted < Sidekiq::Test
+  describe 'sidekiq_retries_exhausted' do
+    class NewWorker
+      include Sidekiq::Worker
+
+      class_attribute :exhausted_called, :exhausted_message, :exhausted_exception
+
+      sidekiq_retries_exhausted do |msg, e|
+        self.exhausted_called = true
+        self.exhausted_message = msg
+        self.exhausted_exception = e
+      end
+    end
+
+    class OldWorker
+      include Sidekiq::Worker
+
+      class_attribute :exhausted_called, :exhausted_message, :exhausted_exception
+
+      sidekiq_retries_exhausted do |msg|
+        self.exhausted_called = true
+        self.exhausted_message = msg
+      end
+    end
+
+    def cleanup
+      [NewWorker, OldWorker].each do |worker_class|
+        worker_class.exhausted_called = nil
+        worker_class.exhausted_message = nil
+        worker_class.exhausted_exception = nil
+      end
+    end
+
+    before do
+      cleanup
+    end
+
+    after do
+      cleanup
+    end
+
+    def new_worker
+      @new_worker ||= NewWorker.new
+    end
+
+    def old_worker
+      @old_worker ||= OldWorker.new
+    end
+
+    def handler(options={})
+      @handler ||= Sidekiq::Middleware::Server::RetryJobs.new(options)
+    end
+
+    def job(options={})
+      @job ||= {'class' => 'Bob', 'args' => [1, 2, 'foo']}.merge(options)
+    end
+
+    it 'does not run exhausted block when job successful on first run' do
+      handler.call(new_worker, job('retry' => 2), 'default') do
+        # successful
+      end
+
+      refute NewWorker.exhausted_called?
+    end
+
+    it 'does not run exhausted block when job successful on last retry' do
+      handler.call(new_worker, job('retry_count' => 0, 'retry' => 1), 'default') do
+        # successful
+      end
+
+      refute NewWorker.exhausted_called?
+    end
+
+    it 'does not run exhausted block when retries not exhausted yet' do
+      assert_raises RuntimeError do
+        handler.call(new_worker, job('retry' => 1), 'default') do
+          raise 'kerblammo!'
+        end
+      end
+
+      refute NewWorker.exhausted_called?
+    end
+
+    it 'runs exhausted block when retries exhausted' do
+      assert_raises RuntimeError do
+        handler.call(new_worker, job('retry_count' => 0, 'retry' => 1), 'default') do
+          raise 'kerblammo!'
+        end
+      end
+
+      assert NewWorker.exhausted_called?
+    end
+
+
+    it 'passes message and exception to retries exhausted block' do
+      raised_error = assert_raises RuntimeError do
+        handler.call(new_worker, job('retry_count' => 0, 'retry' => 1), 'default') do
+          raise 'kerblammo!'
+        end
+      end
+
+      assert new_worker.exhausted_called?
+      assert_equal raised_error.message, new_worker.exhausted_message['error_message']
+      assert_equal raised_error, new_worker.exhausted_exception
+    end
+
+    it 'passes message to retries exhausted block' do
+      raised_error = assert_raises RuntimeError do
+        handler.call(old_worker, job('retry_count' => 0, 'retry' => 1), 'default') do
+          raise 'kerblammo!'
+        end
+      end
+
+      assert old_worker.exhausted_called?
+      assert_equal raised_error.message, old_worker.exhausted_message['error_message']
+      assert_equal nil, new_worker.exhausted_exception
+    end
+  end
+end


### PR DESCRIPTION
Behold! I'm taking a challenge of making an **extremely** compelling case for why Sidekiq's thousands of users would want that change. :-)

1. Finally have a dead easy way to handle an exception when retries are exhausted. Currently it's doable only through global error handlers (`config.error_handlers`). A lot of custom code is needed to implement a per-job handler. Example use cases:
  - Suspend account when no money could be collected after retries.
  - Report to Bugsnag after the job really fails. (Instead of the default way of doing that, every job retry)
2. Backwards compatible. Block parameters are optional in Ruby. Thanks to that `sidekiq_retries_exhausted do |msg|` and `sidekiq_retries_exhausted do |msg, e|` just work.
3. No performance penalty. No extra computing is needed to create an object. No extra garbage created. Exception object is there, just pass it.