### PR TITLE
Truncate text in display_args based on formerly unused variable

### DIFF
--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -166,7 +166,7 @@ module Sidekiq
 
     def display_args(args, truncate_after_chars = 2000)
       args.map do |arg|
-        h(truncate(to_display(arg)))
+        h(truncate(to_display(arg), truncate_after_chars))
       end.join(", ")
     end
 


### PR DESCRIPTION
Updates the `display_args` method to pass the unused `truncate_after_chars` method to `truncate`