### PR TITLE
Restrict Ruby 2.3.0 due to frozen string literal adoption

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 require File.expand_path('../lib/sidekiq/version', __FILE__)
 
 Gem::Specification.new do |gem|
@@ -15,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "sidekiq"
   gem.require_paths = ["lib"]
   gem.version       = Sidekiq::VERSION
-  gem.required_ruby_version = ">= 2.2.2"
+  gem.required_ruby_version = ">= 2.3.0"
 
   gem.add_dependency                  'redis', '>= 3.3.5', '< 5'
   gem.add_dependency                  'connection_pool', '~> 2.2', '>= 2.2.0'


### PR DESCRIPTION
`frozen_string_literal` requires Ruby 2.3. It's worth to specify that requirement in gemspec.
https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/

I understand it's not mandatory, as far as pragma just skipped in earlier versions of Ruby, but 2.2 is EOL.