### PR TITLE
Handle errors raised by the reloader

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -119,9 +119,9 @@ module Sidekiq
       jobstr = work.job
       queue = work.queue_name
 
-      @reloader.call do
-        ack = false
-        begin
+      ack = false
+      begin
+        @reloader.call do
           job = Sidekiq.load_json(jobstr)
           klass  = job['class'.freeze].constantize
           worker = klass.new
@@ -137,17 +137,17 @@ module Sidekiq
             end
           end
           ack = true
-        rescue Sidekiq::Shutdown
-          # Had to force kill this job because it didn't finish
-          # within the timeout.  Don't acknowledge the work since
-          # we didn't properly finish it.
-          ack = false
-        rescue Exception => ex
-          handle_exception(ex, { :context => "Job raised exception", :job => job, :jobstr => jobstr })
-          raise
-        ensure
-          work.acknowledge if ack
         end
+      rescue Sidekiq::Shutdown
+        # Had to force kill this job because it didn't finish
+        # within the timeout.  Don't acknowledge the work since
+        # we didn't properly finish it.
+        ack = false
+      rescue Exception => ex
+        handle_exception(ex, { :context => "Job raised exception", :job => job, :jobstr => jobstr })
+        raise
+      ensure
+        work.acknowledge if ack
       end
     end
 


### PR DESCRIPTION
The reloader might raise an error instead of yielding control. If this happens, the job will silently fail to run, without being reenqueued and without logging any indication of what happened. I'm pretty sure that's what was happening here: https://github.com/mperham/sidekiq/issues/3154#issuecomment-253125379.

This change doesn't prevent the job from being lost, but at least if the error handlers are called it will be possible to diagnose the problem.