### PR TITLE
Memoize web helpers namespace with instance variable instead of class variable

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -155,7 +155,7 @@ module Sidekiq
     end
 
     def namespace
-      @@ns ||= Sidekiq.redis { |conn| conn.respond_to?(:namespace) ? conn.namespace : nil }
+      @ns ||= Sidekiq.redis { |conn| conn.respond_to?(:namespace) ? conn.namespace : nil }
     end
 
     def redis_info


### PR DESCRIPTION
I was working on a middleware for the web UI that swaps the redis pool using `Sidekiq::Client.via` + `Sidekiq.redis=`. Everything appears to work correctly except the namespace in the footer.

This PR changes the web helpers namespace memoization to use an instance variable instead of class variable.

