### PR TITLE
Add CSP header to web admin to ensure it matches needs

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -7,6 +7,21 @@ module Sidekiq
     CONTENT_LENGTH = "Content-Length"
     CONTENT_TYPE = "Content-Type"
     REDIS_KEYS = %w(redis_version uptime_in_days connected_clients used_memory_human used_memory_peak_human)
+    CSP_HEADER = [
+      "default-src 'self' https: http:",
+      "child-src 'self'",
+      "connect-src 'self' https: http: wss: ws:",
+      "font-src 'self' https: http:",
+      "frame-src 'self'",
+      "img-src 'self' https: http: data:",
+      "manifest-src 'self'",
+      "media-src 'self'",
+      "object-src 'none'",
+      "script-src 'self' https: http:",
+      "style-src 'self' https: http: 'unsafe-inline'",
+      "worker-src 'self'",
+      "base-uri 'self'"
+    ].join('; ').freeze
 
     def initialize(klass)
       @klass = klass
@@ -279,6 +294,7 @@ module Sidekiq
           "Content-Type" => "text/html",
           "Cache-Control" => "no-cache",
           "Content-Language" => action.locale,
+          "Content-Security-Policy" => CSP_HEADER
         }
 
         [200, headers, [resp]]

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -54,6 +54,15 @@ class TestWeb < Sidekiq::Test
       assert_match(/Oversikt/, last_response.body)
     end
 
+    it 'can provide a default, appropriate CSP for its content' do
+      get '/', {}
+      policies = last_response.headers["Content-Security-Policy"].split('; ')
+      assert_includes(policies, "connect-src 'self' https: http: wss: ws:")
+      assert_includes(policies, "style-src 'self' https: http: 'unsafe-inline'")
+      assert_includes(policies, "script-src 'self' https: http:")
+      assert_includes(policies, "object-src 'none'")
+    end
+
     describe 'busy' do
 
       it 'can display workers' do


### PR DESCRIPTION
Given that the Sidekiq admin does not define it's own Content-Security-Policy, if a parent application is using a CSP, e.g. in Rails 5.2, the parent policy will be used for the admin pages. This may cause problems with the admin pages, depending on the application policy.

