### PR TITLE
Make process string more informative

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -21,6 +21,7 @@ module Sidekiq
       proc { Sidekiq::VERSION },
       proc { |me, data| data['tag'] },
       proc { |me, data| "[#{Processor::WORKER_STATE.size} of #{data['concurrency']} busy]" },
+      proc { |me, data| "(#{data['queues'].join(', ')})" },
       proc { |me, data| "stopping" if me.stopping? },
     ]
 

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -39,7 +39,7 @@ class TestLauncher < Sidekiq::Test
         end
 
         it 'sets useful info to proctitle' do
-          assert_equal "sidekiq #{Sidekiq::VERSION} myapp [1 of 3 busy] xyz", $0
+          assert_equal "sidekiq #{Sidekiq::VERSION} myapp [1 of 3 busy] (notifications, reports) xyz", $0
         end
 
         it 'stores process info in redis' do
@@ -61,7 +61,7 @@ class TestLauncher < Sidekiq::Test
         #end
 
         it 'indicates stopping status in proctitle' do
-          assert_equal "sidekiq #{Sidekiq::VERSION} myapp [1 of 3 busy] stopping", $0
+          assert_equal "sidekiq #{Sidekiq::VERSION} myapp [1 of 3 busy] (notifications, reports) stopping", $0
         end
 
         it 'stores process info in redis' do
@@ -78,7 +78,7 @@ class TestLauncher < Sidekiq::Test
     end
 
     def heartbeat_data
-      { 'concurrency' => 3, 'tag' => 'myapp' }
+      { 'concurrency' => 3, 'tag' => 'myapp', 'queues' => ['notifications', 'reports'] }
     end
   end
 


### PR DESCRIPTION
When there are many Sidekiq processes running on a server each processing different queues, it is hard to say which is which 😰