### PR TITLE
Fix support link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Useful resources:
 **No support via Twitter, 140 characters is not enough.**
 
 Every Friday morning is Sidekiq happy hour: I video chat and answer questions.
-See the [Sidekiq support page](http://sidekiq.org/support) for details.
+See the [Sidekiq support page](http://sidekiq.org/support.html) for details.
 
 Thanks
 -----------------


### PR DESCRIPTION
The link to the Support page, for happy hour, is pointing to the incorrect url.