### PR TITLE
change alias method to prepend in testing module

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -72,9 +72,7 @@ module Sidekiq
 
   class EmptyQueueError < RuntimeError; end
 
-  class Client
-    alias_method :raw_push_real, :raw_push
-
+  module ClientCoreExt
     def raw_push(payloads)
       if Sidekiq::Testing.fake?
         payloads.each do |job|
@@ -92,10 +90,12 @@ module Sidekiq
         end
         true
       else
-        raw_push_real(payloads)
+        super
       end
     end
   end
+
+  Sidekiq::Client.prepend ClientCoreExt
 
   module Queues
     ##


### PR DESCRIPTION
I have meet the issue in testing environment with sidekiq and https://github.com/marshall-lee/sidekiq-postpone.
There are some test to reproduce the issue https://github.com/moofkit/reproduce_sidekiq_postpone_issue/blob/master/spec/integration_testing_spec.rb#L30

```
bundle exec rspec
.F

Failures:

  1) integration spec testing disabled overflows stack
     Failure/Error: MyWorker.perform_async

     SystemStackError:
       stack level too deep
     # ./spec/integration_testing_spec.rb:30:in `block (4 levels) in <top (required)>'
     # ./spec/integration_testing_spec.rb:29:in `block (3 levels) in <top (required)>'

Finished in 0.00677 seconds (files took 0.14778 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/integration_testing_spec.rb:28 # integration spec testing disabled overflows stack
```

the reason of this issue that both `Sidekiq::Testing` module and [sidekiq-postpone](https://github.com/marshall-lee/sidekiq-postpone/blob/master/lib/sidekiq/postpone/core_ext.rb#L13) monkey patching `Sidekiq::Client` but do it in different ways. 

The falling test is easy to fix with changing the order of require from this https://github.com/moofkit/reproduce_sidekiq_postpone_issue/blob/master/spec/integration_testing_spec.rb#L3-L4
to this
```
require "sidekiq/testing"
require "sidekiq/postpone"
```
But I think it is no good to rely on order of require.
This simple fix solving this issue.

P.S. this [article](https://blog.newrelic.com/2016/12/15/ruby-agent-module-prepend-alias-method-chains/) explains more detailed and possible solutions.
I have chose the easiest one.