### PR TITLE
Configurable :fetch strategy

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -296,6 +296,10 @@ module Sidekiq
           opts[:environment] = arg
         end
 
+        o.on '--fetch FETCH', 'Custom fetch strategy class to use for picking up jobs from queues' do |arg|
+          opts[:fetch] = arg
+        end
+
         o.on '-g', '--tag TAG', "Process tag for procline" do |arg|
           opts[:tag] = arg
         end

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -49,8 +49,7 @@ module Sidekiq
 
       # Requeue everything in case there was a worker who grabbed work while stopped
       # This call is a no-op in Sidekiq but necessary for Sidekiq Pro.
-      strategy = (@options[:fetch] || Sidekiq::BasicFetch)
-      strategy.bulk_requeue([], @options)
+      @manager.strategy.bulk_requeue([], @options)
 
       clear_heartbeat
     end

--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -103,6 +103,10 @@ module Sidekiq
       @done
     end
 
+    def strategy
+      @options[:fetch] ? Object.const_get(@options[:fetch]) : Sidekiq::BasicFetch
+    end
+
     private
 
     def hard_shutdown

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -35,7 +35,7 @@ module Sidekiq
       @done = false
       @job = nil
       @thread = nil
-      @strategy = (mgr.options[:fetch] || Sidekiq::BasicFetch).new(mgr.options)
+      @strategy = mgr.strategy.new(mgr.options)
       @reloader = Sidekiq.options[:reloader]
     end
 

--- a/test/test_actors.rb
+++ b/test/test_actors.rb
@@ -74,6 +74,9 @@ class TestActors < Sidekiq::Test
             @cond.signal
           end
         end
+        def strategy
+          Sidekiq::BasicFetch
+        end
         def options
           { :concurrency => 3, :queues => ['default'] }
         end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -113,6 +113,11 @@ class TestCli < Sidekiq::Test
       Sidekiq.logger.level = old
     end
 
+    it 'sets custom fetch class' do
+      @cli.parse(['sidekiq', '--fetch', 'FakeApp::FakeFetch'])
+      assert_equal 'FakeApp::FakeFetch', Sidekiq.options[:fetch]
+    end
+
     describe 'with logfile' do
       before do
         @old_logger = Sidekiq.logger

--- a/test/test_manager.rb
+++ b/test/test_manager.rb
@@ -42,6 +42,13 @@ class TestManager < Sidekiq::Test
       assert_raises(ArgumentError) { new_manager(concurrency: -1) }
     end
 
+    class CustomFetch < Sidekiq::BasicFetch; end
+
+    it 'returns a strategy class' do
+      assert_equal Sidekiq::BasicFetch, new_manager(options).strategy
+      assert_equal CustomFetch, new_manager(options.merge(:fetch => 'TestManager::CustomFetch')).strategy
+    end
+
     def options
       { :concurrency => 3, :queues => ['default'] }
     end

--- a/test/test_middleware.rb
+++ b/test/test_middleware.rb
@@ -80,6 +80,7 @@ class TestMiddleware < Sidekiq::Test
       end
 
       boss = Minitest::Mock.new
+      boss.expect(:strategy, Sidekiq::BasicFetch)
       boss.expect(:options, {:queues => ['default'] }, [])
       boss.expect(:options, {:queues => ['default'] }, [])
       processor = Sidekiq::Processor.new(boss)

--- a/test/test_processor.rb
+++ b/test/test_processor.rb
@@ -12,6 +12,7 @@ class TestProcessor < Sidekiq::Test
     before do
       $invokes = 0
       @mgr = Minitest::Mock.new
+      @mgr.expect(:strategy, Sidekiq::BasicFetch)
       @mgr.expect(:options, {:queues => ['default']})
       @mgr.expect(:options, {:queues => ['default']})
       @processor = ::Sidekiq::Processor.new(@mgr)


### PR DESCRIPTION
Hi,

I'm using a custom fetch class in some of my Sidekiq processes and thought that it might be a good idea to expose it in CLI.

So this PR introduces a new `--fetch` CLI option that accepts a class name to be used for job fetching and also removes duplication around deciding which fetch class to use.

I haven't added the shorthand option because `-f` is usually used for files… it might make sense to rename this option to `strategy` with an `s` shorthand.