### PR TITLE
Use redis' default driver

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -78,7 +78,7 @@ module Sidekiq
           opts.delete(:network_timeout)
         end
 
-        opts[:driver] ||= 'ruby'
+        opts[:driver] ||= Redis::Connection.drivers.last || 'ruby'
 
         # Issue #3303, redis-rb will silently retry an operation.
         # This can lead to duplicate jobs if Sidekiq::Client's LPUSH


### PR DESCRIPTION
Redis stores its loaded drivers in `Redis::Connection.drivers` and uses the
last one of them when initializing a new client. Sidekiq always uses `'ruby'`
(or `Redis::Connection::Ruby`) per default, though.

With this commit we are following redis' default by passing the last
loaded driver per default (or a given `:driver`).

Closes #3944.