### PR TITLE
absolute path for bundle in sidekiq.service for rbenv

### DIFF
--- a/examples/systemd/sidekiq.service
+++ b/examples/systemd/sidekiq.service
@@ -26,7 +26,7 @@ After=syslog.target network.target
 Type=simple
 WorkingDirectory=/opt/myapp/current
 # If you use rbenv:
-# ExecStart=/bin/bash -lc 'bundle exec sidekiq -e production'
+# ExecStart=/bin/bash -lc '/home/deploy/.rbenv/shims/bundle exec sidekiq -e production'
 # If you use the system's ruby:
 ExecStart=/usr/local/bin/bundle exec sidekiq -e production
 User=deploy


### PR DESCRIPTION
After a odyssey of searching, trying, testing and failing i managed to find to answer to a really simple problem 
the path to bundle has to absolute otherwise it exits with code 127 (command not found).
thank you for introducing me to world of services in ubuntu  !

https://github.com/mperham/sidekiq/issues/2361#issuecomment-103475054
