### PR TITLE
Provide consistent interface to exception handlers

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -143,7 +143,7 @@ module Sidekiq
           # we didn't properly finish it.
           ack = false
         rescue Exception => ex
-          handle_exception(ex, job || { :job => jobstr })
+          handle_exception(ex, { :context => "Job raised exception", :job => job, :jobstr => jobstr })
           raise
         ensure
           work.acknowledge if ack

--- a/lib/sidekiq/util.rb
+++ b/lib/sidekiq/util.rb
@@ -53,7 +53,7 @@ module Sidekiq
         begin
           block.call
         rescue => ex
-          handle_exception(ex, { event: event })
+          handle_exception(ex, { context: "Exception during Sidekiq lifecycle event.", event: event })
         end
       end
       arr.clear


### PR DESCRIPTION
When working on Sentry's Sidekiq integration, I noticed that the message provided to the exception handler can change a little depending on the context, making it difficult to pull structured data out. This makes all exceptions handle consistently.