### PR TITLE
Hide the intial preview line when using Show All in the UI

### DIFF
--- a/web/views/queue.erb
+++ b/web/views/queue.erb
@@ -24,9 +24,9 @@
         <td>
           <% a = msg.display_args.inspect %>
           <% if a.size > 100 %>
-            <%= h(msg.display_args.inspect[0..100]) + "... " %>
-            <button data-toggle="collapse" data-target="#worker_<%= index %>" class="btn btn-default btn-xs"><%= t('ShowAll') %></button>
-            <div class="toggle" id="worker_<%= index %>"><%= h(msg.display_args) %></div>
+            <span class="worker_<%= index %>"><%= h(msg.display_args.inspect[0..100]) + "... " %></span>
+            <button data-toggle="collapse" data-target=".worker_<%= index %>" class="btn btn-default btn-xs"><%= t('ShowAll') %></button>
+            <div class="toggle worker_<%= index %>"><%= h(msg.display_args) %></div>
           <% else %>
             <%= h(msg.display_args) %>
           <% end %>


### PR DESCRIPTION
Implements [#3282](https://github.com/mperham/sidekiq/issues/3282).

Hides the initial preview line when 'Show All' button is pressed.