### PR TITLE
Fix issue with Set

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'uri'
+require 'set'
 require 'yaml'
 
 module Sidekiq


### PR DESCRIPTION
Fixes the following issue:

```
C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/sidekiq-4.2.5/lib/sidekiq/web/helpers.rb:191:in `<module:WebHelpers>': uninitialized constant Sidekiq::WebHelpers::Set (NameError)
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/sidekiq-4.2.5/lib/sidekiq/web/helpers.rb:7:in `<module:Sidekiq>'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/sidekiq-4.2.5/lib/sidekiq/web/helpers.rb:5:in `<top (required)>'
        from C:/Ruby23-x64/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from C:/Ruby23-x64/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/sidekiq-4.2.5/lib/sidekiq/web.rb:7:in `<top (required)>'
        from C:/Ruby23-x64/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from C:/Ruby23-x64/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from C:/Users/L33T/Documents/repos/ruby-steam-scraper/config.ru:7:in `block in <main>'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/builder.rb:55:in `instance_eval'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/builder.rb:55:in `initialize'
        from C:/Users/L33T/Documents/repos/ruby-steam-scraper/config.ru:in `new'
        from C:/Users/L33T/Documents/repos/ruby-steam-scraper/config.ru:in `<main>'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/builder.rb:49:in `eval'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/builder.rb:49:in `new_from_string'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/builder.rb:40:in `parse_file'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/server.rb:318:in `build_app_and_options_from_config'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/server.rb:218:in `app'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/server.rb:353:in `wrapped_app'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/server.rb:282:in `start'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rack-2.0.1/lib/rack/server.rb:147:in `start'
        from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rack-2.0.1/bin/rackup:4:in `<top (required)>'
        from C:/Ruby23-x64/bin/rackup:22:in `load'
        from C:/Ruby23-x64/bin/rackup:22:in `<main>'