### PR TITLE
Mention the error handler context change in 4.2.3

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -52,6 +52,7 @@ Sidekiq::Web.set :sessions, false
 - Fix Web UI sharding support broken in 4.2.2. [#3169]
 - Fix timestamps not updating during UI polling [#3193, shaneog]
 - Relax rack-protection version to >= 1.5.0
+- Provide consistent interface to exception handlers, changing the structure of the context hash. [#3161]
 
 4.2.2
 -----------


### PR DESCRIPTION
I believe a custom handler added to `error_handlers` is supported functionality. The change in #3161 unknowingly broke some of our exception handling on retries, because we were expecting `context` to be `job`, whereas we now need to use `context[:job]` before pulling out job args.

```ruby
# before
context["retry_count"]

# after
context[:job]["retry_count"]
```