### PR TITLE
Sidekiq::Job#display_class: use consistent Class#method format

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -318,7 +318,7 @@ module Sidekiq
       @klass ||= case klass
                  when /\ASidekiq::Extensions::Delayed/
                    safe_load(args[0], klass) do |target, method, _|
-                     "#{target}.#{method}"
+                     "#{target}##{method}"
                    end
                  when "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
                    job_class = @item['wrapped'] || args[0]

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -241,7 +241,7 @@ class TestApi < Sidekiq::Test
         Sidekiq::Queue.delay.foo(1,2,3)
         q = Sidekiq::Queue.new
         x = q.first
-        assert_equal "Sidekiq::Queue.foo", x.display_class
+        assert_equal "Sidekiq::Queue#foo", x.display_class
         assert_equal [1,2,3], x.display_args
       end
 


### PR DESCRIPTION
@mperham I have discovered another issue with `display_class`. There seems to be a difference between two scenarios:

- https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/api.rb#L321
- https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/api.rb#L327

Delayed job extensions are stringified as `Class.method` while mailers are stringified as `Class#method` (`.` vs `#`).

This pr fixes that (both now use `#`).