### PR TITLE
Remove incorrect part of Manager's description

### DIFF
--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -10,7 +10,7 @@ module Sidekiq
 
   ##
   # The Manager is the central coordination point in Sidekiq, controlling
-  # the lifecycle of the Processors and feeding them jobs as necessary.
+  # the lifecycle of the Processors.
   #
   # Tasks:
   #


### PR DESCRIPTION
It seems it was feeding Processors at some point, but it is not anymore.