### PR TITLE
Fix uninitialized constant Sidekiq::WebAction::CONTENT_TYPE error

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -28,7 +28,7 @@ module Sidekiq
     def self.set(key, val)
       # nothing, backwards compatibility
     end
-    
+
     get "" do
       redirect(root_path)
     end

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -286,7 +286,7 @@ module Sidekiq
         when :json
           WebAction::APPLICATION_JSON
         when String
-          { WebAction::CONTENT_TYPE => action.type, "Cache-Control" => "no-cache" }
+          { "Content-Type" => action.type, "Cache-Control" => "no-cache" }
         else
           WebAction::TEXT_HTML
         end


### PR DESCRIPTION
## Situation

If content_type other than json (ex. "text/css", "text/javascript"),  `NameError - uninitialized constant Sidekiq::WebAction::CONTENT_TYPE:` has occurred.

## Problem

`Sidekiq::WebAction::CONTENT_TYPE` was removed.

https://github.com/mperham/sidekiq/commit/ad350433a87718ca9d83c14c50631d3bca0954f6

## Solution

Restore `WebAction::CONTENT_TYPE` or set "Content-Type".

## Backtrace

```
NameError - uninitialized constant Sidekiq::WebAction::CONTENT_TYPE:
  activesupport (5.0.0.1) lib/active_support/dependencies.rb:550:in `load_missing_constant'
  activesupport (5.0.0.1) lib/active_support/dependencies.rb:203:in `const_missing'
  sidekiq (4.2.2) lib/sidekiq/web/application.rb:289:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack-protection (1.5.3) lib/rack/protection/xss_header.rb:18:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack-protection (1.5.3) lib/rack/protection/base.rb:49:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack-protection (1.5.3) lib/rack/protection/base.rb:49:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack-protection (1.5.3) lib/rack/protection/path_traversal.rb:16:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack-protection (1.5.3) lib/rack/protection/json_csrf.rb:18:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack-protection (1.5.3) lib/rack/protection/base.rb:49:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack-protection (1.5.3) lib/rack/protection/base.rb:49:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack-protection (1.5.3) lib/rack/protection/frame_options.rb:31:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack-protection (1.5.3) lib/rack/protection/base.rb:49:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack (2.0.1) lib/rack/session/abstract/id.rb:222:in `context'
  rack (2.0.1) lib/rack/session/abstract/id.rb:216:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack (2.0.1) lib/rack/urlmap.rb:68:in `block in call'
  rack (2.0.1) lib/rack/urlmap.rb:53:in `call'
  rack (2.0.1) lib/rack/builder.rb:153:in `call'
  sidekiq (4.2.2) lib/sidekiq/web.rb:88:in `call'
  sidekiq (4.2.2) lib/sidekiq/web.rb:93:in `call'
  actionpack (5.0.0.1) lib/action_dispatch/routing/mapper.rb:17:in `block in <class:Constraints>'
  actionpack (5.0.0.1) lib/action_dispatch/routing/mapper.rb:46:in `serve'
  actionpack (5.0.0.1) lib/action_dispatch/journey/router.rb:39:in `block in serve'
  actionpack (5.0.0.1) lib/action_dispatch/journey/router.rb:26:in `serve'
  actionpack (5.0.0.1) lib/action_dispatch/routing/route_set.rb:725:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  bullet (5.2.1) lib/bullet/rack.rb:12:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/rack/agent_hooks.rb:30:in `traced_call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/rack/browser_monitoring.rb:32:in `traced_call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/rack/developer_mode.rb:48:in `traced_call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack (2.0.1) lib/rack/etag.rb:25:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack (2.0.1) lib/rack/conditional_get.rb:25:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack (2.0.1) lib/rack/head.rb:12:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  activerecord (5.0.0.1) lib/active_record/migration.rb:552:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  actionpack (5.0.0.1) lib/action_dispatch/middleware/callbacks.rb:38:in `block in call'
  activesupport (5.0.0.1) lib/active_support/callbacks.rb:97:in `__run_callbacks__'
  activesupport (5.0.0.1) lib/active_support/callbacks.rb:750:in `_run_call_callbacks'
  activesupport (5.0.0.1) lib/active_support/callbacks.rb:90:in `run_callbacks'
  actionpack (5.0.0.1) lib/action_dispatch/middleware/callbacks.rb:36:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  actionpack (5.0.0.1) lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  bugsnag (5.0.1) lib/bugsnag/rack.rb:33:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  better_errors (2.1.1) lib/better_errors/middleware.rb:84:in `protected_app_call'
  better_errors (2.1.1) lib/better_errors/middleware.rb:79:in `better_errors_call'
  better_errors (2.1.1) lib/better_errors/middleware.rb:57:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  actionpack (5.0.0.1) lib/action_dispatch/middleware/debug_exceptions.rb:49:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  actionpack (5.0.0.1) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  railties (5.0.0.1) lib/rails/rack/logger.rb:36:in `call_app'
  railties (5.0.0.1) lib/rails/rack/logger.rb:24:in `block in call'
  activesupport (5.0.0.1) lib/active_support/tagged_logging.rb:70:in `block in tagged'
  activesupport (5.0.0.1) lib/active_support/tagged_logging.rb:26:in `tagged'
  activesupport (5.0.0.1) lib/active_support/tagged_logging.rb:70:in `tagged'
  railties (5.0.0.1) lib/rails/rack/logger.rb:24:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  actionpack (5.0.0.1) lib/action_dispatch/middleware/request_id.rb:24:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack (2.0.1) lib/rack/runtime.rb:22:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  activesupport (5.0.0.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  actionpack (5.0.0.1) lib/action_dispatch/middleware/executor.rb:12:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  actionpack (5.0.0.1) lib/action_dispatch/middleware/static.rb:136:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  rack (2.0.1) lib/rack/sendfile.rb:111:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  railties (5.0.0.1) lib/rails/engine.rb:522:in `call'
  newrelic_rpm (3.16.3.323) lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
  puma (3.6.0) lib/puma/configuration.rb:225:in `call'
  puma (3.6.0) lib/puma/server.rb:578:in `handle_request'
  puma (3.6.0) lib/puma/server.rb:415:in `process_client'
  puma (3.6.0) lib/puma/server.rb:275:in `block in run'
  puma (3.6.0) lib/puma/thread_pool.rb:116:in `block in spawn_thread'
```

## Environment

OS: Mac OSX 10.10.5
Ruby: 2.3.1
Rails: 5.0.0.1
Sidekiq: 4.2.2

## Sidekiq plugins

- sidekiq-failures
- sidekiq-history
- sidekiq-statistic
- sidekqi-ent

## Sidekiq initializer

```rb
Sidekiq.configure_server do |config|
  config.redis = {
    url: Rails.application.secrets.redis,
    namespace: '%s-expires' % Rails.env
  }

  config.periodic do |manager|
    manager.register('0 4 * * *', ExampleWorker)
  end

  config.timed_fetch!
  config.reliable_scheduler!
end

Sidekiq.configure_client do |config|
  config.redis = {
    url: Rails.application.secrets.redis,
    namespace: '%s-expires' % Rails.env
  }
end
```




