### PR TITLE
bump redis client gem dependency

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = Sidekiq::VERSION
   gem.required_ruby_version = ">= 2.2.2"
 
-  gem.add_dependency                  'redis', '>= 3.3.4', '< 5'
+  gem.add_dependency                  'redis', '>= 4.0.1', '< 5'
   gem.add_dependency                  'connection_pool', '~> 2.2', '>= 2.2.0'
   gem.add_dependency                  'concurrent-ruby', '~> 1.0'
   gem.add_dependency                  'rack-protection', '>= 1.5.0'


### PR DESCRIPTION
Ensure compatability with the redis '_client' method introduced in https://github.com/mperham/sidekiq/commit/89fcf0c145de9c49bab037a9e5c8d77d262c2d82

I came across this error `ERR unknown command '_client'` bumping to sidekiq 5.1.0 from 5.0.5. It appears that older versions of redis gem that do not support the new redis api can slip through the install. 

Manually bumping the required redis gem in your Gemfile is a workaround in the meantime for me. 
