### PR TITLE
Use Rails executor if code reloading is disabled

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -33,6 +33,7 @@ module Sidekiq
     dead_max_jobs: 10_000,
     dead_timeout_in_seconds: 180 * 24 * 60 * 60, # 6 months
     reloader: proc { |&block| block.call },
+    executor: proc { |&block| block.call },
   }
 
   DEFAULT_WORKER_OPTIONS = {


### PR DESCRIPTION
We have to release the current thread's Active Record connection after performing each job, in case another thread is waiting to use it.

On Rails 4 and earlier, this is handled with [middleware](https://github.com/mperham/sidekiq/blob/v4.2.5/lib/sidekiq/middleware/server/active_record.rb). On Rails 5 in development mode, the reloader does it by [delegating to the executor](https://github.com/rails/rails/blob/v5.0.0.1/activesupport/lib/active_support/reloader.rb#L67-L69). However on Rails 5 in production mode, we're not adding the middleware or enabling the reloader, so connections will never be released.

We can call the executor directly to have it [release the connection for us](https://github.com/rails/rails/blob/v5.0.0.1/activerecord/lib/active_record/query_cache.rb#L48) in this case. By calling it inside the middleware stack, the job will be retried if the executor raises, avoiding the problem with lost jobs that led to the reloader being [disabled in production](https://github.com/mperham/sidekiq/commit/4b3d5edd1872d64adfea0c033feb10b859f2424a).