### PR TITLE
Add fallback for 'retry' value server-side.

### DIFF
--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -79,6 +79,10 @@ module Sidekiq
           # ignore, will be pushed back onto queue during hard_shutdown
           raise Sidekiq::Shutdown if exception_caused_by_shutdown?(e)
 
+          if msg['retry'].nil?
+            msg['retry'] = worker.class.get_sidekiq_options['retry']
+          end
+
           raise e unless msg['retry']
           attempt_retry(worker, msg, queue, e)
         end

--- a/test/test_processor.rb
+++ b/test/test_processor.rb
@@ -93,7 +93,12 @@ class TestProcessor < Sidekiq::Test
         assert_equal 1, errors.count
         assert_instance_of TestException, errors.first[:exception]
         assert_equal msg, errors.first[:context][:jobstr]
-        assert_equal job_hash, errors.first[:context][:job]
+
+        # TODO: Replace with `assert errors.first[:context][:job] <= job_hash`
+        # when support for Ruby < 2.3 is dropped
+        job_hash.each do |key, value|
+          assert_equal value, errors.first[:context][:job][key]
+        end
       end
 
       it 'handles exceptions raised by the reloader' do


### PR DESCRIPTION
If using a client other than Sidekiq to enqueue jobs,
the `retry` value set in the `sidekiq_options` hash will be ignored.

This is somewhat counterintuitive, so fall back to value if no value
is set in the message.