### PR TITLE
Prevent an infinite loop when the job queue is not the worker default

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -264,7 +264,7 @@ module Sidekiq
       def drain
         while jobs.any?
           next_job = jobs.first
-          Queues.delete_for(next_job["jid"], queue, self.to_s)
+          Queues.delete_for(next_job["jid"], next_job["queue"], self.to_s)
           process_job(next_job)
         end
       end


### PR DESCRIPTION
When adding the job to the Queue, it uses the value corresponding to the
"queue" key in the job hash, but for deleting that it has just processed, the
queue from the sidekiq_configuration of the Worker is used. This means that the
job is only removed from the jobs_by_worker hash in the Queue, and not the
jobs_by_queue Hash, leading to drain_all repeatedly trying to get a worker to
work on the job (as it uses jobs_by_queue), and the worker not finding a job to
work on (as it uses jobs_by_worker).

This can be fixed by deleting the job from the queue by using the queue for the
job, and not the default for the worker.

Fixes #3144 