### PR TITLE
Fix the error that the worker does not run if you pass nonexistent directories

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -385,7 +385,11 @@ module Sidekiq
     end
 
     def initialize_logger
-      Sidekiq::Logging.initialize_logger(options[:logfile]) if options[:logfile]
+      if path = options[:logfile]
+        logfile = File.expand_path(path)
+        mkdir_unless_exists_dir(logfile)
+        Sidekiq::Logging.initialize_logger(logfile)
+      end
 
       Sidekiq.logger.level = ::Logger::DEBUG if options[:verbose]
     end
@@ -393,6 +397,7 @@ module Sidekiq
     def write_pid
       if path = options[:pidfile]
         pidfile = File.expand_path(path)
+        mkdir_unless_exists_dir(pidfile)
         File.open(pidfile, 'w') do |f|
           f.puts ::Process.pid
         end
@@ -434,6 +439,11 @@ module Sidekiq
        (opts[:queues] ||= []) << q
       end
       opts[:strict] = false if weight.to_i > 0
+    end
+
+    def mkdir_unless_exists_dir(path)
+      dirname = File.dirname(path)
+      FileUtils.mkdir_p(dirname) unless File.exist?(dirname)
     end
   end
 end


### PR DESCRIPTION
Immediately after cloneing the Rails application, the `tmp/pids` directory does not exist.
Therefore, running sidekiq with the `--pidfile tmp/pids/sidekiq.pid` arguments before starting `rails server` causes an error.

```console
$ sidekiq --pidfile tmp/pids/sidekiq.pid
No such file or directory @ rb_sysopen - /Users/sinsoku/rails_app/tmp/pids/sidekiq.pid
```

This is to avoid the error by preparing directories when `pidfile` and `logfile` directories do not exist.