### PR TITLE
allow sidekiq::client.via to point to same redis

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -110,7 +110,8 @@ module Sidekiq
     # you cannot scale any other way (e.g. splitting your app into smaller apps).
     def self.via(pool)
       raise ArgumentError, "No pool given" if pool.nil?
-      raise RuntimeError, "Sidekiq::Client.via is not re-entrant" if x = Thread.current[:sidekiq_via_pool] && x != pool
+      current_sidekiq_pool = Thread.current[:sidekiq_via_pool]
+      raise RuntimeError, "Sidekiq::Client.via is not re-entrant" if current_sidekiq_pool && current_sidekiq_pool != pool
       Thread.current[:sidekiq_via_pool] = pool
       yield
     ensure

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -181,6 +181,18 @@ class TestClient < Sidekiq::Test
       conn.verify
     end
 
+    it 'allows #via to point to same Redi' do
+      conn = MiniTest::Mock.new
+      conn.expect(:multi, [0, 1])
+      sharded_pool = ConnectionPool.new(size: 1) { conn }
+      Sidekiq::Client.via(sharded_pool) do
+        Sidekiq::Client.via(sharded_pool) do
+          CWorker.perform_async(1,2,3)
+        end
+      end
+      conn.verify
+    end
+
     it 'allows #via to point to different Redi' do
       conn = MiniTest::Mock.new
       conn.expect(:multi, [0, 1])


### PR DESCRIPTION
this fixes the incorrect conditional statement 

`if x = Thread.current[:sidekiq_via_pool] && x != pool`

which evaluates as if it was written as 

`if x = (Thread.current[:sidekiq_via_pool] && x != pool)`