### PR TITLE
Add the enqueued_at attribute when fake Testing

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -69,7 +69,9 @@ module Sidekiq
     def raw_push(payloads)
       if Sidekiq::Testing.fake?
         payloads.each do |job|
-          Queues.push(job['queue'], job['class'], Sidekiq.load_json(Sidekiq.dump_json(job)))
+          job = Sidekiq.load_json(Sidekiq.dump_json(job))
+          job.merge!('enqueued_at' => Time.now.to_f) unless job['at']
+          Queues.push(job['queue'], job['class'], job)
         end
         true
       elsif Sidekiq::Testing.inline?

--- a/test/test_testing_fake.rb
+++ b/test/test_testing_fake.rb
@@ -61,8 +61,10 @@ class TestTesting < Sidekiq::Test
     it 'stubs the async call' do
       assert_equal 0, DirectWorker.jobs.size
       assert DirectWorker.perform_async(1, 2)
+      assert_in_delta Time.now.to_f, DirectWorker.jobs.last['enqueued_at'], 0.01
       assert_equal 1, DirectWorker.jobs.size
       assert DirectWorker.perform_in(10, 1, 2)
+      refute DirectWorker.jobs.last['enqueued_at']
       assert_equal 2, DirectWorker.jobs.size
       assert DirectWorker.perform_at(10, 1, 2)
       assert_equal 3, DirectWorker.jobs.size


### PR DESCRIPTION
Implements https://github.com/mperham/sidekiq/issues/3245

Trying to emulate the real behavior, the job obtains an `enqueued_at` attribute when it's placed in a queue.

Since using `perform_in` or `perform_at` does not put the job in the queue when run, the attribute is not set for those methods.