### PR TITLE
Implement a global retries exhausted handler

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,17 @@
 # Sidekiq Changes
 
+HEAD
+-----------
+
+- Allow definition of a global retries_exhausted handler. [#2807]
+```ruby
+Sidekiq.configure_server do |config|
+  config.default_retries_exhausted = -> (job, ex) do
+    Sidekiq.logger.info "#{job['class']} job is now dead"
+  end
+end
+```
+
 4.1.0
 -----------
 

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -44,7 +44,6 @@ module Sidekiq
   def self.options
     @options ||= DEFAULTS.dup
   end
-
   def self.options=(opts)
     @options = opts
   end
@@ -132,15 +131,24 @@ module Sidekiq
   def self.default_worker_options=(hash)
     @default_worker_options = default_worker_options.merge(hash.stringify_keys)
   end
-
   def self.default_worker_options
     defined?(@default_worker_options) ? @default_worker_options : DEFAULT_WORKER_OPTIONS
+  end
+
+  # Sidekiq.configure_server do |config|
+  #   config.default_retries_exhausted = -> (job, ex) do
+  #   end
+  # end
+  def self.default_retries_exhausted=(prok)
+    @default_retries_exhausted = prok
+  end
+  def self.default_retries_exhausted
+    @default_retries_exhausted
   end
 
   def self.load_json(string)
     JSON.parse(string)
   end
-
   def self.dump_json(object)
     JSON.generate(object)
   end
@@ -148,7 +156,6 @@ module Sidekiq
   def self.logger
     Sidekiq::Logging.logger
   end
-
   def self.logger=(log)
     Sidekiq::Logging.logger = log
   end

--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -137,11 +137,10 @@ module Sidekiq
         end
 
         def retries_exhausted(worker, msg, exception)
-          logger.debug { "Dropping message after hitting the retry maximum: #{msg}" }
+          logger.debug { "Retries exhausted for job" }
           begin
-            if worker.sidekiq_retries_exhausted_block?
-              worker.sidekiq_retries_exhausted_block.call(msg, exception)
-            end
+            block = worker.sidekiq_retries_exhausted_block || Sidekiq.default_retries_exhausted
+            block.call(msg, exception) if block
           rescue => e
             handle_exception(e, { context: "Error calling retries_exhausted for #{worker.class}", job: msg })
           end

--- a/test/test_retry_exhausted.rb
+++ b/test/test_retry_exhausted.rb
@@ -7,11 +7,11 @@ class TestRetryExhausted < Sidekiq::Test
     class NewWorker
       include Sidekiq::Worker
 
-      class_attribute :exhausted_called, :exhausted_message, :exhausted_exception
+      class_attribute :exhausted_called, :exhausted_job, :exhausted_exception
 
-      sidekiq_retries_exhausted do |msg, e|
+      sidekiq_retries_exhausted do |job, e|
         self.exhausted_called = true
-        self.exhausted_message = msg
+        self.exhausted_job = job
         self.exhausted_exception = e
       end
     end
@@ -19,18 +19,18 @@ class TestRetryExhausted < Sidekiq::Test
     class OldWorker
       include Sidekiq::Worker
 
-      class_attribute :exhausted_called, :exhausted_message, :exhausted_exception
+      class_attribute :exhausted_called, :exhausted_job, :exhausted_exception
 
-      sidekiq_retries_exhausted do |msg|
+      sidekiq_retries_exhausted do |job|
         self.exhausted_called = true
-        self.exhausted_message = msg
+        self.exhausted_job = job
       end
     end
 
     def cleanup
       [NewWorker, OldWorker].each do |worker_class|
         worker_class.exhausted_called = nil
-        worker_class.exhausted_message = nil
+        worker_class.exhausted_job = nil
         worker_class.exhausted_exception = nil
       end
     end
@@ -96,7 +96,7 @@ class TestRetryExhausted < Sidekiq::Test
     end
 
 
-    it 'passes message and exception to retries exhausted block' do
+    it 'passes job and exception to retries exhausted block' do
       raised_error = assert_raises RuntimeError do
         handler.call(new_worker, job('retry_count' => 0, 'retry' => 1), 'default') do
           raise 'kerblammo!'
@@ -104,11 +104,11 @@ class TestRetryExhausted < Sidekiq::Test
       end
 
       assert new_worker.exhausted_called?
-      assert_equal raised_error.message, new_worker.exhausted_message['error_message']
+      assert_equal raised_error.message, new_worker.exhausted_job['error_message']
       assert_equal raised_error, new_worker.exhausted_exception
     end
 
-    it 'passes message to retries exhausted block' do
+    it 'passes job to retries exhausted block' do
       raised_error = assert_raises RuntimeError do
         handler.call(old_worker, job('retry_count' => 0, 'retry' => 1), 'default') do
           raise 'kerblammo!'
@@ -116,8 +116,34 @@ class TestRetryExhausted < Sidekiq::Test
       end
 
       assert old_worker.exhausted_called?
-      assert_equal raised_error.message, old_worker.exhausted_message['error_message']
+      assert_equal raised_error.message, old_worker.exhausted_job['error_message']
       assert_equal nil, new_worker.exhausted_exception
+    end
+
+    it 'allows a global default handler' do
+      begin
+        class Foobar
+          include Sidekiq::Worker
+        end
+
+        exhausted_job = nil
+        exhausted_exception = nil
+        Sidekiq.default_retries_exhausted = -> (job, ex) do
+          exhausted_job = job
+          exhausted_exception = ex
+        end
+        f = Foobar.new
+        raised_error = assert_raises RuntimeError do
+          handler.call(f, job('retry_count' => 0, 'retry' => 1), 'default') do
+            raise 'kerblammo!'
+          end
+        end
+
+        assert exhausted_job
+        assert_equal raised_error, exhausted_exception
+      ensure
+        Sidekiq.default_retries_exhausted = nil
+      end
     end
   end
 end

--- a/test/test_retry_exhausted.rb
+++ b/test/test_retry_exhausted.rb
@@ -128,7 +128,7 @@ class TestRetryExhausted < Sidekiq::Test
 
         exhausted_job = nil
         exhausted_exception = nil
-        Sidekiq.default_retries_exhausted = -> (job, ex) do
+        Sidekiq.default_retries_exhausted = lambda do |job, ex|
           exhausted_job = job
           exhausted_exception = ex
         end


### PR DESCRIPTION
I'd like to be able to notify an on-call service like Pager Duty whenever _any_ worker exhausts all available retry attempts. 

Implementing this on each worker as a `sidekiq_retries_exhausted` block is a bit fragile and tedious. Authoring custom middleware might work, but requires a bit of job metadata parsing to determine if any retry attempts remain and is somewhat implementation-dependent.

Would love to see a support feature for registering global "dead job" handlers!