### PR TITLE
Make heartbeat TTL configurable

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -34,6 +34,7 @@ module Sidekiq
     dead_timeout_in_seconds: 180 * 24 * 60 * 60, # 6 months
     reloader: proc { |&block| block.call },
     executor: proc { |&block| block.call },
+    heartbeat_expiration: 60,
   }
 
   DEFAULT_WORKER_OPTIONS = {
@@ -185,6 +186,10 @@ module Sidekiq
   end
   def self.logger=(log)
     Sidekiq::Logging.logger = log
+  end
+
+  def self.heartbeat_expiration=(timeout)
+    self.options[:heartbeat_expiration] = timeout
   end
 
   # How frequently Redis should be checked by a random Sidekiq process for

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -90,7 +90,7 @@ module Sidekiq
             Processor::WORKER_STATE.each_pair do |tid, hash|
               conn.hset(workers_key, tid, Sidekiq.dump_json(hash))
             end
-            conn.expire(workers_key, 60)
+            conn.expire(workers_key, @options[:heartbeat_expiration])
           end
         end
         fails = procd = 0
@@ -100,7 +100,7 @@ module Sidekiq
             conn.sadd('processes', key)
             conn.exists(key)
             conn.hmset(key, 'info', to_json, 'busy', Processor::WORKER_STATE.size, 'beat', Time.now.to_f, 'quiet', @done)
-            conn.expire(key, 60)
+            conn.expire(key, @options[:heartbeat_expiration])
             conn.rpop("#{key}-signals")
           end
         end

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -85,7 +85,7 @@ class TestLauncher < Sidekiq::Test
     end
 
     def options
-      { :concurrency => 3, :queues => ['default'], :tag => 'myapp' }
+      { :concurrency => 3, :queues => ['default'], :tag => 'myapp', :heartbeat_expiration => 60 }
     end
 
   end


### PR DESCRIPTION
**What**
Make the worker's heartbeat TTL configurable, rather than hard-coded at 60 seconds

**Why**
*Note: we're evaluating pro, using `super_fetch!`*

When a worker process crashes the Ruby VM, `super_fetch!` helps us ensure that dead jobs are still in redis and can be requeued with `SuperFetch::Retriever.cleanup_the_dead` which is called as part of process startup. We think this'll work pretty well for us, but has the downside that we have to wait 60 seconds before restarting the process, because "the dead" in this case means the heartbeat has expired.

In our particular use-case, the one minute heartbeat expiration makes for a poor user experience: we have "real-time" jobs, and clients which are prone to worry if processing latency goes way up.

We'd like to be able to tune the heartbeat TTL to balance user-experience in this case with the possibility of network events etc. Obviously the TTL can't go too low (causing partitions, etc.) but we've got a pretty small and stable network and relatively few worker/threads at the moment, so we feel pretty confident we can bring the TTL down at least half if not more.

**Misc**

* this was a small enough set of changes that I figured I'd just open the PR, rather than go through an issue, apologies if this was incorrect.
* this PR is against 4.x which is what we needed for our experiments, but I'd be happy to bring these changes to master as well

---

Thanks for taking the time to look at this, and hopefully I'm not thinking of this 100% wrong :wink: 