### PR TITLE
Use default retry interval in sidekiq_retry_in

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -215,7 +215,8 @@ module Sidekiq
 
     def retry_in(worker, count, exception)
       begin
-        worker.sidekiq_retry_in_block.call(count, exception).to_i
+        custom_retry_in = worker.sidekiq_retry_in_block.call(count, exception)
+        custom_retry_in.nil? ? nil : custom_retry_in.to_i
       rescue Exception => e
         handle_exception(e, { context: "Failure scheduling retry using the defined `sidekiq_retry_in` in #{worker.class.name}, falling back to default" })
         nil

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -256,7 +256,7 @@ class TestRetry < Sidekiq::Test
         sidekiq_retry_in do |count, exception|
           case exception
           when SpecialError
-            nil
+            Sidekiq::JobRetry::USE_DEFAULT_RETRY_FORMULA
           when ArgumentError
             count * 4
           else


### PR DESCRIPTION
Hi, Mike!

Want to have possibility to use default retry interval for case like this:
```ruby
    class TwitterWorker
      include ::Sidekiq::Worker

      sidekiq_options queue: :twitter,
                      unique: :until_executing,
                      retry: 3

      sidekiq_retry_in do |_count, exception|
        case exception
          when Twitter::Error::TooManyRequests
            # retry in specified time
            exception.rate_limit.reset_at - Time.now
          else
            # retry in default time
            raise 'Use default intervals'
        end
      end
         
      def perform(project_name)
        # do something with Twitter gem
      end
    end
```
And defining `sidekiq_retry_in` for now does not allow to use default interval calculation (except the using ugly workaround - raise error

Will be great to have the way to say to `JobRetry` use default calculated interval, for example by returning nil:
```ruby
      sidekiq_retry_in do |_count, exception|
        case exception
          when Twitter::Error::TooManyRequests
            # retry in specified time
            exception.rate_limit.reset_at - Time.now
          else
            nil # says to use default basic formula seconds_to_delay
        end
      end
```

But this is the breaking changes for some uses, who used to `nil` means zero time, may be return some specific value, f.e. `-1` for this issue?

Thank you