### PR TITLE
Validate 'at' argument for Sidekiq::Client.push

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -48,6 +48,7 @@ module Sidekiq
     #   queue - the named queue to use, default 'default'
     #   class - the worker class to call, required
     #   args - an array of simple arguments to the perform method, must be JSON-serializable
+    #   at - timestamp to schedule the job (optional), must be Numeric (e.g. Time.now.to_f)
     #   retry - whether to retry this job if it fails, default true or an integer number of retries
     #   backtrace - whether to save any error backtrace, default false
     #
@@ -212,6 +213,7 @@ module Sidekiq
       raise(ArgumentError, "Job must be a Hash with 'class' and 'args' keys: { 'class' => SomeWorker, 'args' => ['bob', 1, :foo => 'bar'] }") unless item.is_a?(Hash) && item.has_key?('class'.freeze) && item.has_key?('args'.freeze)
       raise(ArgumentError, "Job args must be an Array") unless item['args'].is_a?(Array)
       raise(ArgumentError, "Job class must be either a Class or String representation of the class name") unless item['class'.freeze].is_a?(Class) || item['class'.freeze].is_a?(String)
+      raise(ArgumentError, "Job 'at' must be a Numeric timestamp") unless item['at'].nil? || item['at'].is_a?(Numeric)
       #raise(ArgumentError, "Arguments must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices") unless JSON.load(JSON.dump(item['args'])) == item['args']
 
       normalized_hash(item['class'.freeze])

--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -213,7 +213,7 @@ module Sidekiq
       raise(ArgumentError, "Job must be a Hash with 'class' and 'args' keys: { 'class' => SomeWorker, 'args' => ['bob', 1, :foo => 'bar'] }") unless item.is_a?(Hash) && item.has_key?('class'.freeze) && item.has_key?('args'.freeze)
       raise(ArgumentError, "Job args must be an Array") unless item['args'].is_a?(Array)
       raise(ArgumentError, "Job class must be either a Class or String representation of the class name") unless item['class'.freeze].is_a?(Class) || item['class'.freeze].is_a?(String)
-      raise(ArgumentError, "Job 'at' must be a Numeric timestamp") unless item['at'].nil? || item['at'].is_a?(Numeric)
+      raise(ArgumentError, "Job 'at' must be a Numeric timestamp") if item.has_key?('at'.freeze) && !item['at'].is_a?(Numeric)
       #raise(ArgumentError, "Arguments must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices") unless JSON.load(JSON.dump(item['args'])) == item['args']
 
       normalized_hash(item['class'.freeze])

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -23,6 +23,10 @@ class TestClient < Sidekiq::Test
       assert_raises ArgumentError do
         Sidekiq::Client.push('queue' => 'foo', 'class' => MyWorker, 'args' => 1)
       end
+
+      assert_raises ArgumentError do
+        Sidekiq::Client.push('queue' => 'foo', 'class' => MyWorker, 'args' => [1], 'at' => Time.now)
+      end
     end
   end
 


### PR DESCRIPTION
I know `'at'` wasn't a documented argument for `Sidekiq::Client.push`, and maybe that was intentional.

We tried to use it passing a `Time` argument, and specs were passing but it raised at runtime with a `Redis::CommandError: ERR value is not a valid float`
```
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/pipeline.rb:129:in `value'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/pipeline.rb:121:in `_set'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/pipeline.rb:63:in `block in finish'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/pipeline.rb:62:in `each'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/pipeline.rb:62:in `each_with_index'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/pipeline.rb:62:in `each'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/pipeline.rb:62:in `map'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/pipeline.rb:62:in `finish'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/pipeline.rb:86:in `finish'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/client.rb:157:in `block in call_pipeline'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/client.rb:293:in `with_reconnect'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/client.rb:155:in `call_pipeline'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis.rb:2304:in `block in multi'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis.rb:58:in `block in synchronize'
/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis.rb:58:in `synchronize'
/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis.rb:2296:in `multi'
/ruby/gems/2.4.0/gems/redis-namespace-1.5.3/lib/redis/namespace.rb:471:in `namespaced_block'
/ruby/gems/2.4.0/gems/redis-namespace-1.5.3/lib/redis/namespace.rb:277:in `multi'
/sidekiq/lib/sidekiq/client.rb:178:in `block in raw_push'
...
```

So maybe it would be good to validate the argument before pushing it to Redis?

Another option would be to make Sidekiq testing mode fail with a non-`Numeric` `'at'` argument.