### PR TITLE
Fixed the translation of "idle" for the de locale

### DIFF
--- a/web/locales/de.yml
+++ b/web/locales/de.yml
@@ -48,7 +48,7 @@ de:
   NoScheduledFound: Keine geplanten Jobs gefunden
   When: Wann
   ScheduledJobs: Jobs in der Warteschlange
-  idle: inaktiv
+  idle: untätig
   active: aktiv
   Version: Version
   Connections: Verbindungen


### PR DESCRIPTION
"Inaktiv" has a specific connotation in German, which I suspect is not what we're looking to convey here.