### PR TITLE
Warn users of the Redis persistence requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ message format as Resque so it can integrate into an existing Resque processing 
 You can have Sidekiq and Resque run side-by-side at the same time and
 use the Resque client to enqueue jobs in Redis to be processed by Sidekiq.
 
+**Caveat emptor: Sidekiq expects Redis to be [configured as a persistent store](https://github.com/mperham/sidekiq/wiki/Using-Redis#memory).**
+
 Performance
 ---------------
 


### PR DESCRIPTION
Very happy to move this around within the README, change phrasing, etc.

I was bit by not realizing my Redis wasn't configured optimally for Sidekiq and had some dataloss when my instances ran out of memory.

It was at this point I realized the errs of my ways, and found this wiki page post-mortem: https://github.com/mperham/sidekiq/wiki/Using-Redis#memory

I figure that other developers would be able to avoid my mistake (and lack of critical thinking) by exposing quite visibly the Redis requirements Sidekiq expects.