### PR TITLE
fix charset attribute of Web UI meta element

### DIFF
--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -2,7 +2,7 @@
 <html dir="<%= text_direction %>">
   <head>
     <title><%= environment_title_prefix %><%= Sidekiq::NAME %></title>
-    <meta charset="utf8" />
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
 
     <link href="<%= root_path %>stylesheets/bootstrap.css" media="screen" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
I have seen corrupted Web UI on Internet Explorer 11(locale: ja).

According to [MDN document](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta), `charset` must contain a [standard IANA MIME name for character encodings](https://www.iana.org/assignments/character-sets/character-sets.xhtml).

So I changed `charset`, and get correct view.

## before (`utf8`)
![before](https://user-images.githubusercontent.com/7273960/42362452-4321e206-812e-11e8-943a-60f9e321a854.png)

## after (`utf-8`)
![after](https://user-images.githubusercontent.com/7273960/42362458-48a751a2-812e-11e8-9935-ee1e254db210.png)

Regards.