### PR TITLE
Make error handler change fully backwards compatible

### DIFF
--- a/lib/sidekiq/exception_handler.rb
+++ b/lib/sidekiq/exception_handler.rb
@@ -24,7 +24,13 @@ module Sidekiq
     def handle_exception(ex, ctxHash={}, options={})
       Sidekiq.error_handlers.each do |handler|
         begin
-          handler.call(ex, ctxHash, options)
+          arity = handler.method(:call).arity
+          # new-style three argument method or fully variable arguments
+          if arity == -3 || arity == -1
+            handler.call(ex, ctxHash, options)
+          else
+            handler.call(ex, ctxHash)
+          end
         rescue => ex
           Sidekiq.logger.error "!!! ERROR HANDLER THREW AN ERROR !!!"
           Sidekiq.logger.error ex
@@ -32,6 +38,5 @@ module Sidekiq
         end
       end
     end
-
   end
 end

--- a/lib/sidekiq/exception_handler.rb
+++ b/lib/sidekiq/exception_handler.rb
@@ -5,32 +5,19 @@ module Sidekiq
   module ExceptionHandler
 
     class Logger
-      def call(ex, ctxHash, options={})
-        # In practice, this will only be called on exceptions so this increase
-        # in complexity in selecting log level is low compared to expense of
-        # the logging messages themselves.
-        options = options || {}
-        level = options.fetch(:level, :warn)
-        Sidekiq.logger.send(level, options[:message]) if options.key?(:message)
-        Sidekiq.logger.send(level, Sidekiq.dump_json(ctxHash)) if !ctxHash.empty?
-        Sidekiq.logger.send(level, "#{ex.class.name}: #{ex.message}")
-        Sidekiq.logger.send(level, ex.backtrace.join("\n")) unless ex.backtrace.nil?
+      def call(ex, ctxHash)
+        Sidekiq.logger.warn(Sidekiq.dump_json(ctxHash)) if !ctxHash.empty?
+        Sidekiq.logger.warn("#{ex.class.name}: #{ex.message}")
+        Sidekiq.logger.warn(ex.backtrace.join("\n")) unless ex.backtrace.nil?
       end
 
-      # Set up default handler which just logs the error
       Sidekiq.error_handlers << Sidekiq::ExceptionHandler::Logger.new
     end
 
-    def handle_exception(ex, ctxHash={}, options={})
+    def handle_exception(ex, ctxHash={})
       Sidekiq.error_handlers.each do |handler|
         begin
-          arity = handler.method(:call).arity
-          # new-style three argument method or fully variable arguments
-          if arity == -3 || arity == -1
-            handler.call(ex, ctxHash, options)
-          else
-            handler.call(ex, ctxHash)
-          end
+          handler.call(ex, ctxHash)
         rescue => ex
           Sidekiq.logger.error "!!! ERROR HANDLER THREW AN ERROR !!!"
           Sidekiq.logger.error ex

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -110,7 +110,8 @@ module Sidekiq
     def handle_fetch_exception(ex)
       if !@down
         @down = Time.now
-        handle_exception(ex, {}, level: :error, message: 'Error fetching job:')
+        logger.error("Error fetching job: #{ex}")
+        handle_exception(ex, {})
       end
       sleep(1)
       nil

--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -79,9 +79,7 @@ module Sidekiq
           # Most likely a problem with redis networking.
           # Punt and try again at the next interval
           logger.error ex.message
-          ex.backtrace.each do |bt|
-            logger.error(bt)
-          end
+          handle_exception(ex, {})
         end
       end
 
@@ -95,7 +93,7 @@ module Sidekiq
         # if poll_interval_average hasn't been calculated yet, we can
         # raise an error trying to reach Redis.
         logger.error ex.message
-        logger.error ex.backtrace.first
+        handle_exception(ex, {})
         sleep 5
       end
 


### PR DESCRIPTION
The change that Fixes mperham/sidekiq#3673 actually broke any existing
exception handlers due to differences in expected parameter count. This
fixes it explicitly which normally seems like it won't matter but there
are random monitoring gems that install their own sidekiq exception
handlers that I don't want to break.

Sorry I broke things. :(