### PR TITLE
Remove redundant code & set environment via ::Rails.env

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -218,7 +218,7 @@ module Sidekiq
     end
 
     def set_environment(cli_env)
-      @environment = cli_env || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+      @environment = cli_env || ::Rails.env
     end
 
     def symbolize_keys_deep!(hash)


### PR DESCRIPTION
This PR deals with removing a redundant piece of code, which is already present in Rails, in the implementation of `Rails.env` method. The relevant piece of code is [here](https://github.com/rails/rails/blob/master/railties/lib/rails.rb#L73).

Since Rails is already implementing the same logic, in my humble opinion, I don't feel there is a need for Sidekiq to repeat the same to set the `@environment` variable.