### PR TITLE
Freeze sidekiq_label string constant to prevent unnecessary allocations

### DIFF
--- a/lib/sidekiq/util.rb
+++ b/lib/sidekiq/util.rb
@@ -21,7 +21,7 @@ module Sidekiq
 
     def safe_thread(name, &block)
       Thread.new do
-        Thread.current['sidekiq_label'] = name
+        Thread.current['sidekiq_label'.freeze] = name
         watchdog(name, &block)
       end
     end


### PR DESCRIPTION
In looking at some of our object space dumps, I noticed a number of these strings were being allocated and garbage collected in Ruby 2.3.3.