### PR TITLE
Remove gemspec version constraint for rack-protection

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency                  'redis', '~> 3.2', '>= 3.2.1'
   gem.add_dependency                  'connection_pool', '~> 2.2', '>= 2.2.0'
   gem.add_dependency                  'concurrent-ruby', '~> 1.0'
-  gem.add_dependency                  'rack-protection', '~> 1.5'
+  gem.add_dependency                  'rack-protection'
   gem.add_development_dependency      'redis-namespace', '~> 1.5', '>= 1.5.2'
   gem.add_development_dependency      'minitest', '~> 5.7', '>= 5.7.0'
   gem.add_development_dependency      'rake', '~> 10.0'

--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency                  'redis', '~> 3.2', '>= 3.2.1'
   gem.add_dependency                  'connection_pool', '~> 2.2', '>= 2.2.0'
   gem.add_dependency                  'concurrent-ruby', '~> 1.0'
-  gem.add_dependency                  'rack-protection'
+  gem.add_dependency                  'rack-protection', '>= 1.5.0'
   gem.add_development_dependency      'redis-namespace', '~> 1.5', '>= 1.5.2'
   gem.add_development_dependency      'minitest', '~> 5.7', '>= 5.7.0'
   gem.add_development_dependency      'rake', '~> 10.0'


### PR DESCRIPTION
Addresses #3145 
Tested and currently in production use.
Deals with rack-protection Sinatra version conflict by removing version constraint from gemspec.