### PR TITLE
Fix CSP errors on Sinatra / Rack 2

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -12,21 +12,20 @@ module Sidekiq
   class Web < Sinatra::Base
     include Sidekiq::Paginator
 
-
     enable :sessions
 
-    # N.B. until https://github.com/sinatra/rack-protection/pull/111 lands,
-    #  you'll need to uncomment the next line:
-    Rack::Protection::ContentSecurityPolicy::KEYS.push :img_src
-    unless ENV['RACK_ENV'] == 'test'
+    def self.protections
       local = ENV['RACK_ENV'] == 'development' ? "'self' localhost" : "'self'"
-      set :protection,
-          connect_src: local,
-          default_src: local,
-          script_src:  local,
-          style_src:   "#{local} 'unsafe-inline'",
-          img_src:     "'self' data:"
+      {
+        use:         :authenticity_token,
+        connect_src: local,
+        default_src: local,
+        script_src:  local,
+        style_src:   "#{local} 'unsafe-inline'",
+        img_src:     "'self' data:"
+      }
     end
+    use ::Rack::Protection, protections unless ENV['RACK_ENV'] == 'test'
 
     set :root, File.expand_path(File.dirname(__FILE__) + "/../../web")
     set :public_folder, proc { "#{root}/assets" }


### PR DESCRIPTION
See #3070 

Now that https://github.com/sinatra/rack-protection/pull/111 has been merged in, this should work for users pulling `sinatra` and `rack-protect` from master (e.g. edge Rails folks). It _should_ be backwards compatible, though I've only tested against Rails 4.2 and 5 personally.

@mperham - it seemed like you thought that Sinatra 2 should already be backwards compatible, so let me know if you'd prefer to fight this fight upstream. Also - is adding a method here a reasonable way to allow folks to configure if needed, or would you prefer something else?