### PR TITLE
Always want to stay in static context for performing a worker immediately

### DIFF
--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -84,7 +84,7 @@ module Sidekiq
       end
 
       def perform_now(*args)
-        self.new.perform(*args)
+        new.perform(*args)
       end
 
       def perform_async(*args)

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -83,6 +83,10 @@ module Sidekiq
         Setter.new(self, options)
       end
 
+      def perform_now(*args)
+        self.new.perform(*args)
+      end
+
       def perform_async(*args)
         client_push('class' => self, 'args' => args)
       end


### PR DESCRIPTION
I simply wanted a perform_now static method. Just like the ActiveJob's `perform_now`.
I've used sidekiq for a while, I soon realised that sometimes there are some conditional jobs that I want to run immediately synchronous.
So it readily came to my mind to do
```ruby
MyWorker.new.perform(something.id)
```
But then, I asked myself, if it was correct to do that and is it the right way of doing it.
I was unsure as to the implications of creating a new instance of my worker since it has an `include` and I wanted to stay in static context just like `perform_async` and `perform_in`.

I've also used **resque** in the past, and I could easily do `MyWorker.perform(one, two)` without worrying about the implications since `MyWorker` is a simple class with a static method and does not have any `include`.

If sidekiq adds the static `perform_now` method, users will be assured that their way of doing it is actually correct and will have a cleaner looking code like below.
```ruby
if something.urgent?
  MyWorker.perform_now(something.id)
else
  MyWorker.perform_async(something.id)
end
```