### PR TITLE
Update footer UTC time in web dashboard polling refresh

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -234,7 +234,6 @@ module Sidekiq
     get '/stats' do
       sidekiq_stats = Sidekiq::Stats.new
       redis_stats   = redis_info.select { |k, v| REDIS_KEYS.include? k }
-
       json(
         sidekiq: {
           processed:       sidekiq_stats.processed,
@@ -247,7 +246,8 @@ module Sidekiq
           dead:            sidekiq_stats.dead_size,
           default_latency: sidekiq_stats.default_queue_latency
         },
-        redis: redis_stats
+        redis: redis_stats,
+        server_utc_time: server_utc_time
       )
     end
 

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -279,6 +279,10 @@ module Sidekiq
       "Sidekiq v#{Sidekiq::VERSION}"
     end
 
+    def server_utc_time
+      Time.now.utc.strftime('%H:%M:%S UTC')
+    end
+
     def redis_connection_and_namespace
       @redis_connection_and_namespace ||= begin
         namespace_suffix = namespace == nil ? '' : "##{namespace}"

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -480,6 +480,7 @@ class TestWeb < Sidekiq::Test
       it 'works' do
         get '/stats'
         @response = Sidekiq.load_json(last_response.body)
+
         assert_equal 200, last_response.status
         assert_includes @response.keys, "sidekiq"
         assert_equal 5, @response["sidekiq"]["processed"]
@@ -495,6 +496,7 @@ class TestWeb < Sidekiq::Test
         assert_includes @response["redis"].keys, "connected_clients"
         assert_includes @response["redis"].keys, "used_memory_human"
         assert_includes @response["redis"].keys, "used_memory_peak_human"
+        assert_includes @response.keys, "server_utc_time"
       end
     end
 

--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -111,8 +111,11 @@ var realtimeGraph = function(updatePath) {
 
       updateStatsSummary(data.sidekiq);
       updateRedisStats(data.redis);
+      updateFooterUTCTime(data.server_utc_time)
+
       pulseBeacon();
     });
+
     i++;
   }, timeInterval);
 }
@@ -222,6 +225,10 @@ var updateRedisStats = function(data) {
   $('.stat h3.connected_clients').html(data.connected_clients)
   $('.stat h3.used_memory_human').html(data.used_memory_human)
   $('.stat h3.used_memory_peak_human').html(data.used_memory_peak_human)
+}
+
+var updateFooterUTCTime = function(time) {
+  $('.navbar-fixed-bottom .navbar-inner .server-utc-time').html(time)
 }
 
 var pulseBeacon = function(){

--- a/web/views/_footer.erb
+++ b/web/views/_footer.erb
@@ -9,7 +9,7 @@
             <p class="navbar-text redis-url" title="<%= redis_connection_and_namespace %>"><%= redis_connection_and_namespace %></p>
           </li>
           <li>
-            <p class="navbar-text"><%= Time.now.utc.strftime('%H:%M:%S UTC') %></p>
+            <p class="navbar-text server-utc-time"><%= server_utc_time %></p>
           </li>
         </ul>
     </div>


### PR DESCRIPTION
Hi there! First of all, thank you guys for the amazing work on Sidekiq, I really appreciate it.


I'm sending this small PR with a small change in Sidekiq Web Dashboard:


### Why this?


When I running my jobs, I keep an eye in dashboard to follow how it's going...and for debugging
purposes sometimes I want to know how much time a specific batch of jobs takes to run(from enquedued to processed) and
how many seconds it take...and I dont want to count the seconds by myself...So I thought updating the current time in footer would be a good ideia...even if I don't need to count the time...it's just a good thing so this reflect the current stats for current time.
I mean, this is a way to say "this stats are related to this current time"(if you let Sidekiq Dashboard opened for 1 hour for example, the date in dashboard will be one hour late...weird)
