### PR TITLE
update redis namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,3 @@ gem 'rails', '>= 5.0.1'
 gem 'simplecov'
 gem 'minitest'
 #gem 'toxiproxy'
-
-# For Redis 4.0 support. Unreleased 9cb81bf.
-gem 'redis-namespace', git: 'https://github.com/resque/redis-namespace'


### PR DESCRIPTION
The redis-namespace 1.6.0 released.
And gemspec allow installing 1.6.0.
https://github.com/mperham/sidekiq/blob/master/sidekiq.gemspec#L24

So there aren't necessary to lock master branch already.
