### PR TITLE
Explicitly require `sidekiq/cli`

### DIFF
--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -3,6 +3,7 @@
 require 'sidekiq/manager'
 require 'sidekiq/fetch'
 require 'sidekiq/scheduled'
+require 'sidekiq/cli'
 
 module Sidekiq
   # The Launcher is a very simple Actor whose job is to


### PR DESCRIPTION
When I tested with Ruby 2.5.0.rc1, the following error occurred.

```
Traceback (most recent call last):
	3: from /home/.rbenv/versions/2.5.0-rc1/lib/ruby/gems/2.5.0/gems/sidekiq-5.0.5/lib/sidekiq/util.rb:25:in `block in safe_thread'
	2: from /home/.rbenv/versions/2.5.0-rc1/lib/ruby/gems/2.5.0/gems/sidekiq-5.0.5/lib/sidekiq/util.rb:16:in `watchdog'
	1: from /home/.rbenv/versions/2.5.0-rc1/lib/ruby/gems/2.5.0/gems/sidekiq-5.0.5/lib/sidekiq/launcher.rb:124:in `start_heartbeat'
/home/.rbenv/versions/2.5.0-rc1/lib/ruby/gems/2.5.0/gems/sidekiq-5.0.5/lib/sidekiq/launcher.rb:66:in `heartbeat': uninitialized constant Sidekiq::CLI (NameError)
```

Although this file uses `Sidekiq::CLI`, since `sidekiq/cli` is not required, it seems that an error occurred in thread. 
Therefore, I added require.