### PR TITLE
Dump the context as JSON for proper logging

### DIFF
--- a/lib/sidekiq/exception_handler.rb
+++ b/lib/sidekiq/exception_handler.rb
@@ -5,7 +5,7 @@ module Sidekiq
 
     class Logger
       def call(ex, ctxHash)
-        Sidekiq.logger.warn(ctxHash) if !ctxHash.empty?
+        Sidekiq.logger.warn(Sidekiq.dump_json(ctxHash)) if !ctxHash.empty?
         Sidekiq.logger.warn "#{ex.class.name}: #{ex.message}"
         Sidekiq.logger.warn ex.backtrace.join("\n") unless ex.backtrace.nil?
       end

--- a/test/test_exception_handler.rb
+++ b/test/test_exception_handler.rb
@@ -32,7 +32,7 @@ class TestExceptionHandler < Sidekiq::Test
       Component.new.invoke_exception(:a => 1)
       @str_logger.rewind
       log = @str_logger.readlines
-      assert_match(/a=>1/, log[0], "didn't include the context")
+      assert_match(/"a":1/, log[0], "didn't include the context")
       assert_match(/Something didn't work!/, log[1], "didn't include the exception message")
       assert_match(/test\/test_exception_handler.rb/, log[2], "didn't include the backtrace")
     end


### PR DESCRIPTION
Dump the context as JSON for proper logging