### PR TITLE
Redirect from no trailing slash on Web UI

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -28,6 +28,10 @@ module Sidekiq
     def self.set(key, val)
       # nothing, backwards compatibility
     end
+    
+    get "" do
+      redirect(root_path)
+    end
 
     get "/" do
       @redis_info = redis_info.select{ |k, v| REDIS_KEYS.include? k }


### PR DESCRIPTION
Fixes #3151

If you mount at `/sidekiq` and visit the `/sidekiq` URL, it will now redirect over to `/sidekiq/`, rather than 404ing.