### PR TITLE
Use pessimistic version operator instead of less-than in docs

### DIFF
--- a/3.0-Upgrade.md
+++ b/3.0-Upgrade.md
@@ -4,7 +4,7 @@ Sidekiq 3.0 brings several new features but also removes old APIs and
 changes a few data elements in Redis.  To upgrade cleanly:
 
 * Upgrade to the latest Sidekiq 2.x and run it for a few weeks.
-  `gem 'sidekiq', '< 3'`
+  `gem 'sidekiq', '~> 2.0'`
   This is only needed if you have retries pending.
 * 3rd party gems which use **client-side middleware** will need to update
   due to an API change.  The Redis connection for a particular job is

--- a/4.0-Upgrade.md
+++ b/4.0-Upgrade.md
@@ -44,10 +44,10 @@ First, make sure you are using Redis 2.8 or greater. Next:
 
 * Upgrade to the latest Sidekiq 3.x.
 ```ruby
-gem 'sidekiq', '< 4'
+gem 'sidekiq', '~> 3.0'
 ```
 * Fix any deprecation warnings you see.
 * Upgrade to 4.x.
 ```ruby
-gem 'sidekiq', '< 5'
+gem 'sidekiq', '~> 4.0'
 ```

--- a/5.0-Upgrade.md
+++ b/5.0-Upgrade.md
@@ -47,10 +47,10 @@ If you are already running Sidekiq 4.x, then:
 
 * Upgrade to the latest Sidekiq 4.x.
 ```ruby
-gem 'sidekiq', '< 5'
+gem 'sidekiq', '~> 4.0'
 ```
 * Fix any deprecation warnings you see.
 * Upgrade to 5.x.
 ```ruby
-gem 'sidekiq', '< 6'
+gem 'sidekiq', '~> 5.0'
 ```


### PR DESCRIPTION
Technically, the code as is allows any version less than the given version, which would include `0.0.1`. This is a little more common and easier to grok. It's also consistent with SemVer.

Not a big deal, just thought I'd suggest it. Thanks!