### PR TITLE
Resolve Rails Reloader and ActiveRecord middleware incompatibility

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -150,10 +150,6 @@ module Sidekiq
     Middleware::Chain.new do |m|
       m.add Middleware::Server::Logging
       m.add Middleware::Server::RetryJobs
-      if defined?(::ActiveRecord::Base) && !(defined?(Sidekiq::Rails::Reloader) && Sidekiq.options[:reloader].is_a?(Sidekiq::Rails::Reloader))
-        require 'sidekiq/middleware/server/active_record'
-        m.add Sidekiq::Middleware::Server::ActiveRecord
-      end
     end
   end
 

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -150,7 +150,7 @@ module Sidekiq
     Middleware::Chain.new do |m|
       m.add Middleware::Server::Logging
       m.add Middleware::Server::RetryJobs
-      if defined?(::ActiveRecord::Base)
+      if defined?(::ActiveRecord::Base) && (!defined?(Sidekiq::Rails::Reloader) || Sidekiq.options[:reloader].is_a?(Sidekiq::Rails::Reloader))
         require 'sidekiq/middleware/server/active_record'
         m.add Sidekiq::Middleware::Server::ActiveRecord
       end

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -150,7 +150,7 @@ module Sidekiq
     Middleware::Chain.new do |m|
       m.add Middleware::Server::Logging
       m.add Middleware::Server::RetryJobs
-      if defined?(::ActiveRecord::Base) && (!defined?(Sidekiq::Rails::Reloader) || Sidekiq.options[:reloader].is_a?(Sidekiq::Rails::Reloader))
+      if defined?(::ActiveRecord::Base) && !(defined?(Sidekiq::Rails::Reloader) && Sidekiq.options[:reloader].is_a?(Sidekiq::Rails::Reloader))
         require 'sidekiq/middleware/server/active_record'
         m.add Sidekiq::Middleware::Server::ActiveRecord
       end

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -240,7 +240,6 @@ module Sidekiq
         else
           require 'sidekiq/rails'
           require File.expand_path("#{options[:require]}/config/environment.rb")
-          Sidekiq.options[:reloader] = Sidekiq::Rails::Reloader.new
         end
         options[:tag] ||= default_tag
       else

--- a/lib/sidekiq/middleware/server/active_record.rb
+++ b/lib/sidekiq/middleware/server/active_record.rb
@@ -7,7 +7,8 @@ module Sidekiq
           #
           # The reloader needs the active connection to clear its query cache
           # before releasing it otherwise other workers will see dirty query
-          # cache data.
+          # cache data. The reloader will then take care of clearing
+          # ActiveRecord connections as well.
           #
           # We need to make sure folks remove this middleware if they've added
           # it themselves.

--- a/lib/sidekiq/middleware/server/active_record.rb
+++ b/lib/sidekiq/middleware/server/active_record.rb
@@ -5,21 +5,7 @@ module Sidekiq
         def call(*args)
           yield
         ensure
-          # We can't use this middleware with the Rails reloader.
-          #
-          # The reloader needs the active connection to clear its query cache
-          # before releasing it otherwise other workers will see dirty query
-          # cache data. The reloader will then take care of clearing
-          # ActiveRecord connections as well.
-          #
-          # We need to make sure folks remove this middleware if they've added
-          # it themselves.
-          #
-          if defined?(Sidekiq::Rails::Reloader) && Sidekiq.options[:reloader].is_a?(Sidekiq::Rails::Reloader)
-            raise ArgumentError, "You are using the Sidekiq ActiveRecord middleware and the new Rails 5 reloader which are incompatible. Please remove the ActiveRecord middleware from your Sidekiq middleware configuration."
-          else
-            ::ActiveRecord::Base.clear_active_connections!
-          end
+          ::ActiveRecord::Base.clear_active_connections!
         end
       end
     end

--- a/lib/sidekiq/middleware/server/active_record.rb
+++ b/lib/sidekiq/middleware/server/active_record.rb
@@ -16,7 +16,7 @@ module Sidekiq
           # it themselves.
           #
           if defined?(Sidekiq::Rails::Reloader) && Sidekiq.options[:reloader].is_a?(Sidekiq::Rails::Reloader)
-            raise ArgumentError, "Your are usign the Sidekiq ActiveRecord middleware and the new Rails 5 reloader which are incompatible. Please remove the ActiveRecord middleware from your Sidekiq middleware configuration."
+            raise ArgumentError, "You are using the Sidekiq ActiveRecord middleware and the new Rails 5 reloader which are incompatible. Please remove the ActiveRecord middleware from your Sidekiq middleware configuration."
           else
             ::ActiveRecord::Base.clear_active_connections!
           end

--- a/lib/sidekiq/middleware/server/active_record.rb
+++ b/lib/sidekiq/middleware/server/active_record.rb
@@ -2,7 +2,9 @@ module Sidekiq
   module Middleware
     module Server
       class ActiveRecord
-        def initialize
+        def call(*args)
+          yield
+        ensure
           # We can't use this middleware with the Rails reloader.
           #
           # The reloader needs the active connection to clear its query cache
@@ -15,13 +17,9 @@ module Sidekiq
           #
           if defined?(Sidekiq::Rails::Reloader) && Sidekiq.options[:reloader].is_a?(Sidekiq::Rails::Reloader)
             raise ArgumentError, "Your are usign the Sidekiq ActiveRecord middleware and the new Rails 5 reloader which are incompatible. Please remove the ActiveRecord middleware from your Sidekiq middleware configuration."
+          else
+            ::ActiveRecord::Base.clear_active_connections!
           end
-        end
-
-        def call(*args)
-          yield
-        ensure
-          ::ActiveRecord::Base.clear_active_connections!
         end
       end
     end


### PR DESCRIPTION
The new Rails reloader enables the query cache within every yield and expects to have access to the current connection that it enabled the query cache for at the end of the block to clear the cache and then release the connection. The Sidekiq ActiveRecord middleware which is added automatically releases the connection earlier, the query cache of another connection may instead be cleared, and the dirty query cache might be used by another worker.

This change makes sure that the ActiveRecord middleware cannot be used in tandem with the new Rails reloader (in case folks have added it to their middleware stacks explicitly) and removes it from the default middleware stack when the reloader is in play.

I couldn't figure out a way to raise the error from the middleware during startup. It seems the middleware is instantiated per job and so the raise only happens when a job is run? Not sure if there's a better way.

Fixes the query cache issue in #3157.

/cc @mperham @matthewd