### PR TITLE
Fix japanese locale of web

### DIFF
--- a/web/locales/ja.yml
+++ b/web/locales/ja.yml
@@ -60,9 +60,9 @@ ja:
   SixMonths: 6 ヶ月
   Batches: バッチ
   Failures: 失敗
-  DeadJobs: 死亡したジョブ
-  NoDeadJobsFound: 死亡したジョブはありません
-  Dead: 死亡
+  DeadJobs: デッドジョブ
+  NoDeadJobsFound: デッドジョブはありません
+  Dead: デッド
   Processes: プロセス
   Thread: スレッド
   Threads: スレッド
@@ -76,3 +76,5 @@ ja:
   Plugins: プラグイン
   NotYetEnqueued: キューに入っていません
   CreatedAt: 作成日時
+  BackToApp: アプリに戻る
+  Latency: レイテンシ


### PR DESCRIPTION
Rename `Dead`  from Hani to Kana. (Hani and Kana are [ISO 15924 ](http://unicode.org/iso15924/iso15924-codes.html))
There is no Japanese locale to match the dead.

Also, Add  `BackToApp` and `Latency`.