### PR TITLE
Modify `drain_all` to respect enqueued order

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -306,11 +306,9 @@ module Sidekiq
       # Drain all queued jobs across all workers
       def drain_all
         while jobs.any?
-          worker_classes = jobs.map { |job| job["class"] }.uniq
-
-          worker_classes.each do |worker_class|
-            worker_class.constantize.drain
-          end
+          next_job = jobs.first
+          Queues.delete_for(next_job["jid"], next_job["queue"], next_job["class"])
+          next_job["class"].constantize.process_job(next_job)
         end
       end
     end

--- a/test/test_testing_fake.rb
+++ b/test/test_testing_fake.rb
@@ -274,6 +274,54 @@ class TestTesting < Sidekiq::Test
       assert_equal 0, AltQueueWorker.jobs.size
     end
 
+    class OrderedWorker
+      include Sidekiq::Worker
+      @@ran = []
+
+      def perform
+        @@ran << name
+      end
+
+      def name
+        'base'
+      end
+
+      def self.clear
+        @@ran = []
+      end
+
+      def self.ran
+        @@ran
+      end
+    end
+
+    class OrderedWorkerA < OrderedWorker
+      def name
+        'a'
+      end
+    end
+
+    class OrderedWorkerB < OrderedWorker
+      def name
+        'b'
+      end
+    end
+
+    it 'drains jobs in enqueued order' do
+      Sidekiq::Worker.jobs.clear
+      OrderedWorker.clear
+
+      assert_equal [], OrderedWorker.ran
+
+      OrderedWorkerB.perform_async
+      OrderedWorkerA.perform_async
+      OrderedWorkerB.perform_async
+
+      Sidekiq::Worker.drain_all
+
+      assert_equal %w(b a b), OrderedWorker.ran
+    end
+
     it 'can execute a job' do
       DirectWorker.execute_job(DirectWorker.new, [2, 3])
     end


### PR DESCRIPTION
Currently `Sidekiq::Worker.drain_all` effectively reorders the queue by
grouping job classes together. This change maintains the enqueued order
of jobs in the queue when using `drain_all`.