### PR TITLE
Edge case where 'args' is a string passed to display_args

### DIFF
--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -166,6 +166,7 @@ module Sidekiq
     end
 
     def display_args(args, truncate_after_chars = 2000)
+      args = [args] unless args.respond_to?(:map)
       args.map do |arg|
         h(truncate(to_display(arg), truncate_after_chars))
       end.join(", ")

--- a/lib/sidekiq/web_helpers.rb
+++ b/lib/sidekiq/web_helpers.rb
@@ -166,8 +166,7 @@ module Sidekiq
     end
 
     def display_args(args, truncate_after_chars = 2000)
-      args = [args] unless args.respond_to?(:map)
-      args.map do |arg|
+      Array(args).map do |arg|
         h(truncate(to_display(arg), truncate_after_chars))
       end.join(", ")
     end

--- a/test/test_web_helpers.rb
+++ b/test/test_web_helpers.rb
@@ -51,4 +51,13 @@ class TestWebHelpers < Sidekiq::Test
     obj = Helpers.new('HTTP_ACCEPT_LANGUAGE' => '*')
     assert_equal 'en', obj.locale
   end
+
+  def test_view_helpers
+    obj = Helpers.new
+
+    assert_equal '&quot;arg1&quot;, &quot;arg2&quot;', obj.display_args(['arg1', 'arg2'])
+    assert_equal '&quot;arg...', obj.display_args(['arg1'], 3)
+    assert_equal '&quot;arg1&quot;...', obj.display_args(['arg1'], 5)
+    assert_equal '&quot;arg1&quot;', obj.display_args('arg1')
+  end
 end


### PR DESCRIPTION
Why:
In rare cases the UI at /sidekiq/morgue will throw a 500 error with: undefined method `map' for "value":String; especially when third party tools can submit to a queue.

What:
This PR handles the edge case where a job's arguments are passed through to the display helper as a string, instead of an array. It also adds some minimal tests for the display_args helper.