### PR TITLE
Fixnum -> Integer replacement and Ruby 2.4 support for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ before_install:
 rvm:
   - 2.2.4
   - 2.3.0
+  - 2.4.0
   - jruby-head

--- a/lib/sidekiq/middleware/server/retry_jobs.rb
+++ b/lib/sidekiq/middleware/server/retry_jobs.rb
@@ -162,7 +162,7 @@ module Sidekiq
         end
 
         def retry_attempts_from(msg_retry, default)
-          if msg_retry.is_a?(Fixnum)
+          if msg_retry.is_a?(Integer)
             msg_retry
           else
             default

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -274,7 +274,7 @@ module Sidekiq
       resp = case resp
       when Array
         resp
-      when Fixnum
+      when Integer
         [resp, {}, []]
       else
         type_header = case action.type


### PR DESCRIPTION
Fixnum is deprecated in Ruby 2.4 so we should get rid of it.