### PR TITLE
Allow passing int value or duration to Worker#sidekiq_retry_in

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,8 @@ HEAD
 - Switch Sidekiq::Testing impl from alias\_method to Module#prepend, for resiliency [#3852]
 - Update Sidekiq APIs to use SCAN for scalability [#3848, ffiller]
 - Remove concurrent-ruby gem dependency [#3830]
+- Sidekiq::Worker `sidekiq_retry_in` can accept plain value instead of block,
+  e.g. `sidekiq_retry_in(4)` or `sidekiq_retry_in(3.minutes)` [#3908, DmitryTsepelev]
 
 5.1.3
 -----------

--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -205,7 +205,7 @@ module Sidekiq
     end
 
     def delay_for(worker, count, exception)
-      if worker && worker.sidekiq_retry_in_block
+      if worker && (worker.sidekiq_retry_in_block || worker.sidekiq_retry_in_duration)
         custom_retry_in = retry_in(worker, count, exception).to_i
         return custom_retry_in if custom_retry_in > 0
       end
@@ -218,6 +218,8 @@ module Sidekiq
     end
 
     def retry_in(worker, count, exception)
+      return worker.sidekiq_retry_in_duration if worker.sidekiq_retry_in_duration
+
       begin
         worker.sidekiq_retry_in_block.call(count, exception)
       rescue Exception => e

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -29,6 +29,7 @@ module Sidekiq
       base.extend(ClassMethods)
       base.sidekiq_class_attribute :sidekiq_options_hash
       base.sidekiq_class_attribute :sidekiq_retry_in_block
+      base.sidekiq_class_attribute :sidekiq_retry_in_duration
       base.sidekiq_class_attribute :sidekiq_retries_exhausted_block
     end
 
@@ -121,8 +122,20 @@ module Sidekiq
         self.sidekiq_options_hash = get_sidekiq_options.merge(Hash[opts.map{|k, v| [k.to_s, v]}])
       end
 
-      def sidekiq_retry_in(&block)
-        self.sidekiq_retry_in_block = block
+      def sidekiq_retry_in(duration = nil, &block)
+        if block && duration || !block && !duration
+          raise ArgumentError, "you should pass either block and duration"
+        end
+
+        if block
+          self.sidekiq_retry_in_block = block
+        else
+          begin
+            self.sidekiq_retry_in_duration = Integer(duration)
+          rescue
+            raise ArgumentError, "you should pass either date or integer"
+          end
+        end
       end
 
       def sidekiq_retries_exhausted(&block)


### PR DESCRIPTION
Now `sidekiq_retry_in` accepts a block, which can determine a delay before the next retry based on the exception and retry count. This PR contains a change allowing to pass an integer value or duration - it can be helpful for cases when we don't need dynamic value detection. For instance, instead of `sidekiq_retry_in { 5.minutes }` we can write `sidekiq_retry_in(5.minutes)`