### PR TITLE
When a middleware mutates arguments, retry with original args

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -126,7 +126,7 @@ module Sidekiq
       pristine = cloned(job_hash)
 
       Sidekiq::Logging.with_job_hash_context(job_hash) do
-        @retrier.global(job_hash, queue) do
+        @retrier.global(pristine, queue) do
           @logging.call(job_hash, queue) do
             stats(pristine, queue) do
               # Rails 5 requires a Reloader to wrap code execution.  In order to
@@ -137,7 +137,7 @@ module Sidekiq
                 klass  = constantize(job_hash['class'.freeze])
                 worker = klass.new
                 worker.jid = job_hash['jid'.freeze]
-                @retrier.local(worker, job_hash, queue) do
+                @retrier.local(worker, pristine, queue) do
                   yield worker
                 end
               end


### PR DESCRIPTION
Currently when a server middleware mutates arguments and then the job
fails, it will get re-queued with the mutated arguments, not the
original arguments.

This is unexpected and (IMO) faulty behavior as that same middleware
will now see the already-mutated arguments when the job gets executed
again.

This changes the behavior to use the pristine, unmutated jobs hash when
requeueing the failed job. It also includes a failing test case for the
old code.