### PR TITLE
Use active record cache when available

### DIFF
--- a/lib/sidekiq/middleware/server/active_record_cache.rb
+++ b/lib/sidekiq/middleware/server/active_record_cache.rb
@@ -1,0 +1,11 @@
+module Sidekiq
+  module Middleware
+    module Server
+      class ActiveRecordCache
+        def call(*args, &block)
+          ::ActiveRecord::Base.cache(&block)
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -9,10 +9,15 @@ module Sidekiq
     # class block. Definitely before config/environments/*.rb and
     # config/initializers/*.rb.
     config.before_configuration do
-      if ::Rails::VERSION::MAJOR < 5 && defined?(::ActiveRecord)
+      if defined?(::ActiveRecord)
         Sidekiq.server_middleware do |chain|
-          require 'sidekiq/middleware/server/active_record'
-          chain.add Sidekiq::Middleware::Server::ActiveRecord
+          if ::Rails::VERSION::MAJOR < 5
+            require 'sidekiq/middleware/server/active_record'
+            chain.add Sidekiq::Middleware::Server::ActiveRecord
+          end
+
+          require 'sidekiq/middleware/server/active_record_cache'
+          chain.add Sidekiq::Middleware::Server::ActiveRecordCache
         end
       end
     end


### PR DESCRIPTION
This will prevent duplicated queries on database at the same job.