### PR TITLE
Change "really needs" to "must" in redis_connection.rb

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -38,7 +38,7 @@ module Sidekiq
       #   - enterprise's leader election
       #   - enterprise's cron support
       def verify_sizing(size, concurrency)
-        raise ArgumentError, "Your Redis connection pool is too small for Sidekiq to work. Your pool has #{size} connections but really needs to have at least #{concurrency + 2}" if size <= concurrency
+        raise ArgumentError, "Your Redis connection pool is too small for Sidekiq to work. Your pool has #{size} connections but must have at least #{concurrency + 2}" if size <= concurrency
       end
 
       def build_client(options)


### PR DESCRIPTION
This is a semantic change to `verify_sizing`'s `ArgumentError` message in redis_connection.rb. 

In my mind, "must have" is more prescriptive than "really needs to have". The wording of the existing message implies that the program will continue run, but the user should do something differently in the future.