### PR TITLE
Put source encoding comment as line for [j]ruby 1.9 compatibility

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # encoding: utf-8
+# frozen_string_literal: true
 require 'sidekiq/version'
 fail "Sidekiq #{Sidekiq::VERSION} does not support Ruby versions below 2.0.0." if RUBY_PLATFORM != 'java' && RUBY_VERSION < '2.0.0'
 

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # encoding: utf-8
+# frozen_string_literal: true
 require 'sidekiq'
 
 module Sidekiq

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # encoding: utf-8
+# frozen_string_literal: true
 $stdout.sync = true
 
 require 'yaml'

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # encoding: utf-8
+# frozen_string_literal: true
 require 'sidekiq/manager'
 require 'sidekiq/fetch'
 require 'sidekiq/scheduled'

--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # encoding: utf-8
+# frozen_string_literal: true
 require 'sidekiq/util'
 require 'sidekiq/processor'
 require 'sidekiq/fetch'

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # encoding: utf-8
+# frozen_string_literal: true
 require_relative 'helper'
 require 'sidekiq/scheduled'
 require 'sidekiq/middleware/server/retry_jobs'

--- a/test/test_sidekiq.rb
+++ b/test/test_sidekiq.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # encoding: utf-8
+# frozen_string_literal: true
 require_relative 'helper'
 
 class TestSidekiq < Sidekiq::Test

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -1,5 +1,5 @@
-# frozen_string_literal: true
 # encoding: utf-8
+# frozen_string_literal: true
 require_relative 'helper'
 require 'sidekiq/web'
 require 'rack/test'


### PR DESCRIPTION
In jruby 1.7.22 (1.9.3p551 compatibility mode), UTF-8 encoding is not properly
detected, because the encoding comment is not on the first line as required in ruby
1.9.

The frozen_string_literal magic comment did not come into existence until ruby 2.3,
and ruby 1.9 does not look past the first line for magic comments.

This results encoding-related syntax errors. Examples:

    SyntaxError: /home/nilbus/ws/rental_express/ROOT/rails/vendor/bundle/jruby/1.9/gems/sidekiq-4.2.6/lib/sidekiq.rb:52: Invalid char `\235' ('') in expression
      def self.â¨â¯Â°â¡Â°â©â¯ï¸µâ»ââ»
                ^

    SyntaxError: /home/nilbus/ws/rental_express/ROOT/rails/vendor/bundle/jruby/1.9/gems/sidekiq-4.2.6/lib/sidekiq/api.rb:269: Invalid char `\237' ('') in expression
        alias_method :ð£, :clear
                       ^

This patch should restore compatibility with ruby 1.9 and greater.

Can you release this fix quickly? It's blocking my ability to upgrade to
sidekiq-ent-1.2.3 to resolve our issue related to #3047. Thanks!