### PR TITLE
Fix the error in worker#perform_in about interval type

### DIFF
--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -64,13 +64,13 @@ module Sidekiq
       #   numeric (like an activesupport time interval).
       def perform_in(interval, *args)
         int = interval.to_f
-        now = Time.now
-        ts = (int < 1_000_000_000 ? (now + interval).to_f : int)
+        now = Time.now.to_f
+        ts = (int < 1_000_000_000 ? now + int : int)
 
         item = { 'class' => self, 'args' => args, 'at' => ts }
 
         # Optimization to enqueue something now that is scheduled to go out now or in the past
-        item.delete('at'.freeze) if ts <= now.to_f
+        item.delete('at'.freeze) if ts <= now
 
         client_push(item)
       end

--- a/test/test_scheduling.rb
+++ b/test/test_scheduling.rb
@@ -11,6 +11,11 @@ class TestScheduling < Sidekiq::Test
       end
     end
 
+    # Assume we can pass any class as time to perform_in
+    class TimeDuck
+      def to_f; 42.0 end
+    end
+
     it 'schedules jobs' do
       ss = Sidekiq::ScheduledSet.new
       ss.clear
@@ -34,6 +39,9 @@ class TestScheduling < Sidekiq::Test
 
       assert Sidekiq::Client.push_bulk('class' => ScheduledWorker, 'args' => [['mike'], ['mike']], 'at' => 600)
       assert_equal 5, ss.size
+
+      assert ScheduledWorker.perform_in(TimeDuck.new, 'samwise')
+      assert_equal 6, ss.size
     end
 
     it 'removes the enqueued_at field when scheduling' do


### PR DESCRIPTION
## Situation:
We are using Sidekiq Pro with ActiveSupport.
When I passed a object which is ActiveSupport::TimeWithZone to perform_at,
`TypeError: can't convert ActiveSupport::TimeWithZone into an exact
number` has occurred.

## Problem:
The object of Time class can't plus a ActiveSupport::TimeWithZone object.

## Solution:
We can transform any Time object to float, and use it to compare and
calculate.