### PR TITLE
Use exception handler for logging for fetch exception

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -110,10 +110,7 @@ module Sidekiq
     def handle_fetch_exception(ex)
       if !@down
         @down = Time.now
-        logger.error("Error fetching job: #{ex}")
-        ex.backtrace.each do |bt|
-          logger.error(bt)
-        end
+        handle_exception(ex, {}, level: :error, message: 'Error fetching job:')
       end
       sleep(1)
       nil


### PR DESCRIPTION
Extends the `ExceptionHandler` to support multiple log levels and
additional context text in order to use it when the `Processor`
encounters an exception when fetching new work. The added options ensure
that the new behavior is fairly close to the old behavior (same log
level, same fetch error message).

Fixes mperham/sidekiq#3673