### PR TITLE
Extract Processor#log_context to ease extending what's logged

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ HEAD
 - Reimplement Web UI's HTTP\_ACCEPT\_LANGUAGE parsing because the spec is utterly
   incomprehensible for various edge cases. [johanlunds, natematykiewicz, #3449]
 - Update `class_attribute` core extension to avoid warnings
+- Expose `job_hash_context` from `Sidekiq::Logging` to support log customization
 
 5.0.0
 -----------

--- a/lib/sidekiq/logging.rb
+++ b/lib/sidekiq/logging.rb
@@ -26,6 +26,18 @@ module Sidekiq
       end
     end
 
+    def self.job_hash_context(job_hash)
+      # If we're using a wrapper class, like ActiveJob, use the "wrapped"
+      # attribute to expose the underlying thing.
+      klass = job_hash['wrapped'.freeze] || job_hash["class".freeze]
+      bid = job_hash['bid'.freeze]
+      "#{klass} JID-#{job_hash['jid'.freeze]}#{" BID-#{bid}" if bid}"
+    end
+
+    def self.with_job_hash_context(job_hash, &block)
+      with_context(job_hash_context(job_hash), &block)
+    end
+
     def self.with_context(msg)
       Thread.current[:sidekiq_context] ||= []
       Thread.current[:sidekiq_context] << msg

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -119,21 +119,13 @@ module Sidekiq
       nil
     end
 
-    def log_context(job_hash)
-      # If we're using a wrapper class, like ActiveJob, use the "wrapped"
-      # attribute to expose the underlying thing.
-      klass = job_hash['wrapped'.freeze] || job_hash["class".freeze]
-      bid = job_hash['bid'.freeze]
-      "#{klass} JID-#{job_hash['jid'.freeze]}#{" BID-#{bid}" if bid}"
-    end
-
     def dispatch(job_hash, queue)
       # since middleware can mutate the job hash
       # we clone here so we report the original
       # job structure to the Web UI
       pristine = cloned(job_hash)
 
-      Sidekiq::Logging.with_context(log_context(job_hash)) do
+      Sidekiq::Logging.with_job_hash_context(job_hash) do
         @retrier.global(job_hash, queue) do
           @logging.call(job_hash, queue) do
             stats(pristine, queue) do

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -119,18 +119,21 @@ module Sidekiq
       nil
     end
 
+    def log_context(job_hash)
+      # If we're using a wrapper class, like ActiveJob, use the "wrapped"
+      # attribute to expose the underlying thing.
+      klass = job_hash['wrapped'.freeze] || job_hash["class".freeze]
+      bid = job_hash['bid'.freeze]
+      "#{klass} JID-#{job_hash['jid'.freeze]}#{" BID-#{bid}" if bid}"
+    end
+
     def dispatch(job_hash, queue)
       # since middleware can mutate the job hash
       # we clone here so we report the original
       # job structure to the Web UI
       pristine = cloned(job_hash)
 
-      # If we're using a wrapper class, like ActiveJob, use the "wrapped"
-      # attribute to expose the underlying thing.
-      klass = job_hash['wrapped'.freeze] || job_hash["class".freeze]
-      ctx = "#{klass} JID-#{job_hash['jid'.freeze]}#{" BID-#{job_hash['bid'.freeze]}" if job_hash['bid'.freeze]}"
-
-      Sidekiq::Logging.with_context(ctx) do
+      Sidekiq::Logging.with_context(log_context(job_hash)) do
         @retrier.global(job_hash, queue) do
           @logging.call(job_hash, queue) do
             stats(pristine, queue) do


### PR DESCRIPTION
This was previously exposed in JobLogger and Middleware::Server::Logging
but was inlined into Processor.
https://github.com/mperham/sidekiq/commit/701e06224cebfeeb1f9c84e3abd9b96263defa46

Useful, e.g. in this case:
https://github.com/mperham/sidekiq/issues/1786