### PR TITLE
Monkeypatch Psych to enable Rails autoloading

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -69,6 +69,7 @@ module Sidekiq
           Sidekiq.logger.debug { "Autoload disabled in #{::Rails.env}, Sidekiq will not reload changed classes" }
         else
           Sidekiq.options[:reloader] = Sidekiq::Rails::Reloader.new
+          Psych::Visitors::ToRuby.prepend(Sidekiq::Rails::PsychAutoload)
         end
       end
     end
@@ -87,6 +88,14 @@ module Sidekiq
 
       def inspect
         "#<Sidekiq::Rails::Reloader @app=#{@app.class.name}>"
+      end
+    end
+
+    module PsychAutoload
+      def resolve_class(klass_name)
+        klass_name && klass_name.constantize
+      rescue NameError
+        super
       end
     end
   end if defined?(::Rails)


### PR DESCRIPTION
This little PR teaches Psych how to use `constantize` in the development environment of Rails. It fixes #3171, so you don't need to remove delay extensions anymore :)