### PR TITLE
Resolve `rack.session` cookie duplication

### DIFF
--- a/lib/sidekiq/web/action.rb
+++ b/lib/sidekiq/web/action.rb
@@ -2,9 +2,9 @@
 
 module Sidekiq
   class WebAction
-    RACK_SESSION = 'rack.session'
-    TEXT_HTML = { "Content-Type" => "text/html", "Cache-Control" => "no-cache" }
-    APPLICATION_JSON = { "Content-Type" => "application/json", "Cache-Control" => "no-cache" }
+    RACK_SESSION = 'rack.session'.freeze
+    TEXT_HTML = { "Content-Type" => "text/html", "Cache-Control" => "no-cache" }.freeze
+    APPLICATION_JSON = { "Content-Type" => "application/json", "Cache-Control" => "no-cache" }.freeze
 
     attr_accessor :env, :block, :type
 

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -7,7 +7,7 @@ module Sidekiq
     CONTENT_LENGTH = "Content-Length".freeze
     CONTENT_TYPE = "Content-Type".freeze
     REDIS_KEYS = %w(redis_version uptime_in_days connected_clients used_memory_human used_memory_peak_human)
-    NOT_FOUND = [404, {"Content-Type" => "text/plain", "X-Cascade" => "pass" }, ["Not Found"]]
+    NOT_FOUND = [404, {"Content-Type" => "text/plain", "X-Cascade" => "pass" }.freeze, ["Not Found"]]
 
     def initialize(klass)
       @klass = klass
@@ -289,6 +289,8 @@ module Sidekiq
 
         [200, type_header, [resp]]
       end
+
+      resp[1] = resp[1].dup
 
       resp[1][CONTENT_LENGTH] = resp[2].inject(0) { |l, p| l + p.bytesize }.to_s
 


### PR DESCRIPTION
Duplicate headers hash before returning to Rack to prevent the global header responses from getting modified.  Freeze the global header objects to surface situations where the global constant headers are modified.  See #3143 for problem description and reproduction.