### PR TITLE
require 'fcntl' in logging.rb

### DIFF
--- a/lib/sidekiq/logging.rb
+++ b/lib/sidekiq/logging.rb
@@ -1,5 +1,6 @@
 require 'time'
 require 'logger'
+require 'fcntl'
 
 module Sidekiq
   module Logging


### PR DESCRIPTION

Sidekiq crashes when reopening log with `uninitialized constant Sidekiq::Logging::Fcntl`

Ruby 2.3.0
Rails 4.2.5.1
Sidekiq running with `-d` `-L`

It seems that if the USR2 signal is sent to the sidekiq process and nothing else loaded has done `require 'fcntl'` yet, the `Fcntl` lookup can fail.
```
2016-02-23T08:31:55.195Z 3192 TID-ovd5cufiw INFO: Received USR2, reopening log file
uninitialized constant Sidekiq::Logging::Fcntl
/.../vendor/bundle/ruby/2.3.0/gems/sidekiq-4.0.2/lib/sidekiq/logging.rb:65:in `block in reopen_logs'
/.../vendor/bundle/ruby/2.3.0/gems/sidekiq-4.0.2/lib/sidekiq/logging.rb:63:in `each_object'
/.../vendor/bundle/ruby/2.3.0/gems/sidekiq-4.0.2/lib/sidekiq/logging.rb:63:in `reopen_logs'
/.../vendor/bundle/ruby/2.3.0/gems/sidekiq-4.0.2/lib/sidekiq/cli.rb:140:in `handle_signal'
/.../vendor/bundle/ruby/2.3.0/gems/sidekiq-4.0.2/lib/sidekiq/cli.rb:95:in `run'
/.../vendor/bundle/ruby/2.3.0/gems/sidekiq-4.0.2/bin/sidekiq:12:in `<top (required)>'
/.../vendor/bundle/ruby/2.3.0/bin/sidekiq:23:in `load'
/.../vendor/bundle/ruby/2.3.0/bin/sidekiq:23:in `<main>'
```
