### PR TITLE
Fix bug where latency calculation would fail converting a string to a float.

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -259,7 +259,7 @@ module Sidekiq
       return 0 unless entry
       job = Sidekiq.load_json(entry)
       now = Time.now.to_f
-      thence = job['enqueued_at'] || now
+      thence = job['enqueued_at'].to_f || now
       now - thence
     end
 

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -259,7 +259,7 @@ module Sidekiq
       return 0 unless entry
       job = Sidekiq.load_json(entry)
       now = Time.now.to_f
-      thence = job['enqueued_at'].to_f || now
+      thence = job['enqueued_at'] ? job['enqueued_at'].to_f : now
       now - thence
     end
 


### PR DESCRIPTION
In our production instance of Sidekiq we periodically run into an error where the `queues` page of the sidekiq UI failed to load due to an error casting a string to a float. The stack trace points to line 263 of api.rb.

This PR simply makes sure that the `enqueued_at` time pulled from sidekiq is a float before trying to subtract it from `time` to avoid this error.

This may be better fixed by figuring out how `enqueued_at` is being set to a string in the first place and fixing that.