### PR TITLE
redis-rb 4.0 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ gem 'minitest'
 #gem 'minitest-utils'
 gem 'toxiproxy'
 
+# For Redis 4.0 support. Unreleased 9cb81bf.
+gem 'redis-namespace', git: 'https://github.com/resque/redis-namespace'
+
 platforms :rbx do
   gem 'rubysl', '~> 2.0'         # if using anything in the ruby standard library
   gem 'psych'                    # if using yaml


### PR DESCRIPTION
* Loosen Redis version dep to `>= 3.3.5, < 5`
* Bump redis-namespace for looser Redis version dep. Pending https://github.com/resque/redis-namespace/pull/136 gem release.

Use `redis.connection` where we can and fall back to `redis._client` where we need (to inspect timeout and scheme).

References #3617