### PR TITLE
Remove String#freeze calls

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,12 @@
 
 [Sidekiq Changes](https://github.com/mperham/sidekiq/blob/master/Changes.md) | [Sidekiq Pro Changes](https://github.com/mperham/sidekiq/blob/master/Pro-Changes.md) | [Sidekiq Enterprise Changes](https://github.com/mperham/sidekiq/blob/master/Ent-Changes.md)
 
+HEAD
+-----------
+
+- Remove `freeze` calls on String constants. This is superfluous with Ruby
+  2.3+ and `frozen_string_literal: true`. [#3759]
+
 5.1.1
 -----------
 

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 require 'sidekiq/version'
 fail "Sidekiq #{Sidekiq::VERSION} does not support Ruby versions below 2.2.2." if RUBY_PLATFORM != 'java' && RUBY_VERSION < '2.2.2'
@@ -12,7 +11,7 @@ require 'sidekiq/delay'
 require 'json'
 
 module Sidekiq
-  NAME = 'Sidekiq'.freeze
+  NAME = 'Sidekiq'
   LICENSE = 'See LICENSE and the LGPL-3.0 for licensing details.'
 
   DEFAULTS = {
@@ -48,7 +47,7 @@ module Sidekiq
     "connected_clients" => "9999",
     "used_memory_human" => "9P",
     "used_memory_peak_human" => "9P"
-  }.freeze
+  }
 
   def self.❨╯°□°❩╯︵┻━┻
     puts "Calm down, yo."

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 require 'sidekiq'
 
@@ -51,21 +50,21 @@ module Sidekiq
     def fetch_stats!
       pipe1_res = Sidekiq.redis do |conn|
         conn.pipelined do
-          conn.get('stat:processed'.freeze)
-          conn.get('stat:failed'.freeze)
-          conn.zcard('schedule'.freeze)
-          conn.zcard('retry'.freeze)
-          conn.zcard('dead'.freeze)
-          conn.scard('processes'.freeze)
-          conn.lrange('queue:default'.freeze, -1, -1)
-          conn.smembers('processes'.freeze)
-          conn.smembers('queues'.freeze)
+          conn.get('stat:processed')
+          conn.get('stat:failed')
+          conn.zcard('schedule')
+          conn.zcard('retry')
+          conn.zcard('dead')
+          conn.scard('processes')
+          conn.lrange('queue:default', -1, -1)
+          conn.smembers('processes')
+          conn.smembers('queues')
         end
       end
 
       pipe2_res = Sidekiq.redis do |conn|
         conn.pipelined do
-          pipe1_res[7].each {|key| conn.hget(key, 'busy'.freeze) }
+          pipe1_res[7].each {|key| conn.hget(key, 'busy') }
           pipe1_res[8].each {|queue| conn.llen("queue:#{queue}") }
         end
       end
@@ -77,7 +76,7 @@ module Sidekiq
       default_queue_latency = if (entry = pipe1_res[6].first)
                                 job = Sidekiq.load_json(entry) rescue {}
                                 now = Time.now.to_f
-                                thence = job['enqueued_at'.freeze] || now
+                                thence = job['enqueued_at'] || now
                                 now - thence
                               else
                                 0
@@ -119,7 +118,7 @@ module Sidekiq
     class Queues
       def lengths
         Sidekiq.redis do |conn|
-          queues = conn.smembers('queues'.freeze)
+          queues = conn.smembers('queues')
 
           lengths = conn.pipelined do
             queues.each do |queue|
@@ -163,7 +162,7 @@ module Sidekiq
 
         while i < @days_previous
           date = @start_date - i
-          datestr = date.strftime("%Y-%m-%d".freeze)
+          datestr = date.strftime("%Y-%m-%d")
           keys << "stat:#{stat}:#{datestr}"
           dates << datestr
           i += 1
@@ -204,7 +203,7 @@ module Sidekiq
     # Return all known queues within Redis.
     #
     def self.all
-      Sidekiq.redis { |c| c.smembers('queues'.freeze) }.sort.map { |q| Sidekiq::Queue.new(q) }
+      Sidekiq.redis { |c| c.smembers('queues') }.sort.map { |q| Sidekiq::Queue.new(q) }
     end
 
     attr_reader :name
@@ -273,7 +272,7 @@ module Sidekiq
       Sidekiq.redis do |conn|
         conn.multi do
           conn.del(@rname)
-          conn.srem("queues".freeze, name)
+          conn.srem("queues", name)
         end
       end
     end
@@ -349,9 +348,9 @@ module Sidekiq
                     job_args
                   end
                 else
-                  if self['encrypt'.freeze]
+                  if self['encrypt']
                     # no point in showing 150+ bytes of random garbage
-                    args[-1] = '[encrypted data]'.freeze
+                    args[-1] = '[encrypted data]'
                   end
                   args
                 end

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 $stdout.sync = true
 
@@ -17,7 +16,7 @@ module Sidekiq
     include Singleton unless $TESTING
 
     PROCTITLES = [
-      proc { 'sidekiq'.freeze },
+      proc { 'sidekiq' },
       proc { Sidekiq::VERSION },
       proc { |me, data| data['tag'] },
       proc { |me, data| "[#{Processor::WORKER_STATE.size} of #{data['concurrency']} busy]" },

--- a/lib/sidekiq/fetch.rb
+++ b/lib/sidekiq/fetch.rb
@@ -13,7 +13,7 @@ module Sidekiq
       end
 
       def queue_name
-        queue.sub(/.*queue:/, ''.freeze)
+        queue.sub(/.*queue:/, '')
       end
 
       def requeue

--- a/lib/sidekiq/job_logger.rb
+++ b/lib/sidekiq/job_logger.rb
@@ -3,7 +3,7 @@ module Sidekiq
 
     def call(item, queue)
       start = Time.now
-      logger.info("start".freeze)
+      logger.info("start")
       yield
       logger.info("done: #{elapsed(start)} sec")
     rescue Exception

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 require 'sidekiq/manager'
 require 'sidekiq/fetch'
@@ -76,13 +75,13 @@ module Sidekiq
         Processor::FAILURE.update {|curr| fails = curr; 0 }
         Processor::PROCESSED.update {|curr| procd = curr; 0 }
 
-        workers_key = "#{key}:workers".freeze
-        nowdate = Time.now.utc.strftime("%Y-%m-%d".freeze)
+        workers_key = "#{key}:workers"
+        nowdate = Time.now.utc.strftime("%Y-%m-%d")
         Sidekiq.redis do |conn|
           conn.multi do
-            conn.incrby("stat:processed".freeze, procd)
+            conn.incrby("stat:processed", procd)
             conn.incrby("stat:processed:#{nowdate}", procd)
-            conn.incrby("stat:failed".freeze, fails)
+            conn.incrby("stat:failed", fails)
             conn.incrby("stat:failed:#{nowdate}", fails)
             conn.del(workers_key)
             Processor::WORKER_STATE.each_pair do |tid, hash|

--- a/lib/sidekiq/logging.rb
+++ b/lib/sidekiq/logging.rb
@@ -33,9 +33,9 @@ module Sidekiq
     def self.job_hash_context(job_hash)
       # If we're using a wrapper class, like ActiveJob, use the "wrapped"
       # attribute to expose the underlying thing.
-      klass = job_hash['wrapped'.freeze] || job_hash["class".freeze]
-      bid = job_hash['bid'.freeze]
-      "#{klass} JID-#{job_hash['jid'.freeze]}#{" BID-#{bid}" if bid}"
+      klass = job_hash['wrapped'] || job_hash["class"]
+      bid = job_hash['bid']
+      "#{klass} JID-#{job_hash['jid']}#{" BID-#{bid}" if bid}"
     end
 
     def self.with_job_hash_context(job_hash, &block)

--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 require 'sidekiq/util'
 require 'sidekiq/processor'

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -132,9 +132,9 @@ module Sidekiq
               # the Reloader.  It handles code loading, db connection management, etc.
               # Effectively this block denotes a "unit of work" to Rails.
               @reloader.call do
-                klass  = constantize(job_hash['class'.freeze])
+                klass  = constantize(job_hash['class'])
                 worker = klass.new
-                worker.jid = job_hash['jid'.freeze]
+                worker.jid = job_hash['jid']
                 @retrier.local(worker, pristine, queue) do
                   yield worker
                 end
@@ -166,7 +166,7 @@ module Sidekiq
         ack = true
         dispatch(job_hash, queue) do |worker|
           Sidekiq.server_middleware.invoke(worker, job_hash, queue) do
-            execute_job(worker, cloned(job_hash['args'.freeze]))
+            execute_job(worker, cloned(job_hash['args']))
           end
         end
       rescue Sidekiq::Shutdown

--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -70,7 +70,7 @@ module Sidekiq
           opts.delete(:network_timeout)
         end
 
-        opts[:driver] ||= 'ruby'.freeze
+        opts[:driver] ||= 'ruby'
 
         # Issue #3303, redis-rb will silently retry an operation.
         # This can lead to duplicate jobs if Sidekiq::Client's LPUSH

--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -17,7 +17,7 @@ module Sidekiq
             # We need to go through the list one at a time to reduce the risk of something
             # going wrong between the time jobs are popped from the scheduled queue and when
             # they are pushed onto a work queue and losing the jobs.
-            while job = conn.zrangebyscore(sorted_set, '-inf'.freeze, now, :limit => [0, 1]).first do
+            while job = conn.zrangebyscore(sorted_set, '-inf', now, :limit => [0, 1]).first do
 
               # Pop item off the queue and add it to the work queue. If the job can't be popped from
               # the queue, it's because another process already popped it so we can move on to the

--- a/lib/sidekiq/util.rb
+++ b/lib/sidekiq/util.rb
@@ -21,7 +21,7 @@ module Sidekiq
 
     def safe_thread(name, &block)
       Thread.new do
-        Thread.current['sidekiq_label'.freeze] = name
+        Thread.current['sidekiq_label'] = name
         watchdog(name, &block)
       end
     end

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -19,10 +19,10 @@ require 'rack/session/cookie'
 module Sidekiq
   class Web
     ROOT = File.expand_path("#{File.dirname(__FILE__)}/../../web")
-    VIEWS = "#{ROOT}/views".freeze
-    LOCALES = ["#{ROOT}/locales".freeze]
-    LAYOUT = "#{VIEWS}/layout.erb".freeze
-    ASSETS = "#{ROOT}/assets".freeze
+    VIEWS = "#{ROOT}/views"
+    LOCALES = ["#{ROOT}/locales"]
+    LAYOUT = "#{VIEWS}/layout.erb"
+    ASSETS = "#{ROOT}/assets"
 
     DEFAULT_TABS = {
       "Dashboard" => '',

--- a/lib/sidekiq/web/action.rb
+++ b/lib/sidekiq/web/action.rb
@@ -2,7 +2,7 @@
 
 module Sidekiq
   class WebAction
-    RACK_SESSION = 'rack.session'.freeze
+    RACK_SESSION = 'rack.session'
 
     attr_accessor :env, :block, :type
 

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -4,8 +4,8 @@ module Sidekiq
   class WebApplication
     extend WebRouter
 
-    CONTENT_LENGTH = "Content-Length".freeze
-    CONTENT_TYPE = "Content-Type".freeze
+    CONTENT_LENGTH = "Content-Length"
+    CONTENT_TYPE = "Content-Type"
     REDIS_KEYS = %w(redis_version uptime_in_days connected_clients used_memory_human used_memory_peak_human)
 
     def initialize(klass)

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -80,7 +80,7 @@ module Sidekiq
 
     # See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
     def user_preferred_languages
-      languages = env['HTTP_ACCEPT_LANGUAGE'.freeze]
+      languages = env['HTTP_ACCEPT_LANGUAGE']
       languages.to_s.downcase.gsub(/\s+/, '').split(',').map do |language|
         locale, quality = language.split(';q=', 2)
         locale  = nil if locale == '*' # Ignore wildcards

--- a/lib/sidekiq/web/router.rb
+++ b/lib/sidekiq/web/router.rb
@@ -3,16 +3,16 @@ require 'rack'
 
 module Sidekiq
   module WebRouter
-    GET = 'GET'.freeze
-    DELETE = 'DELETE'.freeze
-    POST = 'POST'.freeze
-    PUT = 'PUT'.freeze
-    PATCH = 'PATCH'.freeze
-    HEAD = 'HEAD'.freeze
+    GET = 'GET'
+    DELETE = 'DELETE'
+    POST = 'POST'
+    PUT = 'PUT'
+    PATCH = 'PATCH'
+    HEAD = 'HEAD'
 
-    ROUTE_PARAMS = 'rack.route_params'.freeze
-    REQUEST_METHOD = 'REQUEST_METHOD'.freeze
-    PATH_INFO = 'PATH_INFO'.freeze
+    ROUTE_PARAMS = 'rack.route_params'
+    REQUEST_METHOD = 'REQUEST_METHOD'
+    PATH_INFO = 'PATH_INFO'
 
     def get(path, &block)
       route(GET, path, &block)
@@ -64,7 +64,7 @@ module Sidekiq
   class WebRoute
     attr_accessor :request_method, :pattern, :block, :name
 
-    NAMED_SEGMENTS_PATTERN = /\/([^\/]*):([^\.:$\/]+)/.freeze
+    NAMED_SEGMENTS_PATTERN = /\/([^\/]*):([^\.:$\/]+)/
 
     def initialize(request_method, pattern, block)
       @request_method = request_method

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -47,7 +47,7 @@ module Sidekiq
       end
 
       def perform_async(*args)
-        @klass.client_push(@opts.merge('args'.freeze => args, 'class'.freeze => @klass))
+        @klass.client_push(@opts.merge('args' => args, 'class' => @klass))
       end
 
       # +interval+ must be a timestamp, numeric or something that acts
@@ -57,9 +57,9 @@ module Sidekiq
         now = Time.now.to_f
         ts = (int < 1_000_000_000 ? now + int : int)
 
-        payload = @opts.merge('class'.freeze => @klass, 'args'.freeze => args, 'at'.freeze => ts)
+        payload = @opts.merge('class' => @klass, 'args' => args, 'at' => ts)
         # Optimization to enqueue something now that is scheduled to go out now or in the past
-        payload.delete('at'.freeze) if ts <= now
+        payload.delete('at') if ts <= now
         @klass.client_push(payload)
       end
       alias_method :perform_at, :perform_in
@@ -84,7 +84,7 @@ module Sidekiq
       end
 
       def perform_async(*args)
-        client_push('class'.freeze => self, 'args'.freeze => args)
+        client_push('class' => self, 'args' => args)
       end
 
       # +interval+ must be a timestamp, numeric or something that acts
@@ -94,10 +94,10 @@ module Sidekiq
         now = Time.now.to_f
         ts = (int < 1_000_000_000 ? now + int : int)
 
-        item = { 'class'.freeze => self, 'args'.freeze => args, 'at'.freeze => ts }
+        item = { 'class' => self, 'args' => args, 'at' => ts }
 
         # Optimization to enqueue something now that is scheduled to go out now or in the past
-        item.delete('at'.freeze) if ts <= now
+        item.delete('at') if ts <= now
 
         client_push(item)
       end
@@ -134,7 +134,7 @@ module Sidekiq
       end
 
       def client_push(item) # :nodoc:
-        pool = Thread.current[:sidekiq_via_pool] || get_sidekiq_options['pool'.freeze] || Sidekiq.redis_pool
+        pool = Thread.current[:sidekiq_via_pool] || get_sidekiq_options['pool'] || Sidekiq.redis_pool
         # stringify
         item.keys.each do |key|
           item[key.to_s] = item.delete(key)


### PR DESCRIPTION
Explicit freezing was required pre-Ruby 2.3.  With 2.3, `frozen_string_literal: true` is available to do the same thing without uglifying the code.

Caveat upgrader: this change will lead to increased memory usage and slower performance on Ruby 2.2.