### PR TITLE
Set kill timeout to 15 sec. in upstart config

### DIFF
--- a/examples/upstart/sidekiq.conf
+++ b/examples/upstart/sidekiq.conf
@@ -42,6 +42,10 @@ normal exit 0 TERM
 # this commented out.
 reload signal USR1
 
+# Upstart waits 5 seconds by default to kill the a process. Increase timeout to
+# give sidekiq process enough time to exit.
+kill timeout 15
+
 instance $index
 
 script


### PR DESCRIPTION
Upstart "kill timeout" is 5 seconds by default (http://upstart.ubuntu.com/cookbook/#kill-timeout). 

This will cause that when using the provided upstart/sidekiq.conf, upstart will kill the sidekiq process while is waiting for any running workers to end, and even before the process enqueue them into the retries queue, losing any running jobs.

This PR sets a higher timeout that should be safe to use with the default sidekiq "kill_timeout" which is 10 seconds.