### PR TITLE
Add SemVer compatibility badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Sidekiq
 [![Code Climate](https://codeclimate.com/github/mperham/sidekiq.svg)](https://codeclimate.com/github/mperham/sidekiq)
 [![Build Status](https://travis-ci.org/mperham/sidekiq.svg)](https://travis-ci.org/mperham/sidekiq)
 [![Gitter Chat](https://badges.gitter.im/mperham/sidekiq.svg)](https://gitter.im/mperham/sidekiq)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=sidekiq&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=sidekiq&package-manager=bundler&version-scheme=semver)
 
 
 Simple, efficient background processing for Ruby.


### PR DESCRIPTION
First up, thanks for Sidekiq - it's brilliant.

Not sure what your opinion of badge is, so I thought I'd create a PR. This adds a SemVer compatibility badge that displays the percentage of CI runs that pass when updating `sidekiq` between SemVer compatible versions. Data comes from Dependabot (which I built it).

Here's what the badge looks like:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=sidekiq&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=sidekiq&package-manager=bundler&version-scheme=semver)

Any feedback very welcome.