### PR TITLE
Raise error for duplicate queue names in config, fixes #3911

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,11 @@
 
 [Sidekiq Changes](https://github.com/mperham/sidekiq/blob/master/Changes.md) | [Sidekiq Pro Changes](https://github.com/mperham/sidekiq/blob/master/Pro-Changes.md) | [Sidekiq Enterprise Changes](https://github.com/mperham/sidekiq/blob/master/Ent-Changes.md)
 
+HEAD
+---------
+
+- Raise error for duplicate queue names in config to avoid unexpected fetch algorithm change [#3911]
+
 5.2.1
 -----------
 

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -436,9 +436,9 @@ module Sidekiq
     end
 
     def parse_queue(opts, q, weight=nil)
-      [weight.to_i, 1].max.times do
-       (opts[:queues] ||= []) << q
-      end
+      opts[:queues] ||= []
+      raise ArgumentError, "queues: #{q} cannot be defined twice" if opts[:queues].include?(q)
+      [weight.to_i, 1].max.times { opts[:queues] << q }
       opts[:strict] = false if weight.to_i > 0
     end
   end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -104,6 +104,11 @@ class TestCli < Sidekiq::Test
       assert_equal ['foo.bar'], Sidekiq.options[:queues]
     end
 
+    it 'raises an error for duplicate queue names' do
+      assert_raises(ArgumentError) { @cli.parse(['sidekiq', '-q', 'foo', '-q', 'foo', '-r', './test/fake_env.rb']) }
+      assert_raises(ArgumentError) { @cli.parse(['sidekiq', '-q', 'foo,3', '-q', 'foo,1', '-r', './test/fake_env.rb']) }
+    end
+
     it 'sets verbose' do
       old = Sidekiq.logger.level
       @cli.parse(['sidekiq', '-v', '-r', './test/fake_env.rb'])


### PR DESCRIPTION
Fixes #3911.