### PR TITLE
Disable delay extensions by default, fixes #3174

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -7,6 +7,7 @@ require 'sidekiq/logging'
 require 'sidekiq/client'
 require 'sidekiq/worker'
 require 'sidekiq/redis_connection'
+require 'sidekiq/delay'
 
 require 'json'
 
@@ -231,7 +232,4 @@ module Sidekiq
 
 end
 
-require 'sidekiq/extensions/class_methods'
-require 'sidekiq/extensions/action_mailer'
-require 'sidekiq/extensions/active_record'
 require 'sidekiq/rails' if defined?(::Rails::Engine)

--- a/lib/sidekiq/delay.rb
+++ b/lib/sidekiq/delay.rb
@@ -1,0 +1,21 @@
+module Sidekiq
+  module Extensions
+
+    def self.enable_delay!
+      if defined?(::ActiveSupport)
+        ActiveSupport.on_load(:active_record) do
+          require 'sidekiq/extensions/active_record'
+          include Sidekiq::Extensions::ActiveRecord
+        end
+        ActiveSupport.on_load(:action_mailer) do
+          require 'sidekiq/extensions/action_mailer'
+          extend Sidekiq::Extensions::ActionMailer
+        end
+      end
+
+      require 'sidekiq/extensions/class_methods'
+      Module.__send__(:include, Sidekiq::Extensions::Klass)
+    end
+
+  end
+end

--- a/lib/sidekiq/extensions/generic_proxy.rb
+++ b/lib/sidekiq/extensions/generic_proxy.rb
@@ -3,6 +3,8 @@ require 'yaml'
 
 module Sidekiq
   module Extensions
+    SIZE_LIMIT = 4_096
+
     class Proxy < BasicObject
       def initialize(performable, target, options={})
         @performable = performable
@@ -17,7 +19,11 @@ module Sidekiq
         # to JSON and then deserialized on the other side back into a
         # Ruby object.
         obj = [@target, name, args]
-        @performable.client_push({ 'class' => @performable, 'args' => [::YAML.dump(obj)] }.merge(@opts))
+        marshalled = ::YAML.dump(obj)
+        if marshalled.size > SIZE_LIMIT
+          ::Sidekiq.logger.warn { "#{@target}.#{name} serialized argument very large, you should refactor it to reduce the size" }
+        end
+        @performable.client_push({ 'class' => @performable, 'args' => [marshalled] }.merge(@opts))
       end
     end
 

--- a/lib/sidekiq/extensions/generic_proxy.rb
+++ b/lib/sidekiq/extensions/generic_proxy.rb
@@ -21,7 +21,7 @@ module Sidekiq
         obj = [@target, name, args]
         marshalled = ::YAML.dump(obj)
         if marshalled.size > SIZE_LIMIT
-          ::Sidekiq.logger.warn { "#{@target}.#{name} serialized argument is #{marshalled.bytesize} bytes, you should refactor it to reduce the size" }
+          ::Sidekiq.logger.warn { "#{@target}.#{name} job argument is #{marshalled.bytesize} bytes, you should refactor it to reduce the size" }
         end
         @performable.client_push({ 'class' => @performable, 'args' => [marshalled] }.merge(@opts))
       end

--- a/lib/sidekiq/extensions/generic_proxy.rb
+++ b/lib/sidekiq/extensions/generic_proxy.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 module Sidekiq
   module Extensions
-    SIZE_LIMIT = 4_096
+    SIZE_LIMIT = 8_192
 
     class Proxy < BasicObject
       def initialize(performable, target, options={})
@@ -21,7 +21,7 @@ module Sidekiq
         obj = [@target, name, args]
         marshalled = ::YAML.dump(obj)
         if marshalled.size > SIZE_LIMIT
-          ::Sidekiq.logger.warn { "#{@target}.#{name} serialized argument very large, you should refactor it to reduce the size" }
+          ::Sidekiq.logger.warn { "#{@target}.#{name} serialized argument is #{marshalled.bytesize} bytes, you should refactor it to reduce the size" }
         end
         @performable.client_push({ 'class' => @performable, 'args' => [marshalled] }.merge(@opts))
       end

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -1,36 +1,5 @@
 # frozen_string_literal: true
 module Sidekiq
-  def self.hook_rails!
-    return if defined?(@delay_removed)
-
-    ActiveSupport.on_load(:active_record) do
-      include Sidekiq::Extensions::ActiveRecord
-    end
-
-    ActiveSupport.on_load(:action_mailer) do
-      extend Sidekiq::Extensions::ActionMailer
-    end
-
-    Module.__send__(:include, Sidekiq::Extensions::Klass)
-  end
-
-  # Removes the generic aliases which MAY clash with names of already
-  #  created methods by other applications. The methods `sidekiq_delay`,
-  #  `sidekiq_delay_for` and `sidekiq_delay_until` can be used instead.
-  def self.remove_delay!
-    @delay_removed = true
-
-    [Extensions::ActiveRecord,
-     Extensions::ActionMailer,
-     Extensions::Klass].each do |mod|
-      mod.module_eval do
-        remove_method :delay if respond_to?(:delay)
-        remove_method :delay_for if respond_to?(:delay_for)
-        remove_method :delay_until if respond_to?(:delay_until)
-      end
-    end
-  end
-
   class Rails < ::Rails::Engine
     # We need to setup this up before any application configuration which might
     # change Sidekiq middleware.
@@ -46,10 +15,6 @@ module Sidekiq
           chain.add Sidekiq::Middleware::Server::ActiveRecord
         end
       end
-    end
-
-    initializer 'sidekiq' do
-      Sidekiq.hook_rails!
     end
 
     config.after_initialize do

--- a/myapp/config/initializers/sidekiq.rb
+++ b/myapp/config/initializers/sidekiq.rb
@@ -34,3 +34,5 @@ class TimedWorker
     puts "Latency: #{now - start} sec"
   end
 end
+
+Sidekiq::Extensions.enable_delay!

--- a/test/test_actors.rb
+++ b/test/test_actors.rb
@@ -124,7 +124,7 @@ class TestActors < Sidekiq::Test
 
         a = $count
         p.start
-        sleep(0.02)
+        sleep(0.05)
         p.terminate
         p.kill(true)
 

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -214,6 +214,7 @@ class TestApi < Sidekiq::Test
       end
 
       it 'unwraps delayed jobs' do
+        Sidekiq::Extensions.enable_delay!
         Sidekiq::Queue.delay.foo(1,2,3)
         q = Sidekiq::Queue.new
         x = q.first

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -100,7 +100,7 @@ class TestExtensions < Sidekiq::Test
       output = capture_logging(Logger::WARN) do
         SomeClass.delay.doit('a' * 8192)
       end
-      assert_match(/#{SomeClass}.doit serialized argument is/, output)
+      assert_match(/#{SomeClass}.doit job argument is/, output)
     end
 
     it 'allows delay of any module class method' do

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -96,6 +96,13 @@ class TestExtensions < Sidekiq::Test
       end
     end
 
+    it 'logs large payloads' do
+      output = capture_logging(Logger::WARN) do
+        SomeClass.delay.doit('a' * 4096)
+      end
+      assert_match(/#{SomeClass}.doit serialized argument very large/, output)
+    end
+
     it 'allows delay of any module class method' do
       q = Sidekiq::Queue.new
       assert_equal 0, q.size

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -98,9 +98,9 @@ class TestExtensions < Sidekiq::Test
 
     it 'logs large payloads' do
       output = capture_logging(Logger::WARN) do
-        SomeClass.delay.doit('a' * 4096)
+        SomeClass.delay.doit('a' * 8192)
       end
-      assert_match(/#{SomeClass}.doit serialized argument very large/, output)
+      assert_match(/#{SomeClass}.doit serialized argument is/, output)
     end
 
     it 'allows delay of any module class method' do

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 require_relative 'helper'
-require 'sidekiq'
+require 'sidekiq/api'
 require 'active_record'
 require 'action_mailer'
-require 'sidekiq/extensions/action_mailer'
-require 'sidekiq/extensions/active_record'
-require 'sidekiq/rails'
-
-Sidekiq.hook_rails!
+Sidekiq::Extensions.enable_delay!
 
 class TestExtensions < Sidekiq::Test
   describe 'sidekiq extensions' do
@@ -107,23 +103,6 @@ class TestExtensions < Sidekiq::Test
       assert_equal 1, q.size
     end
 
-    it 'allows removing of the #delay methods' do
-      q = Sidekiq::Queue.new
-      Sidekiq.remove_delay!
-      assert_equal 0, q.size
-      assert_raises NoMethodError do
-        SomeModule.delay.doit(Date.today)
-      end
-
-      Sidekiq.instance_eval { remove_instance_variable :@delay_removed }
-      # Reload modified modules
-      silence_warnings do
-        load 'sidekiq/extensions/action_mailer.rb'
-        load 'sidekiq/extensions/active_record.rb'
-        load 'sidekiq/extensions/generic_proxy.rb'
-        load 'sidekiq/extensions/class_methods.rb'
-      end
-    end
   end
 
 end

--- a/test/test_testing.rb
+++ b/test/test_testing.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 require_relative 'helper'
 
-require 'active_record'
-require 'action_mailer'
-require 'sidekiq/rails'
-require 'sidekiq/extensions/action_mailer'
-require 'sidekiq/extensions/active_record'
-
-Sidekiq.hook_rails!
-
 class TestTesting < Sidekiq::Test
   describe 'sidekiq testing' do
     describe 'require/load sidekiq/testing.rb' do


### PR DESCRIPTION
The delay extensions give users a shortcut to creating jobs without explicitly defining a Sidekiq::Worker.  They have a few problems though:

1. They add several methods to Module so that calls to class methods can be delayed.  `Foo.delay.bar(args)`
2. They use YAML to marshal the arguments, allowing the user to marshal more complex arguments than Sidekiq::Worker allows.  This can accidentally lead to job payloads that are 100s of KB in size and more susceptible to network issues.  Add a warning message if the payload is over 4KB.

Do the following:

1. [x] Don't load the delay extensions by default.  The user must enable them in their initializer.
3. [x] Add a size check to the YAML marshal that warns at runtime if the args are larger than X.