### PR TITLE
Add event when a process has a new heartbeat

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -28,6 +28,7 @@ module Sidekiq
       startup: [],
       quiet: [],
       shutdown: [],
+      heartbeat: [],
     },
     dead_max_jobs: 10_000,
     dead_timeout_in_seconds: 180 * 24 * 60 * 60 # 6 months

--- a/lib/sidekiq/version.rb
+++ b/lib/sidekiq/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Sidekiq
-  VERSION = "4.1.4"
+  VERSION = "4.1.5"
 end


### PR DESCRIPTION
This allows us to recover from network outages without having to restart the entire process.