### PR TITLE
Issue 3775 - Fixed Ctrl-C exception on Windows.

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -64,7 +64,7 @@ module Sidekiq
       sigs.each do |sig|
         begin
           trap sig do
-            self_write.puts(sig)
+            self_write.write("#{sig}\n")
           end
         rescue ArgumentError
           puts "Signal #{sig} not supported"


### PR DESCRIPTION
Puts was used to push the signal name into the pipe, but puts implementation generates a "can't be called on trap context" exception on Windows.