### PR TITLE
Introspect what sidekiq is working on at any time

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -26,6 +26,7 @@ module Sidekiq
     lifecycle_events: {
       startup: [],
       quiet: [],
+      status: [],
       shutdown: [],
     },
     dead_max_jobs: 10_000,

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -145,6 +145,7 @@ module Sidekiq
             Sidekiq.logger.warn "<no backtrace available>"
           end
         end
+        fire_event(:status)
       end
     end
 


### PR DESCRIPTION
We added an additional event for the TTIN signal, which we use to track which jobs are running. It lets us introspect what sidekiq is working on at any time. For example:

```
Sidekiq.configure_server do |config|
  # ...
  config.on(:status) do
    Thread.list.each do |thread|
      next unless thread[:job].present?
​
      Sidekiq.logger.warn "Interrupted Thread TID-#{thread.object_id.to_s(36)} #{thread[:job]}"
    end
  end
  
  # ...
end
```