### PR TITLE
Fixed SystemCallError for Windows path

### DIFF
--- a/lib/sidekiq/logging.rb
+++ b/lib/sidekiq/logging.rb
@@ -47,8 +47,7 @@ module Sidekiq
     end
 
     def self.logger=(log)
-      null_path = (File.exists?('/dev/null') ? '/dev/null' : 'nul')
-      @logger = (log ? log : Logger.new(null_path))
+      @logger = (log ? log : Logger.new(File::NULL))
     end
 
     # This reopens ALL logfiles in the process that have been rotated

--- a/lib/sidekiq/logging.rb
+++ b/lib/sidekiq/logging.rb
@@ -47,7 +47,8 @@ module Sidekiq
     end
 
     def self.logger=(log)
-      @logger = (log ? log : Logger.new('/dev/null'))
+      null_path = (File.exists?('/dev/null') ? '/dev/null' : 'nul')
+      @logger = (log ? log : Logger.new(null_path))
     end
 
     # This reopens ALL logfiles in the process that have been rotated


### PR DESCRIPTION
Updated logging path to fix SystemCallError on Windows environment, as '/dev/null' will break gem loading