### PR TITLE
Added Sidekiq#redis_info to encapsulate info calls

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -90,6 +90,18 @@ module Sidekiq
     end
   end
 
+  def self.redis_info
+    redis do |conn|
+      # admin commands can't go through redis-namespace starting
+      # in redis-namespace 2.0
+      if conn.respond_to?(:namespace)
+        conn.redis.info
+      else
+        conn.info
+      end
+    end
+  end
+
   def self.redis_pool
     @redis ||= Sidekiq::RedisConnection.create
   end

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -65,12 +65,10 @@ module Sidekiq
       logger.info Sidekiq::LICENSE
       logger.info "Upgrade to Sidekiq Pro for more features and support: http://sidekiq.org" unless defined?(::Sidekiq::Pro)
 
-      Sidekiq.redis do |conn|
-        # touch the connection pool so it is created before we
-        # fire startup and start multithreading.
-        ver = conn.info['redis_version']
-        raise "You are using Redis v#{ver}, Sidekiq requires Redis v2.8.0 or greater" if ver < '2.8'
-      end
+      # touch the connection pool so it is created before we
+      # fire startup and start multithreading.
+      ver = Sidekiq.redis_info['redis_version']
+      raise "You are using Redis v#{ver}, Sidekiq requires Redis v2.8.0 or greater" if ver < '2.8'
 
       # Before this point, the process is initializing with just the main thread.
       # Starting here the process will now have multiple threads running.

--- a/lib/sidekiq/util.rb
+++ b/lib/sidekiq/util.rb
@@ -57,6 +57,5 @@ module Sidekiq
       end
       arr.clear
     end
-
   end
 end

--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -122,15 +122,7 @@ module Sidekiq
     end
 
     def redis_info
-      Sidekiq.redis do |conn|
-        # admin commands can't go through redis-namespace starting
-        # in redis-namespace 2.0
-        if conn.respond_to?(:namespace)
-          conn.redis.info
-        else
-          conn.info
-        end
-      end
+      Sidekiq.redis_info
     end
 
     def root_path

--- a/test/test_sidekiq.rb
+++ b/test/test_sidekiq.rb
@@ -101,7 +101,6 @@ class TestSidekiq < Sidekiq::Test
     it 'calls the INFO command which returns at least redis_version' do
       output = Sidekiq.redis_info
       assert_includes output.keys, "redis_version"
-      assert_includes output.keys, "uptime_in_days"
     end
   end
 end

--- a/test/test_sidekiq.rb
+++ b/test/test_sidekiq.rb
@@ -96,4 +96,12 @@ class TestSidekiq < Sidekiq::Test
       assert_equal counts[0] + 1, counts[1]
     end
   end
+
+  describe 'redis info' do
+    it 'calls the INFO command which returns at least redis_version' do
+      output = Sidekiq.redis_info
+      assert_includes output.keys, "redis_version"
+      assert_includes output.keys, "uptime_in_days"
+    end
+  end
 end


### PR DESCRIPTION
As discussed in #2850 this adds the method `redis_info` to `Sidekiq`, to allow easier monkey patching for servers that disable `INFO`.


### Open items

-  [x] Had to use `Sidekiq.redis_info` and was not able to write it in `Utils.redis_info`, as the `Utils` are not included in the WebHelpers, okay?
- [x] Don't know sidekiq / redis enough, but is the call to `redis.info` for `:namespace` actually required, I've only seen `web_helpers.rb` actually using it like that
- [x] Added a test to check that the call to `redis_info` returns a few keys, maybe we should test more keys or specific values - or are there any keys that return a fixed value in tests?

### Proposal for a monkey-patch-free-version...

One more thing, if possible I'd really like to change `self.redis_info` to the following, but I agree that having to support all crazy redis configuration variants might not really be viable.

```ruby
  def self.redis_info
    redis do |conn|
      begin
        # admin commands can't go through redis-namespace starting
        # in redis-namespace 2.0
        if conn.respond_to?(:namespace)
          conn.redis.info
        else
          conn.info
        end
      rescue Redis::CommandError => ex
        # 2850 assume redis 2.8 when INFO has been renamed
        raise unless ex.message =~ /Unknown command/
        { 'redis_version' => '2.8' }
      end
    end
  end
```

Otherwise is it possible to add this to the wiki, or where would be the place to add a "supported" monkeypatch? Maybe on https://github.com/mperham/sidekiq/wiki/Problems-and-Troubleshooting, can I freely edit this page?