### PR TITLE
Added warning to STDERR if we detect Rails 3.x (< 4)

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -49,3 +49,9 @@ module Sidekiq
     end
   end if defined?(::Rails)
 end
+
+if defined?(::Rails) && ::Rails::VERSION::MAJOR < 4
+  $stderr.puts("**************************************************")
+  $stderr.puts("⛔️ WARNING: Sidekiq server is no longer supported by Rails 3.2 - please ensure your server/workers are updated")
+  $stderr.puts("**************************************************")
+end


### PR DESCRIPTION
Due to Sidekiq dropping support for Rails 3.2 I have added a warning to STDERR (similar to the one in testing.rb) about no longer supporting 3.2 for Server/Workers.