### PR TITLE
Make sure TID varies after fork

### DIFF
--- a/bin/sidekiqload
+++ b/bin/sidekiqload
@@ -72,7 +72,7 @@ def handle_signal(launcher, sig)
     launcher.quiet
   when 'TTIN'
     Thread.list.each do |thread|
-      Sidekiq.logger.warn "Thread TID-#{thread.object_id.to_s(36)} #{thread['label']}"
+      Sidekiq.logger.warn "Thread TID-#{tid(thread_id: thread.object_id)} #{thread['label']}"
       if thread.backtrace
         Sidekiq.logger.warn thread.backtrace.join("\n")
       else

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -159,7 +159,7 @@ module Sidekiq
         end
       when 'TTIN'
         Thread.list.each do |thread|
-          Sidekiq.logger.warn "Thread TID-#{thread.object_id.to_s(36)} #{thread['sidekiq_label']}"
+          Sidekiq.logger.warn "Thread TID-#{tid(thread_id: thread.object_id)} #{thread['sidekiq_label']}"
           if thread.backtrace
             Sidekiq.logger.warn thread.backtrace.join("\n")
           else

--- a/lib/sidekiq/logging.rb
+++ b/lib/sidekiq/logging.rb
@@ -12,8 +12,7 @@ module Sidekiq
       # Provide a call() method that returns the formatted message.
       def call(severity, time, program_name, message)
         pid = ::Process.pid
-        tid = Thread.current.object_id
-        "#{time.utc.iso8601(3)} #{pid} TID-#{(pid * tid).to_s(36)}#{context} #{severity}: #{message}\n"
+        "#{time.utc.iso8601(3)} #{pid} TID-#{tid(process_id: pid)}#{context} #{severity}: #{message}\n"
       end
 
       def context
@@ -25,8 +24,7 @@ module Sidekiq
     class WithoutTimestamp < Pretty
       def call(severity, time, program_name, message)
         pid = ::Process.pid
-        tid = Thread.current.object_id
-        "#{pid} TID-#{(pid * tid).to_s(36)}#{context} #{severity}: #{message}\n"
+        "#{pid} TID-#{tid(process_id: pid)}#{context} #{severity}: #{message}\n"
       end
     end
 

--- a/lib/sidekiq/logging.rb
+++ b/lib/sidekiq/logging.rb
@@ -11,7 +11,9 @@ module Sidekiq
 
       # Provide a call() method that returns the formatted message.
       def call(severity, time, program_name, message)
-        "#{time.utc.iso8601(3)} #{::Process.pid} TID-#{Thread.current.object_id.to_s(36)}#{context} #{severity}: #{message}\n"
+        pid = ::Process.pid
+        tid = Thread.current.object_id
+        "#{time.utc.iso8601(3)} #{pid} TID-#{(pid * tid).to_s(36)}#{context} #{severity}: #{message}\n"
       end
 
       def context
@@ -22,7 +24,9 @@ module Sidekiq
 
     class WithoutTimestamp < Pretty
       def call(severity, time, program_name, message)
-        "#{::Process.pid} TID-#{Thread.current.object_id.to_s(36)}#{context} #{severity}: #{message}\n"
+        pid = ::Process.pid
+        tid = Thread.current.object_id
+        "#{pid} TID-#{(pid * tid).to_s(36)}#{context} #{severity}: #{message}\n"
       end
     end
 

--- a/lib/sidekiq/util.rb
+++ b/lib/sidekiq/util.rb
@@ -46,6 +46,11 @@ module Sidekiq
       @@identity ||= "#{hostname}:#{$$}:#{process_nonce}"
     end
 
+    def tid(thread_id: ::Thread.current.object_id, process_id: ::Process.pid)
+      # Make sure thread ids are unique across forked processes
+      (thread_id ^ process_id).to_s(36)
+    end
+
     def fire_event(event, reverse=false)
       arr = Sidekiq.options[:lifecycle_events][event]
       arr.reverse! if reverse

--- a/test/test_util.rb
+++ b/test/test_util.rb
@@ -2,12 +2,12 @@
 require_relative 'helper'
 
 class TestUtil < Sidekiq::Test
+  include Sidekiq::Util
 
-  class Helpers
-    include Sidekiq::Util
-  end
-
-  def test_nothing_atm
-    assert true
+  def test_tid
+    assert_equal "c3", tid(thread_id: 123, process_id: 456)
+    assert_equal tid, tid
+    refute_equal tid(thread_id: 1), tid(thread_id: 2)
+    refute_equal tid(process_id: 1), tid(process_id: 2)
   end
 end


### PR DESCRIPTION
Currently when starting a sidekiq swarm the TID of the main thread is the same after fork, so it's difficult to tell at first glance which process a log line is coming from:

```
$ ./bin/sidekiqswarm
[swarm] Preloading Bundler groups ["default"]
2017-12-07T09:28:34.042Z 3640 TID-owl6kwmus INFO: Booting Sidekiq 5.0.5 with redis options {:url=>"redis://localhost:6379/2", :id=>"Sidekiq-server-PID-3640"}
2017-12-07T09:28:34.042Z 3637 TID-owl6kwmus INFO: Booting Sidekiq 5.0.5 with redis options {:url=>"redis://localhost:6379/2", :id=>"Sidekiq-server-PID-3637"}
2017-12-07T09:28:34.043Z 3638 TID-owl6kwmus INFO: Booting Sidekiq 5.0.5 with redis options {:url=>"redis://localhost:6379/2", :id=>"Sidekiq-server-PID-3638"}
2017-12-07T09:28:34.093Z 3639 TID-owl6kwmus INFO: Booting Sidekiq 5.0.5 with redis options {:url=>"redis://localhost:6379/2", :id=>"Sidekiq-server-PID-3639"}
...
```

This patch multiplies the thread object id by the process id to introduce a bit of distribution so they vary after fork:

```
$ ./bin/sidekiqswarm
[swarm] Preloading Bundler groups ["default"]
2017-12-07T09:38:13.507Z 4599 TID-4wykzg6rg2i1 INFO: Booting Sidekiq 5.0.5 with redis options {:url=>"redis://localhost:6379/2", :id=>"Sidekiq-server-PID-4599"}
2017-12-07T09:38:13.507Z 4602 TID-4x2ql5bpzgc1 INFO: Booting Sidekiq 5.0.5 with redis options {:url=>"redis://localhost:6379/2", :id=>"Sidekiq-server-PID-4602"}
2017-12-07T09:38:13.517Z 4600 TID-4wzyuokeyj41 INFO: Booting Sidekiq 5.0.5 with redis options {:url=>"redis://localhost:6379/2", :id=>"Sidekiq-server-PID-4600"}
2017-12-07T09:38:13.550Z 4601 TID-4x1cpwy2gzq1 INFO: Booting Sidekiq 5.0.5 with redis options {:url=>"redis://localhost:6379/2", :id=>"Sidekiq-server-PID-4601"}
...
```

I tried a couple of simple ways to distribute the TID slightly and simple multiplication seems to produce different-enough TID values.