### PR TITLE
Raise error if required filed was not loaded

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -244,7 +244,7 @@ module Sidekiq
         end
         options[:tag] ||= default_tag
       else
-        require options[:require]
+        require options[:require] or raise ArgumentError, "#{options[:require]} was not required"
       end
     end
 

--- a/sidekiq.rb
+++ b/sidekiq.rb
@@ -1,0 +1,1 @@
+# Is used for testing purposes

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -31,6 +31,14 @@ class TestCli < Sidekiq::Test
       assert @cli.valid?
     end
 
+    it 'does not require existing file' do
+      @cli.parse(['sidekiq', '-r', 'sidekiq.rb'])
+
+      assert_raises ArgumentError do
+        @cli.run
+      end
+    end
+
     it 'does not boot rails' do
       refute defined?(::Rails::Application)
       @cli.parse(['sidekiq', '-r', './myapp'])


### PR DESCRIPTION
When I was reviewing another's code why Sidekiq does not run, I found issue that it is launched:
`bundle exec sidekiq -r sidekiq.rb` instead of `bundle exec sidekiq -r ./sidekiq.rb`. It took some time because it raised an error about Redis but not launch configuration.