### PR TITLE
Fix nested Sidekiq::Client.via

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -123,7 +123,7 @@ module Sidekiq
       Thread.current[:sidekiq_via_pool] = pool
       yield
     ensure
-      Thread.current[:sidekiq_via_pool] = nil
+      Thread.current[:sidekiq_via_pool] = nil unless current_sidekiq_pool
     end
 
     class << self


### PR DESCRIPTION
We're using `Sidekiq::Client.via(pool)` for sharding our jobs to different Redis'. However, nested `via`s are broken, even if passing the same `pool`. This is because the `ensure` clears the `Thread.current`, even if it didn't get changed.

Fixed by not clearing the `Thread.current` if a pool is already defined in the nested `via`.