### PR TITLE
Stop the server complaining when shut down at the same time as Redis

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -93,6 +93,8 @@ module Sidekiq
       retryable = true
       begin
         yield conn
+      rescue Redis::BaseConnectionError
+        raise unless server? && Sidekiq::CLI.instance.launcher.stopping?
       rescue Redis::CommandError => ex
         #2550 Failover can cause the server to become a slave, need
         # to disconnect and reopen the socket to get back to the master.

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -13,7 +13,14 @@ require 'sidekiq/util'
 module Sidekiq
   class CLI
     include Util
-    include Singleton unless $TESTING
+
+    if $TESTING
+      def self.instance
+        new
+      end
+    else
+      include Singleton
+    end
 
     PROCTITLES = [
       proc { 'sidekiq' },


### PR DESCRIPTION
This makes a lot of noise if they are stopped simultaneously, which can happen when stopping runit, for example. You generally wouldn't do this in production but the noise is annoying in development.