### PR TITLE
Pass job hash to handle_exception again

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -121,8 +121,8 @@ module Sidekiq
 
       ack = false
       begin
+        job = Sidekiq.load_json(jobstr)
         @reloader.call do
-          job = Sidekiq.load_json(jobstr)
           klass  = job['class'.freeze].constantize
           worker = klass.new
           worker.jid = job['jid'.freeze]


### PR DESCRIPTION
Fixes https://github.com/mperham/sidekiq/issues/3223.

When I moved the reloader inside the block in https://github.com/mperham/sidekiq/pull/3212 so that any errors it raised would be handled properly, the `job` local variable was pushed into a nested scope, which meant it wasn't accessible from the rescue block any more. This changed the meaning of `job` in that rescue block from the local variable to [the `attr_reader` with the same name](https://github.com/mperham/sidekiq/blob/v4.2.5/lib/sidekiq/processor.rb#L30).

We don't need to reload the application before parsing the job payload, so we can move this work outside the reloader block so that the job hash is accessible in the rescue block again.