### PR TITLE
Integrate Percy.io for visual regression tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ services:
 before_install:
   - gem install bundler
   - gem update bundler
-rvm:
-  - 2.2.4
-  - 2.3.0
-  - 2.4.0
-  - jruby-9.1.6.0
+matrix:
+  include:
+    - rvm: 2.2.4
+      env: "PERCY_ENABLE=0"
+    - rvm: 2.3.0
+      env: "PERCY_ENABLE=0"
+    - rvm: 2.4.0
+      env: "PERCY_ENABLE=1"
+    - rvm: jruby-9.1.6.0
+      env: "PERCY_ENABLE=0"

--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -23,4 +23,10 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency      'minitest', '~> 5.10', '>= 5.10.1'
   gem.add_development_dependency      'rake', '~> 10.0'
   gem.add_development_dependency      'rails', '>= 3.2.0'
+
+  gem.add_development_dependency      'capybara'
+  gem.add_development_dependency      'poltergeist'
+  gem.add_development_dependency      'percy-capybara'
+  gem.add_development_dependency      'timecop'
+  gem.add_development_dependency      'mocha'
 end

--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency      'rake', '~> 10.0'
   gem.add_development_dependency      'rails', '>= 3.2.0'
 
-  gem.add_development_dependency      'capybara'
-  gem.add_development_dependency      'poltergeist'
-  gem.add_development_dependency      'percy-capybara'
-  gem.add_development_dependency      'timecop'
-  gem.add_development_dependency      'mocha'
+  gem.add_development_dependency      'capybara', '~> 2.11'
+  gem.add_development_dependency      'poltergeist', '~> 1.12'
+  gem.add_development_dependency      'percy-capybara', '~> 2.3'
+  gem.add_development_dependency      'timecop', '~> 0.8'
+  gem.add_development_dependency      'mocha', '~> 1.1'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,13 +6,17 @@ ENV["N"] = "0"
 require 'capybara'
 require 'capybara/dsl'
 require 'capybara/poltergeist'
-require 'percy/capybara'
 
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app,
     debug: false, js_errors: false, timeout: 180
   )
 end
+
+def percy_enabled?
+  !(ENV['PERCY_ENABLE'] == '0')
+end
+require 'percy/capybara' if percy_enabled?
 
 if ENV["COVERAGE"]
   require 'simplecov'
@@ -85,9 +89,10 @@ def with_logging(lvl=Logger::DEBUG)
   end
 end
 
-
-# Initialize and finalize Percy.io
-Percy::Capybara.initialize_build
-MiniTest.after_run {
-  Percy::Capybara.finalize_build
-}
+if percy_enabled?
+  # Initialize and finalize Percy.io
+  Percy::Capybara.initialize_build
+  MiniTest.after_run {
+    Percy::Capybara.finalize_build
+  }
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,6 +3,17 @@ $TESTING = true
 # disable minitest/parallel threads
 ENV["N"] = "0"
 
+require 'capybara'
+require 'capybara/dsl'
+require 'capybara/poltergeist'
+require 'percy/capybara'
+
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app,
+    debug: false, js_errors: false, timeout: 180
+  )
+end
+
 if ENV["COVERAGE"]
   require 'simplecov'
   SimpleCov.start do
@@ -73,3 +84,10 @@ def with_logging(lvl=Logger::DEBUG)
     Sidekiq.logger.level = old
   end
 end
+
+
+# Initialize and finalize Percy.io
+Percy::Capybara.initialize_build
+MiniTest.after_run {
+  Percy::Capybara.finalize_build
+}

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -61,32 +61,32 @@ class TestWeb < Sidekiq::Test
       page.driver.headers = { 'Accept-Language' => 'ru,en' }
       visit '/'
       assert_text('Панель управления')
-      Percy::Capybara.snapshot(page, name: 'Dashboard (Russian)')
+      snapshot(page, name: 'Dashboard (Russian)')
 
       page.driver.headers = { 'Accept-Language' => 'es,en' }
       visit '/'
       assert_text('Panel de Control')
-      Percy::Capybara.snapshot(page, name: 'Dashboard (Spanish)')
+      snapshot(page, name: 'Dashboard (Spanish)')
 
       page.driver.headers = { 'Accept-Language' => 'en-us' }
       visit '/'
       assert_text('Dashboard')
-      Percy::Capybara.snapshot(page, name: 'Dashboard (English)')
+      snapshot(page, name: 'Dashboard (English)')
 
       page.driver.headers = { 'Accept-Language' => 'zh-cn' }
       visit '/'
       assert_text('信息板')
-      Percy::Capybara.snapshot(page, name: 'Dashboard (Chinese)')
+      snapshot(page, name: 'Dashboard (Chinese)')
 
       page.driver.headers = { 'Accept-Language' => 'zh-tw' }
       visit '/'
       assert_text('資訊主頁')
-      Percy::Capybara.snapshot(page, name: 'Dashboard (Taiwanese)')
+      snapshot(page, name: 'Dashboard (Taiwanese)')
 
       page.driver.headers = { 'Accept-Language' => 'nb' }
       visit '/'
       assert_text('Oversikt')
-      Percy::Capybara.snapshot(page, name: 'Dashboard (Norwegian)')
+      snapshot(page, name: 'Dashboard (Norwegian)')
 
       page.driver.headers = { 'Accept-Language' => 'en-us' }
     end
@@ -118,7 +118,7 @@ class TestWeb < Sidekiq::Test
         assert has_button?('Quiet')
         assert has_button?('Stop')
 
-        Percy::Capybara.snapshot(page, name: 'Busy Page')
+        snapshot(page, name: 'Busy Page')
       end
 
       it 'can quiet a process' do
@@ -150,13 +150,13 @@ class TestWeb < Sidekiq::Test
         assert_equal 200, page.status_code
         assert_text('foo')
         assert_no_text('HardWorker')
-        Percy::Capybara.snapshot(page, name: 'Queues Page')
+        snapshot(page, name: 'Queues Page')
       end
 
       it 'handles queue view' do
         visit '/queues/default'
         assert_equal 200, page.status_code
-        Percy::Capybara.snapshot(page, name: 'Queue Page')
+        snapshot(page, name: 'Queue Page')
       end
 
       it 'can delete a queue' do
@@ -203,7 +203,7 @@ class TestWeb < Sidekiq::Test
         assert_equal 200, page.status_code
         assert_text('No retries were found')
         assert_no_text('HardWorker')
-        Percy::Capybara.snapshot(page, name: 'Retries Page - No Retries')
+        snapshot(page, name: 'Retries Page - No Retries')
 
         add_retry
 
@@ -211,7 +211,7 @@ class TestWeb < Sidekiq::Test
         assert_equal 200, page.status_code
         assert_no_text('No retries were found')
         assert_text('HardWorker')
-        Percy::Capybara.snapshot(page, name: 'Retries Page - With Retry')
+        snapshot(page, name: 'Retries Page - With Retry')
       end
 
       it 'can display a single retry' do
@@ -219,7 +219,7 @@ class TestWeb < Sidekiq::Test
         visit "/retries/#{job_params(*params)}"
         assert_equal 200, page.status_code
         assert_text('HardWorker')
-        Percy::Capybara.snapshot(page, name: 'Single Retry Page')
+        snapshot(page, name: 'Single Retry Page')
       end
 
       it 'will redirect to retries when viewing a non-existant retry' do
@@ -291,7 +291,7 @@ class TestWeb < Sidekiq::Test
         assert_equal 200, page.status_code
         assert_text('found')
         assert_no_text('HardWorker')
-        Percy::Capybara.snapshot(page, name: 'Scheduled Jobs Page - Nothing Scheduled')
+        snapshot(page, name: 'Scheduled Jobs Page - Nothing Scheduled')
 
         add_scheduled
 
@@ -299,7 +299,7 @@ class TestWeb < Sidekiq::Test
         assert_equal 200, page.status_code
         assert_no_text('found')
         assert_text('HardWorker')
-        Percy::Capybara.snapshot(page, name: 'Scheduled Jobs Page - Job Scheduled')
+        snapshot(page, name: 'Scheduled Jobs Page - Job Scheduled')
       end
 
       it 'can display a single scheduled job' do
@@ -307,7 +307,7 @@ class TestWeb < Sidekiq::Test
         visit "/scheduled/#{job_params(*params)}"
         assert_equal 200, page.status_code
         assert_text 'HardWorker'
-        Percy::Capybara.snapshot(page, name: 'Scheduled Job Page')
+        snapshot(page, name: 'Scheduled Job Page')
       end
 
       it 'handles missing scheduled job' do
@@ -525,7 +525,7 @@ class TestWeb < Sidekiq::Test
       it 'shows empty index' do
         visit '/morgue'
         assert_equal 200, page.status_code
-        Percy::Capybara.snapshot(page, name: 'Dead Jobs Page - Empty')
+        snapshot(page, name: 'Dead Jobs Page - Empty')
       end
 
       it 'shows index with jobs' do
@@ -533,7 +533,7 @@ class TestWeb < Sidekiq::Test
         visit '/morgue'
         assert_equal 200, page.status_code
         assert_text(score.to_i)
-        Percy::Capybara.snapshot(page, name: 'Dead Jobs Page - With Job')
+        snapshot(page, name: 'Dead Jobs Page - With Job')
       end
 
       it 'can delete all dead' do
@@ -629,6 +629,10 @@ class TestWeb < Sidekiq::Test
           conn.hmset("#{key}:workers", Time.now.to_f, msg)
         end
       end
+    end
+
+    def snapshot(page, options)
+      Percy::Capybara.snapshot(page, options)
     end
   end
 end

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -3,10 +3,20 @@
 require_relative 'helper'
 require 'sidekiq/web'
 require 'rack/test'
+require 'timecop'
+require 'mocha/mini_test'
+
+# Tests in this file are a combination of:
+#   - Capybara tests (using visit) which render the web ui and check elements.
+#       The Capybara tests use Percy.io for visual regression testing.
+#   - Rack::Tests (using get & post) for increased speed and simplicity,
+#       when we're testing actions rather than UI presentation.
 
 class TestWeb < Sidekiq::Test
   describe 'sidekiq web' do
+
     include Rack::Test::Methods
+    include Capybara::DSL
 
     def app
       Sidekiq::Web
@@ -18,6 +28,20 @@ class TestWeb < Sidekiq::Test
 
     before do
       Sidekiq.redis {|c| c.flushdb }
+
+      Capybara.current_driver = :poltergeist
+      Capybara.app = app
+
+      # Freeze time so the time doesn't change in subsequent UI snapshots
+      Timecop.freeze(Time.utc(2016, 9, 1, 10, 5, 0))
+      # Stub redis_info so memory usage doesn't change in subsequent UI snapshots
+      Sidekiq.stubs(:redis_info).returns(Sidekiq::FAKE_INFO)
+    end
+
+    after do
+      Sidekiq.unstub(:redis_info)
+      Timecop.return
+      Capybara.use_default_driver
     end
 
     class WebWorker
@@ -34,24 +58,37 @@ class TestWeb < Sidekiq::Test
     end
 
     it 'can show text with any locales' do
-      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'ru,en'}
-      get '/', {}, rackenv
-      assert_match(/Панель управления/, last_response.body)
-      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'es,en'}
-      get '/', {}, rackenv
-      assert_match(/Panel de Control/, last_response.body)
-      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'en-us'}
-      get '/', {}, rackenv
-      assert_match(/Dashboard/, last_response.body)
-      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'zh-cn'}
-      get '/', {}, rackenv
-      assert_match(/信息板/, last_response.body)
-      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'zh-tw'}
-      get '/', {}, rackenv
-      assert_match(/資訊主頁/, last_response.body)
-      rackenv = {'HTTP_ACCEPT_LANGUAGE' => 'nb'}
-      get '/', {}, rackenv
-      assert_match(/Oversikt/, last_response.body)
+      page.driver.headers = { 'Accept-Language' => 'ru,en' }
+      visit '/'
+      assert_text('Панель управления')
+      Percy::Capybara.snapshot(page, name: 'Dashboard (Russian)')
+
+      page.driver.headers = { 'Accept-Language' => 'es,en' }
+      visit '/'
+      assert_text('Panel de Control')
+      Percy::Capybara.snapshot(page, name: 'Dashboard (Spanish)')
+
+      page.driver.headers = { 'Accept-Language' => 'en-us' }
+      visit '/'
+      assert_text('Dashboard')
+      Percy::Capybara.snapshot(page, name: 'Dashboard (English)')
+
+      page.driver.headers = { 'Accept-Language' => 'zh-cn' }
+      visit '/'
+      assert_text('信息板')
+      Percy::Capybara.snapshot(page, name: 'Dashboard (Chinese)')
+
+      page.driver.headers = { 'Accept-Language' => 'zh-tw' }
+      visit '/'
+      assert_text('資訊主頁')
+      Percy::Capybara.snapshot(page, name: 'Dashboard (Taiwanese)')
+
+      page.driver.headers = { 'Accept-Language' => 'nb' }
+      visit '/'
+      assert_text('Oversikt')
+      Percy::Capybara.snapshot(page, name: 'Dashboard (Norwegian)')
+
+      page.driver.headers = { 'Accept-Language' => 'en-us' }
     end
 
     describe 'busy' do
@@ -67,11 +104,21 @@ class TestWeb < Sidekiq::Test
         end
         assert_equal ['1001'], Sidekiq::Workers.new.map { |pid, tid, data| tid }
 
-        get '/busy'
-        assert_equal 200, last_response.status
-        assert_match(/status-active/, last_response.body)
-        assert_match(/critical/, last_response.body)
-        assert_match(/WebWorker/, last_response.body)
+        visit '/busy'
+        assert_equal 200, page.status_code
+        assert_selector('.status-active')
+        assert_text('critical')
+        assert_text('WebWorker')
+
+        assert has_button?('Quiet All')
+        assert has_button?('Stop All')
+
+        # Check the processes table has 2 rows - the header and process row
+        assert_equal 2, page.all('table.processes tr').count
+        assert has_button?('Quiet')
+        assert has_button?('Stop')
+
+        Percy::Capybara.snapshot(page, name: 'Busy Page')
       end
 
       it 'can quiet a process' do
@@ -95,216 +142,229 @@ class TestWeb < Sidekiq::Test
       end
     end
 
-    it 'can display queues' do
-      assert Sidekiq::Client.push('queue' => :foo, 'class' => WebWorker, 'args' => [1, 3])
+    describe 'queues' do
+      it 'can display queues' do
+        assert Sidekiq::Client.push('queue' => :foo, 'class' => WebWorker, 'args' => [1, 3])
 
-      get '/queues'
-      assert_equal 200, last_response.status
-      assert_match(/foo/, last_response.body)
-      refute_match(/HardWorker/, last_response.body)
-    end
-
-    it 'handles queue view' do
-      get '/queues/default'
-      assert_equal 200, last_response.status
-    end
-
-    it 'can delete a queue' do
-      Sidekiq.redis do |conn|
-        conn.rpush('queue:foo', '{}')
-        conn.sadd('queues', 'foo')
+        visit '/queues'
+        assert_equal 200, page.status_code
+        assert_text('foo')
+        assert_no_text('HardWorker')
+        Percy::Capybara.snapshot(page, name: 'Queues Page')
       end
 
-      get '/queues/foo'
-      assert_equal 200, last_response.status
-
-      post '/queues/foo'
-      assert_equal 302, last_response.status
-
-      Sidekiq.redis do |conn|
-        refute conn.smembers('queues').include?('foo')
-        refute conn.exists('queue:foo')
-      end
-    end
-
-    it 'can delete a job' do
-      Sidekiq.redis do |conn|
-        conn.rpush('queue:foo', "{}")
-        conn.rpush('queue:foo', "{\"foo\":\"bar\"}")
-        conn.rpush('queue:foo', "{\"foo2\":\"bar2\"}")
+      it 'handles queue view' do
+        visit '/queues/default'
+        assert_equal 200, page.status_code
+        Percy::Capybara.snapshot(page, name: 'Queue Page')
       end
 
-      get '/queues/foo'
-      assert_equal 200, last_response.status
+      it 'can delete a queue' do
+        Sidekiq.redis do |conn|
+          conn.rpush('queue:foo', '{}')
+          conn.sadd('queues', 'foo')
+        end
 
-      post '/queues/foo/delete', key_val: "{\"foo\":\"bar\"}"
-      assert_equal 302, last_response.status
+        get '/queues/foo'
+        assert_equal 200, last_response.status
 
-      Sidekiq.redis do |conn|
-        refute conn.lrange('queue:foo', 0, -1).include?("{\"foo\":\"bar\"}")
-      end
-    end
-
-    it 'can display retries' do
-      get '/retries'
-      assert_equal 200, last_response.status
-      assert_match(/found/, last_response.body)
-      refute_match(/HardWorker/, last_response.body)
-
-      add_retry
-
-      get '/retries'
-      assert_equal 200, last_response.status
-      refute_match(/found/, last_response.body)
-      assert_match(/HardWorker/, last_response.body)
-    end
-
-    it 'can display a single retry' do
-      params = add_retry
-      get '/retries/0-shouldntexist'
-      assert_equal 302, last_response.status
-      get "/retries/#{job_params(*params)}"
-      assert_equal 200, last_response.status
-      assert_match(/HardWorker/, last_response.body)
-    end
-
-    it 'handles missing retry' do
-      get "/retries/0-shouldntexist"
-      assert_equal 302, last_response.status
-    end
-
-    it 'can delete a single retry' do
-      params = add_retry
-      post "/retries/#{job_params(*params)}", 'delete' => 'Delete'
-      assert_equal 302, last_response.status
-      assert_equal 'http://example.org/retries', last_response.header['Location']
-
-      get "/retries"
-      assert_equal 200, last_response.status
-      refute_match(/#{params.first['args'][2]}/, last_response.body)
-    end
-
-    it 'can delete all retries' do
-      3.times { add_retry }
-
-      post "/retries/all/delete", 'delete' => 'Delete'
-      assert_equal 0, Sidekiq::RetrySet.new.size
-      assert_equal 302, last_response.status
-      assert_equal 'http://example.org/retries', last_response.header['Location']
-    end
-
-    it 'can retry a single retry now' do
-      params = add_retry
-      post "/retries/#{job_params(*params)}", 'retry' => 'Retry'
-      assert_equal 302, last_response.status
-      assert_equal 'http://example.org/retries', last_response.header['Location']
-
-      get '/queues/default'
-      assert_equal 200, last_response.status
-      assert_match(/#{params.first['args'][2]}/, last_response.body)
-    end
-
-    it 'can kill a single retry now' do
-      params = add_retry
-      post "/retries/#{job_params(*params)}", 'kill' => 'Kill'
-      assert_equal 302, last_response.status
-      assert_equal 'http://example.org/retries', last_response.header['Location']
-
-      get '/morgue'
-      assert_equal 200, last_response.status
-      assert_match(/#{params.first['args'][2]}/, last_response.body)
-    end
-
-    it 'can display scheduled' do
-      get '/scheduled'
-      assert_equal 200, last_response.status
-      assert_match(/found/, last_response.body)
-      refute_match(/HardWorker/, last_response.body)
-
-      add_scheduled
-
-      get '/scheduled'
-      assert_equal 200, last_response.status
-      refute_match(/found/, last_response.body)
-      assert_match(/HardWorker/, last_response.body)
-    end
-
-    it 'can display a single scheduled job' do
-      params = add_scheduled
-      get '/scheduled/0-shouldntexist'
-      assert_equal 302, last_response.status
-      get "/scheduled/#{job_params(*params)}"
-      assert_equal 200, last_response.status
-      assert_match(/HardWorker/, last_response.body)
-    end
-
-    it 'handles missing scheduled job' do
-      get "/scheduled/0-shouldntexist"
-      assert_equal 302, last_response.status
-    end
-
-    it 'can add to queue a single scheduled job' do
-      params = add_scheduled
-      post "/scheduled/#{job_params(*params)}", 'add_to_queue' => true
-      assert_equal 302, last_response.status
-      assert_equal 'http://example.org/scheduled', last_response.header['Location']
-
-      get '/queues/default'
-      assert_equal 200, last_response.status
-      assert_match(/#{params.first['args'][2]}/, last_response.body)
-    end
-
-    it 'can delete a single scheduled job' do
-      params = add_scheduled
-      post "/scheduled/#{job_params(*params)}", 'delete' => 'Delete'
-      assert_equal 302, last_response.status
-      assert_equal 'http://example.org/scheduled', last_response.header['Location']
-
-      get "/scheduled"
-      assert_equal 200, last_response.status
-      refute_match(/#{params.first['args'][2]}/, last_response.body)
-    end
-
-    it 'can delete scheduled' do
-      params = add_scheduled
-      Sidekiq.redis do |conn|
-        assert_equal 1, conn.zcard('schedule')
-        post '/scheduled', 'key' => [job_params(*params)], 'delete' => 'Delete'
+        post '/queues/foo'
         assert_equal 302, last_response.status
-        assert_equal 'http://example.org/scheduled', last_response.header['Location']
-        assert_equal 0, conn.zcard('schedule')
+
+        Sidekiq.redis do |conn|
+          refute conn.smembers('queues').include?('foo')
+          refute conn.exists('queue:foo')
+        end
+      end
+
+      it 'can delete a job' do
+        Sidekiq.redis do |conn|
+          conn.rpush('queue:foo', "{}")
+          conn.rpush('queue:foo', "{\"foo\":\"bar\"}")
+          conn.rpush('queue:foo', "{\"foo2\":\"bar2\"}")
+        end
+
+        get '/queues/foo'
+        assert_equal 200, last_response.status
+
+        post '/queues/foo/delete', key_val: "{\"foo\":\"bar\"}"
+        assert_equal 302, last_response.status
+
+        Sidekiq.redis do |conn|
+          refute conn.lrange('queue:foo', 0, -1).include?("{\"foo\":\"bar\"}")
+        end
       end
     end
 
-    it "can move scheduled to default queue" do
-      q = Sidekiq::Queue.new
-      params = add_scheduled
-      Sidekiq.redis do |conn|
-        assert_equal 1, conn.zcard('schedule')
-        assert_equal 0, q.size
-        post '/scheduled', 'key' => [job_params(*params)], 'add_to_queue' => 'AddToQueue'
+
+    describe 'retries' do
+      it 'can display retries' do
+        visit '/retries'
+        assert_equal 200, page.status_code
+        assert_text('No retries were found')
+        assert_no_text('HardWorker')
+        Percy::Capybara.snapshot(page, name: 'Retries Page - No Retries')
+
+        add_retry
+
+        visit '/retries'
+        assert_equal 200, page.status_code
+        assert_no_text('No retries were found')
+        assert_text('HardWorker')
+        Percy::Capybara.snapshot(page, name: 'Retries Page - With Retry')
+      end
+
+      it 'can display a single retry' do
+        params = add_retry 'abc'
+        visit "/retries/#{job_params(*params)}"
+        assert_equal 200, page.status_code
+        assert_text('HardWorker')
+        Percy::Capybara.snapshot(page, name: 'Single Retry Page')
+      end
+
+      it 'will redirect to retries when viewing a non-existant retry' do
+        get '/retries/0-shouldntexist'
         assert_equal 302, last_response.status
-        assert_equal 'http://example.org/scheduled', last_response.header['Location']
-        assert_equal 0, conn.zcard('schedule')
-        assert_equal 1, q.size
+        assert_equal 'http://example.org/retries', last_response.header['Location']
+      end
+
+      it 'can delete a single retry' do
+        params = add_retry
+        post "/retries/#{job_params(*params)}", 'delete' => 'Delete'
+        assert_equal 302, last_response.status
+        assert_equal 'http://example.org/retries', last_response.header['Location']
+
+        get "/retries"
+        assert_equal 200, last_response.status
+        refute_match(/#{params.first['args'][2]}/, last_response.body)
+      end
+
+      it 'can delete all retries' do
+        3.times { add_retry }
+
+        post "/retries/all/delete", 'delete' => 'Delete'
+        assert_equal 0, Sidekiq::RetrySet.new.size
+        assert_equal 302, last_response.status
+        assert_equal 'http://example.org/retries', last_response.header['Location']
+      end
+
+      it 'can retry a single retry now' do
+        params = add_retry
+        post "/retries/#{job_params(*params)}", 'retry' => 'Retry'
+        assert_equal 302, last_response.status
+        assert_equal 'http://example.org/retries', last_response.header['Location']
+
         get '/queues/default'
         assert_equal 200, last_response.status
-        assert_match(/#{params[0]['args'][2]}/, last_response.body)
+        assert_match(/#{params.first['args'][2]}/, last_response.body)
+      end
+
+      it 'can kill a single retry now' do
+        params = add_retry
+        post "/retries/#{job_params(*params)}", 'kill' => 'Kill'
+        assert_equal 302, last_response.status
+        assert_equal 'http://example.org/retries', last_response.header['Location']
+
+        get '/morgue'
+        assert_equal 200, last_response.status
+        assert_match(/#{params.first['args'][2]}/, last_response.body)
+      end
+
+      it 'can retry all retries' do
+        msg = add_retry.first
+        add_retry
+
+        post "/retries/all/retry", 'retry' => 'Retry'
+        assert_equal 302, last_response.status
+        assert_equal 'http://example.org/retries', last_response.header['Location']
+        assert_equal 2, Sidekiq::Queue.new("default").size
+
+        get '/queues/default'
+        assert_equal 200, last_response.status
+        assert_match(/#{msg['args'][2]}/, last_response.body)
       end
     end
 
-    it 'can retry all retries' do
-      msg = add_retry.first
-      add_retry
+    describe 'scheduled' do
+      it 'can display scheduled' do
+        visit '/scheduled'
+        assert_equal 200, page.status_code
+        assert_text('found')
+        assert_no_text('HardWorker')
+        Percy::Capybara.snapshot(page, name: 'Scheduled Jobs Page - Nothing Scheduled')
 
-      post "/retries/all/retry", 'retry' => 'Retry'
-      assert_equal 302, last_response.status
-      assert_equal 'http://example.org/retries', last_response.header['Location']
-      assert_equal 2, Sidekiq::Queue.new("default").size
+        add_scheduled
 
-      get '/queues/default'
-      assert_equal 200, last_response.status
-      assert_match(/#{msg['args'][2]}/, last_response.body)
+        visit '/scheduled'
+        assert_equal 200, page.status_code
+        assert_no_text('found')
+        assert_text('HardWorker')
+        Percy::Capybara.snapshot(page, name: 'Scheduled Jobs Page - Job Scheduled')
+      end
+
+      it 'can display a single scheduled job' do
+        params = add_scheduled 'abc'
+        visit "/scheduled/#{job_params(*params)}"
+        assert_equal 200, page.status_code
+        assert_text 'HardWorker'
+        Percy::Capybara.snapshot(page, name: 'Scheduled Job Page')
+      end
+
+      it 'handles missing scheduled job' do
+        get "/scheduled/0-shouldntexist"
+        assert_equal 302, last_response.status
+        assert_equal 'http://example.org/scheduled', last_response.header['Location']
+      end
+
+      it 'can add to queue a single scheduled job' do
+        params = add_scheduled
+        post "/scheduled/#{job_params(*params)}", 'add_to_queue' => true
+        assert_equal 302, last_response.status
+        assert_equal 'http://example.org/scheduled', last_response.header['Location']
+
+        get '/queues/default'
+        assert_equal 200, last_response.status
+        assert_match(/#{params.first['args'][2]}/, last_response.body)
+      end
+
+      it 'can delete a single scheduled job' do
+        params = add_scheduled
+        post "/scheduled/#{job_params(*params)}", 'delete' => 'Delete'
+        assert_equal 302, last_response.status
+        assert_equal 'http://example.org/scheduled', last_response.header['Location']
+
+        get "/scheduled"
+        assert_equal 200, last_response.status
+        refute_match(/#{params.first['args'][2]}/, last_response.body)
+      end
+
+      it 'can delete scheduled' do
+        params = add_scheduled
+        Sidekiq.redis do |conn|
+          assert_equal 1, conn.zcard('schedule')
+          post '/scheduled', 'key' => [job_params(*params)], 'delete' => 'Delete'
+          assert_equal 302, last_response.status
+          assert_equal 'http://example.org/scheduled', last_response.header['Location']
+          assert_equal 0, conn.zcard('schedule')
+        end
+      end
+
+      it "can move scheduled to default queue" do
+        q = Sidekiq::Queue.new
+        params = add_scheduled
+        Sidekiq.redis do |conn|
+          assert_equal 1, conn.zcard('schedule')
+          assert_equal 0, q.size
+          post '/scheduled', 'key' => [job_params(*params)], 'add_to_queue' => 'AddToQueue'
+          assert_equal 302, last_response.status
+          assert_equal 'http://example.org/scheduled', last_response.header['Location']
+          assert_equal 0, conn.zcard('schedule')
+          assert_equal 1, q.size
+          get '/queues/default'
+          assert_equal 200, last_response.status
+          assert_match(/#{params[0]['args'][2]}/, last_response.body)
+        end
+      end
     end
 
     it 'calls updatePage() once when polling' do
@@ -463,15 +523,17 @@ class TestWeb < Sidekiq::Test
 
     describe 'dead jobs' do
       it 'shows empty index' do
-        get 'morgue'
-        assert_equal 200, last_response.status
+        visit '/morgue'
+        assert_equal 200, page.status_code
+        Percy::Capybara.snapshot(page, name: 'Dead Jobs Page - Empty')
       end
 
       it 'shows index with jobs' do
         (_, score) = add_dead
-        get 'morgue'
-        assert_equal 200, last_response.status
-        assert_match(/#{score}/, last_response.body)
+        visit '/morgue'
+        assert_equal 200, page.status_code
+        assert_text(score.to_i)
+        Percy::Capybara.snapshot(page, name: 'Dead Jobs Page - With Job')
       end
 
       it 'can delete all dead' do
@@ -496,18 +558,18 @@ class TestWeb < Sidekiq::Test
       end
     end
 
-    def add_scheduled
+    def add_scheduled(job_id=SecureRandom.hex(12))
       score = Time.now.to_f
       msg = { 'class' => 'HardWorker',
               'args' => ['bob', 1, Time.now.to_f],
-              'jid' => SecureRandom.hex(12) }
+              'jid' => job_id }
       Sidekiq.redis do |conn|
         conn.zadd('schedule', score, Sidekiq.dump_json(msg))
       end
       [msg, score]
     end
 
-    def add_retry
+    def add_retry(job_id=SecureRandom.hex(12))
       msg = { 'class' => 'HardWorker',
               'args' => ['bob', 1, Time.now.to_f],
               'queue' => 'default',
@@ -515,7 +577,7 @@ class TestWeb < Sidekiq::Test
               'error_class' => 'RuntimeError',
               'retry_count' => 0,
               'failed_at' => Time.now.to_f,
-              'jid' => SecureRandom.hex(12) }
+              'jid' => job_id }
       score = Time.now.to_f
       Sidekiq.redis do |conn|
         conn.zadd('retry', score, Sidekiq.dump_json(msg))
@@ -524,7 +586,7 @@ class TestWeb < Sidekiq::Test
       [msg, score]
     end
 
-    def add_dead
+    def add_dead(job_id=SecureRandom.hex(12))
       msg = { 'class' => 'HardWorker',
               'args' => ['bob', 1, Time.now.to_f],
               'queue' => 'foo',
@@ -532,7 +594,7 @@ class TestWeb < Sidekiq::Test
               'error_class' => 'RuntimeError',
               'retry_count' => 0,
               'failed_at' => Time.now.utc,
-              'jid' => SecureRandom.hex(12) }
+              'jid' => job_id }
       score = Time.now.to_f
       Sidekiq.redis do |conn|
         conn.zadd('dead', score, Sidekiq.dump_json(msg))
@@ -540,7 +602,7 @@ class TestWeb < Sidekiq::Test
       [msg, score]
     end
 
-    def add_xss_retry
+    def add_xss_retry(job_id=SecureRandom.hex(12))
       msg = { 'class' => 'FailWorker',
               'args' => ['<a>hello</a>'],
               'queue' => 'foo',
@@ -548,7 +610,7 @@ class TestWeb < Sidekiq::Test
               'error_class' => 'RuntimeError',
               'retry_count' => 0,
               'failed_at' => Time.now.to_f,
-              'jid' => SecureRandom.hex(12) }
+              'jid' => job_id }
       score = Time.now.to_f
       Sidekiq.redis do |conn|
         conn.zadd('retry', score, Sidekiq.dump_json(msg))
@@ -566,113 +628,6 @@ class TestWeb < Sidekiq::Test
           conn.hmset(key, 'info', Sidekiq.dump_json('hostname' => 'foo', 'started_at' => Time.now.to_f, "queues" => []), 'at', Time.now.to_f, 'busy', 4)
           conn.hmset("#{key}:workers", Time.now.to_f, msg)
         end
-      end
-    end
-  end
-
-  describe 'sidekiq web with basic auth' do
-    include Rack::Test::Methods
-
-    def app
-      app = Sidekiq::Web.new
-      app.use(Rack::Auth::Basic) { |user, pass| user == "a" && pass == "b" }
-
-      app
-    end
-
-    it 'requires basic authentication' do
-      get '/'
-
-      assert_equal 401, last_response.status
-      refute_nil last_response.header["WWW-Authenticate"]
-    end
-
-    it 'authenticates successfuly' do
-      basic_authorize 'a', 'b'
-
-      get '/'
-
-      assert_equal 200, last_response.status
-    end
-  end
-
-  describe 'sidekiq web with custom session' do
-    include Rack::Test::Methods
-
-    def app
-      app = Sidekiq::Web.new
-
-      app.use Rack::Session::Cookie, secret: 'v3rys3cr31', host: 'nicehost.org'
-
-      app
-    end
-
-    it 'requires basic authentication' do
-      get '/'
-
-      session_options = last_request.env['rack.session'].options
-
-      assert_equal 'v3rys3cr31', session_options[:secret]
-      assert_equal 'nicehost.org', session_options[:host]
-    end
-  end
-
-  describe 'sidekiq web sessions options' do
-    include Rack::Test::Methods
-
-    describe 'using #disable' do
-      def app
-        app = Sidekiq::Web.new
-        app.disable(:sessions)
-        app
-      end
-
-      it "doesn't create sessions" do
-        get '/'
-        assert_nil last_request.env['rack.session']
-      end
-    end
-
-    describe 'using #set with false argument' do
-      def app
-        app = Sidekiq::Web.new
-        app.set(:sessions, false)
-        app
-      end
-
-      it "doesn't create sessions" do
-        get '/'
-        assert_nil last_request.env['rack.session']
-      end
-    end
-
-    describe 'using #set with an hash' do
-      def app
-        app = Sidekiq::Web.new
-        app.set(:sessions, { domain: :all })
-        app
-      end
-
-      it "creates sessions" do
-        get '/'
-        refute_nil   last_request.env['rack.session']
-        refute_empty last_request.env['rack.session'].options
-        assert_equal :all, last_request.env['rack.session'].options[:domain]
-      end
-    end
-
-    describe 'using #enable' do
-      def app
-        app = Sidekiq::Web.new
-        app.enable(:sessions)
-        app
-      end
-
-      it "creates sessions" do
-        get '/'
-        refute_nil   last_request.env['rack.session']
-        refute_empty last_request.env['rack.session'].options
-        refute_nil   last_request.env['rack.session'].options[:secret]
       end
     end
   end

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -632,7 +632,7 @@ class TestWeb < Sidekiq::Test
     end
 
     def snapshot(page, options)
-      Percy::Capybara.snapshot(page, options)
+      Percy::Capybara.snapshot(page, options) if percy_enabled?
     end
   end
 end

--- a/test/test_web_auth.rb
+++ b/test/test_web_auth.rb
@@ -1,0 +1,54 @@
+# encoding: utf-8
+# frozen_string_literal: true
+require_relative 'helper'
+require 'sidekiq/web'
+require 'rack/test'
+
+class TestWebAuth < Sidekiq::Test
+  describe 'sidekiq web with basic auth' do
+    include Rack::Test::Methods
+
+    def app
+      app = Sidekiq::Web.new
+      app.use(Rack::Auth::Basic) { |user, pass| user == "a" && pass == "b" }
+
+      app
+    end
+
+    it 'requires basic authentication' do
+      get '/'
+
+      assert_equal 401, last_response.status
+      refute_nil last_response.header["WWW-Authenticate"]
+    end
+
+    it 'authenticates successfuly' do
+      basic_authorize 'a', 'b'
+
+      get '/'
+
+      assert_equal 200, last_response.status
+    end
+  end
+
+  describe 'sidekiq web with custom session' do
+    include Rack::Test::Methods
+
+    def app
+      app = Sidekiq::Web.new
+
+      app.use Rack::Session::Cookie, secret: 'v3rys3cr31', host: 'nicehost.org'
+
+      app
+    end
+
+    it 'requires basic authentication' do
+      get '/'
+
+      session_options = last_request.env['rack.session'].options
+
+      assert_equal 'v3rys3cr31', session_options[:secret]
+      assert_equal 'nicehost.org', session_options[:host]
+    end
+  end
+end

--- a/test/test_web_sessions.rb
+++ b/test/test_web_sessions.rb
@@ -1,0 +1,67 @@
+# encoding: utf-8
+# frozen_string_literal: true
+require_relative 'helper'
+require 'sidekiq/web'
+require 'rack/test'
+
+class TestWebSessions < Sidekiq::Test
+  describe 'sidekiq web sessions options' do
+    include Rack::Test::Methods
+
+    describe 'using #disable' do
+      def app
+        app = Sidekiq::Web.new
+        app.disable(:sessions)
+        app
+      end
+
+      it "doesn't create sessions" do
+        get '/'
+        assert_nil last_request.env['rack.session']
+      end
+    end
+
+    describe 'using #set with false argument' do
+      def app
+        app = Sidekiq::Web.new
+        app.set(:sessions, false)
+        app
+      end
+
+      it "doesn't create sessions" do
+        get '/'
+        assert_nil last_request.env['rack.session']
+      end
+    end
+
+    describe 'using #set with an hash' do
+      def app
+        app = Sidekiq::Web.new
+        app.set(:sessions, { domain: :all })
+        app
+      end
+
+      it "creates sessions" do
+        get '/'
+        refute_nil   last_request.env['rack.session']
+        refute_empty last_request.env['rack.session'].options
+        assert_equal :all, last_request.env['rack.session'].options[:domain]
+      end
+    end
+
+    describe 'using #enable' do
+      def app
+        app = Sidekiq::Web.new
+        app.enable(:sessions)
+        app
+      end
+
+      it "creates sessions" do
+        get '/'
+        refute_nil   last_request.env['rack.session']
+        refute_empty last_request.env['rack.session'].options
+        refute_nil   last_request.env['rack.session'].options[:secret]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey Mike, thanks for the chat today.

When you sign up to [Percy](https://percy.io), it'll do a pretty good job of guiding you through the environment variable and github integration steps.

For convenience, here's a couple of links to **Percy Docs**:
- [TravisCI](https://percy.io/docs/setup/travis-ci)
- [Capybara](https://percy.io/docs/clients/ruby/capybara)

The second commit in this PR configures Travis to only run Percy against the latest Ruby.  We got this from a reliable source, but haven't tested it.  If this doesn't "just work", let me know and I'll get it sorted.

If you strike any issues at all, let us know.  I'm on DM, or you can Mike & I via Intercom/Email.