### PR TITLE
Defer caching identity until after daemonization

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -40,6 +40,8 @@ module Sidekiq
       initialize_logger
       validate!
       daemonize
+      # Cache identity *after* daemonization since identity is tied to PID.
+      options[:identity] ||= identity
       write_pid
     end
 
@@ -213,7 +215,6 @@ module Sidekiq
 
       opts[:strict] = true if opts[:strict].nil?
       opts[:concurrency] = Integer(ENV["RAILS_MAX_THREADS"]) if !opts[:concurrency] && ENV["RAILS_MAX_THREADS"]
-      opts[:identity] = identity
 
       options.merge!(opts)
     end


### PR DESCRIPTION
This fixes an issue where the actual PID of a Sidekiq process would not
match the worker identity and thus also not match job identity in the
web UI.

Happy to make changes if needed. There's not a very natural place to put this since options are 99% defaulted and validated before daemonization, and identity is the only one that cannot be. Moving setup_options/validation after daemonization isn't really an option since then errors can't easily be returned to the user.