### PR TITLE
Urdu locale added in sidekiq

### DIFF
--- a/web/locales/ur.yml
+++ b/web/locales/ur.yml
@@ -1,0 +1,80 @@
+# elements like %{queue} are variables and should not be translated
+ur:
+  TextDirection: 'rtl'
+  Dashboard: صفحۂ اول
+  Status: اسٹیٹس
+  Time: ﻭﻗﺖ
+  Namespace: Namespace
+  Realtime: ﺑﺮاﮦ ﺭاﺳﺖ
+  History: ﺗﺎﺭﻳﺦ
+  Busy: مصروف
+  Processed: مکمل شدہ
+  Failed: ﻧﺎکاﻡ ﺷﺪﮦ
+  Scheduled: ﻁےﺷﺪﮦ
+  Retries: ﺩﻭﺑﺎﺭﮦ کﻭﺷﻴﺶ
+  Enqueued: قطار ميں شامل
+  Worker: ورکر
+  LivePoll: ﺑﺮاﮦ ﺭاﺳﺖ
+  StopPolling: ﺑﺮاﮦ ﺭاﺳﺖ روکيے
+  Queue: قطار
+  Class: کلاس
+  Job: جاب
+  Arguments: دلائل
+  Extras: اﺻﺎﻑی
+  Started: شروع
+  ShowAll: سارے دکھاو
+  CurrentMessagesInQueue:  قطار ميں موجود تمام پيغامات <span class='title'>%{queue}</span>
+  AddToQueue: ﻗﻄﺎﺭ ميں شامل کريں
+  AreYouSureDeleteJob: کيا آپ یقین جاب حتم کرنا چاھتے ہيں ؟
+  AreYouSureDeleteQueue: کيا آپ یقین قطار حتم کرنا چاھتے ہيں ؟
+  Delete: ﺣﺬﻑ
+  Queues: قطاريں
+  Size: ﺣﺠﻢ
+  Actions: ﻋﻮاﻣﻞ
+  NextRetry: اگلی کﻭﺷﻴﺶ
+  RetryCount: دوبارہ کوشش کا مکمل شمار
+  RetryNow: ابھی دوبارہ کوشش
+  Kill: ختم کرديں
+  LastRetry: گزشتہ کوشش
+  OriginallyFailed: ابتادائ ناکامی
+  AreYouSure: کيا یقین ؟
+  DeleteAll: ﺗﻤﺎﻡ ﺣﺬﻑ کر ديں
+  RetryAll: ﺗﻤﺎﻡ کی ﺩﻭﺑﺎﺭﮦ کﻭﺷﻴﺶ کﺭيں
+  NoRetriesFound: کویٔ ﺩﻭﺑﺎﺭﮦ کﻭﺷﻴﺶ نھيں ملی
+  Error: مسئلہ
+  ErrorClass: مسئلہ کی کلاس
+  ErrorMessage: مسئلہ کی وجہ
+  ErrorBacktrace: مسئلہ کی کی تحقیقات کريں
+  GoBack: واپس جايں
+  NoScheduledFound: کویٔ ﻁےﺷﺪﮦچيز نہیں ملی
+  When: ﺏک
+  ScheduledJobs: ﻁےﺷﺪﮦجاب
+  idle: بیکار
+  active: فعال
+  Version: ورژن
+  Connections: کنکشنز
+  MemoryUsage: یاداشت کا استعمال
+  PeakMemoryUsage: سب سے زيادہ یاداشت کا استعمال
+  Uptime: اپ ٹائم
+  OneWeek: ایک ہفتہ
+  OneMonth: ایک مہینہ
+  ThreeMonths: تین ماہ
+  SixMonths: چھ ماہ
+  Failures: ناکامیاں
+  DeadJobs: ختم شدہ جاب
+  NoDeadJobsFound: کویٔ ختم شدہ جاب نہيی ملی
+  Dead: ختم شدہ
+  Processes: ﻋﻤﻠﻴﺎﺕ
+  Thread: موضوع
+  Threads: موضوع
+  Jobs: جابز
+  Paused: موقوف
+  Stop: بند کرو
+  Quiet: ﺣﺘﻢ کﺭﻭ
+  StopAll: ﺗﻤﺎﻡ ﺑﻨﺪ کﺭﻭ
+  QuietAll: ﺗﻤﺎﻡ ﺣﺘﻢ کﺭﻭ
+  PollingInterval: ﺑﺮاﮦ ﺭاﺳﺖ کا ﺩﻭﺭاﻧﻴﮧ
+  Plugins: پلگ انز
+  NotYetEnqueued: ﻗﺘﺎﺭميں شامل نھيں
+  CreatedAt: ﺗﺎﺭﻳﺢ آﻏﺎﺯ
+  BackToApp: ﻭاپﺱ صفحۂ اﻭﻝ پر


### PR DESCRIPTION
Urdu locale added in sidekiq, some of the keywords like status, plugins, jobs, workers etc either didn't have exact mapping in Urdu language or their meaning doesn't make sense in the context of sidekiq so I better used them as it is in Urdu alphabets.

Thanks