### PR TITLE
change constantize method to match rails' version

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -217,7 +217,9 @@ module Sidekiq
       names.shift if names.empty? || names.first.empty?
 
       names.inject(Object) do |constant, name|
-        constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
+        # the false flag limits search for name to under the constant namespace
+        #   which mimics Rails' behaviour
+        constant.const_defined?(name, false) ? constant.const_get(name, false) : constant.const_missing(name)
       end
     end
 


### PR DESCRIPTION
I came across a bug where I could enqueue a Sidekiq worker from Rails, but Sidekiq couldn't load it.
There is a difference in how Sidekiq and Rails load constants - if a top level module of the same name was already loaded, then Sidekiq will use this instead of the more specific nested module.

I've made a simple fix in this PR, and here is an [example rails app](https://github.com/caffeinated-tech/sidekiq-autoload-example) where the bug can be reproduced.

Maybe the `constantize` method should be taken straight from `ActiveSupport::Inflector` as this handles even more edge cases involving inheritance (see [source](https://github.com/rails/rails/blob/e1a7260640295642108a364c2cfa56b6868d9947/activesupport/lib/active_support/inflector/methods.rb#L250)) But I think a copy-paste isn't ideal but @mperham specifically removed dependency on ActiveSupport earlier this year, so I don't know how to best resolve it.