### PR TITLE
Don't trigger web UI updates when the page is hidden

### DIFF
--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -56,6 +56,8 @@ function updateFuzzyTimes(locale) {
 
 function updatePage(url) {
   setInterval(function () {
+    if (document.hidden) return;
+
     $.ajax({
       url: url,
       dataType: 'html'

--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -89,6 +89,8 @@ var realtimeGraph = function(updatePath) {
 
   var i = 0;
   poller = setInterval(function() {
+    if (document.hidden) return;
+
     $.getJSON($("#history").data("update-url"), function(data) {
 
       if (i === 0) {


### PR DESCRIPTION
We've got a bunch of different Sidekiq installations scattered throughout our services (at last count, we've got 8), each of which with their own web UI. When I have all of these open at once in different tabs, there is a ton of network activity as each one is making a `/stats` request on its own interval (all are set to a 5-second interval, but each interval is started at a different time).

I wanted to propose skipping this process when a tab is currently `hidden`. The [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) can tell us whether a user has switched tabs away from the Sidekiq web UI. In this scenario, we can suspend polling updates until the user comes back to the page. When the user comes back, the next interval will trigger as usual and `document.hidden` will no longer be `true`, allowing the polling to go through.