### PR TITLE
Use Rack::Utils to parse HTTP_ACCEPT_LANGUAGE

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -85,7 +85,12 @@ module Sidekiq
       @locale ||= begin
         locale = 'en'.freeze
         languages = env['HTTP_ACCEPT_LANGUAGE'.freeze] || 'en'.freeze
-        ::Rack::Utils.best_q_match(languages.downcase, available_locales) || locale
+
+        # Put our default locale in front, since '*' is going to match
+        # the first locale in our list.
+        locales = (available_locales - [locale]).unshift(locale)
+
+        ::Rack::Utils.best_q_match(languages.downcase, locales) || locale
       end
     end
 

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -81,9 +81,8 @@ module Sidekiq
       @locale ||= begin
         locale = 'en'.freeze
         languages = env['HTTP_ACCEPT_LANGUAGE'.freeze] || 'en'.freeze
-        languages.downcase.split(','.freeze).each do |lang|
+        ::Rack::Utils.q_values(languages.downcase).map(&:first).each do |lang|
           next if lang == '*'.freeze
-          lang = lang.split(';'.freeze)[0]
           break locale = lang if find_locale_files(lang).any?
         end
         locale

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -32,6 +32,10 @@ module Sidekiq
       end
     end
 
+    def available_locales
+      @@available_locales ||= locale_files.map { |path| File.basename(path, '.yml') }
+    end
+
     def find_locale_files(lang)
       locale_files.select { |file| file =~ /\/#{lang}\.yml$/ }
     end
@@ -81,11 +85,7 @@ module Sidekiq
       @locale ||= begin
         locale = 'en'.freeze
         languages = env['HTTP_ACCEPT_LANGUAGE'.freeze] || 'en'.freeze
-        ::Rack::Utils.q_values(languages.downcase).map(&:first).each do |lang|
-          next if lang == '*'.freeze
-          break locale = lang if find_locale_files(lang).any?
-        end
-        locale
+        ::Rack::Utils.best_q_match(languages.downcase, available_locales) || locale
       end
     end
 

--- a/test/test_web_helpers.rb
+++ b/test/test_web_helpers.rb
@@ -42,6 +42,9 @@ class TestWebHelpers < Sidekiq::Test
     obj = Helpers.new('HTTP_ACCEPT_LANGUAGE' => 'zh-CN,zh;q=0.8,en-US;q=0.6,en;q=0.4,ru;q=0.2')
     assert_equal 'zh-cn', obj.locale
 
+    obj = Helpers.new('HTTP_ACCEPT_LANGUAGE' => 'en-US,sv-SE;q=0.8,sv;q=0.6,en;q=0.4')
+    assert_equal 'sv', obj.locale
+
     obj = Helpers.new('HTTP_ACCEPT_LANGUAGE' => 'nb-NO,nb;q=0.2')
     assert_equal 'nb', obj.locale
 


### PR DESCRIPTION
In https://github.com/mperham/sidekiq/issues/3437 @mperham asked for the locale parser to use Rack::Utils instead of the one he wrote. The goal was to fix the locale issue that @johanlunds was having. I added a test case for the header his browser was sending. Unfortunately, the current code was already parsing it to "sv", so this shouldn't actually fix the issues he was having. It does, however, use Rack::Utils, which might cover other problems that we don't yet know of.