### PR TITLE
client: bypass multi/exec when pushing single message

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -71,7 +71,9 @@ module Sidekiq
       payload = process_single(item['class'], normed)
 
       if payload
-        raw_push([payload])
+        @redis_pool.with do |conn|
+          atomic_push(conn, [payload])
+        end
         payload['jid']
       end
     end


### PR DESCRIPTION
TLDR: this patch bypasses multi/exec when pushing a single message in the sidekiq client, which allows the client to be used with [twemproxy](https://github.com/twitter/twemproxy). this is extremely useful when running unicorn.

when running on unicorn, a common issue is managing the number of connections to other systems, e.g. redis. because each unicorn worker runs in its own process, each process gets its own connection, so in-process connection pooling is not possible.

a solution to this conundrum is to use an external pooling proxy such as [twemproxy](https://github.com/twitter/twemproxy).

twemproxy brings with it some limitations, however. some commands [are not supported](https://github.com/twitter/twemproxy/blob/master/notes/redis.md), including multi/exec. so in order to be able to use the sidekiq client with twemproxy, we must not use multi/exec.

side-note: `client setname` is also not supported, so the redis client must be explicitly configured with `{id: nil}` to prevent sidekiq from setting a generic client name.

it turns out that when pushing a single message, multi/exec is not needed, because in that case we will always run only a single redis command.

atomic_push will either perform a `zadd` or an `sadd` and an `lpush`. because the `sadd` is idempotent, it should be safe.

refs https://github.com/mperham/sidekiq/issues/1215