### PR TITLE
Sorting Of Available Locales

### DIFF
--- a/test/test_web_helpers.rb
+++ b/test/test_web_helpers.rb
@@ -90,9 +90,9 @@ class TestWebHelpers < Sidekiq::Test
     obj = Helpers.new
     expected = %w(
       ar cs da de el en es fa fr he hi it ja
-      ko nb nl pl pt-br pt ru sv ta uk ur
+      ko nb nl pl pt pt-br ru sv ta uk ur
       zh-cn zh-tw
     )
-    assert_equal expected, obj.available_locales
+    assert_equal expected, obj.available_locales.sort
   end
 end


### PR DESCRIPTION
Failure:
TestWebHelpers#test_available_locales [/home/vaibhav-dhoke/workspace/sidekiq/test/test_web_helpers.rb:96]:
--- expected
+++ actual
@@ -1 +1 @@
-["ar", "cs", "da", "de", "el", "en", "es", "fa", "fr", "he", "hi", "it", "ja", "ko", "nb", "nl", "pl", "pt-br", "pt", "ru", "sv", "ta", "uk", "ur", "zh-cn", "zh-tw"]
+["fa", "he", "it", "zh-cn", "ur", "en", "de", "uk", "ta", "fr", "ru", "cs", "sv", "hi", "ar", "da", "pt", "ja", "ko", "nl", "el", "nb", "es", "pl", "zh-tw", "pt-br"]

Ruby Version: ruby-2.4.1 [ x86_64 ]

OS: Ubuntu 16.04 LTS

rake test ran on cloned repo: https://github.com/vaibhavmdhoke/sidekiq

Bug: https://github.com/mperham/sidekiq/issues/3696