### PR TITLE
Bump default timeout

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -6,7 +6,7 @@
 :verbose: false
 :concurrency: 10
 
-# Set timeout to 8 on Heroku, longer if you manage your own systems.
+# Set timeout to 28 on Heroku, longer if you manage your own systems.
 :timeout: 30
 
 # Sidekiq will run this file through ERB when reading it so you can

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -21,7 +21,7 @@ module Sidekiq
     concurrency: 25,
     require: '.',
     environment: nil,
-    timeout: 8,
+    timeout: 28,
     poll_interval_average: nil,
     average_scheduled_poll_interval: 15,
     error_handlers: [],


### PR DESCRIPTION
Thanks for all the incredibly hard work you've put into Sidekiq!

[Heroku has extended the time](https://devcenter.heroku.com/articles/dynos#shutdown) workers have to terminate when a `TERM` is issued to 30 seconds. I ran into this issue on resque ([more info here](https://github.com/iloveitaly/resque-heroku-signals)).

I think it would be good to update the defaults in sidekiq to match Heroku's new worker timeout. What do you think?