### PR TITLE
Show error class on retry page

### DIFF
--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -219,6 +219,7 @@ class TestWeb < Sidekiq::Test
         visit "/retries/#{job_params(*params)}"
         assert_equal 200, page.status_code
         assert_text('HardWorker')
+        assert_text('RuntimeError')
         snapshot(page, name: 'Single Retry Page')
       end
 

--- a/web/views/retry.erb
+++ b/web/views/retry.erb
@@ -7,7 +7,7 @@
       <tr>
         <th><%= t('ErrorClass') %></th>
         <td>
-          <code><%= h @retry.display_class %></code>
+          <code><%= h @retry['error_class'] %></code>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Shows error class in corresponding table cell. Job's display class is still on the page, it is shown at the top of the page (in job details).