### PR TITLE
Use a mutex to synchronize access to shared WORKER_STATE hash

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ HEAD
 ---------
 
 - Raise error for duplicate queue names in config to avoid unexpected fetch algorithm change [#3911]
+- Wrap WORKER_STATE in a mutex since Hash is not threadsafe on jruby [#3958]
 
 5.2.1
 -----------

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -20,7 +20,7 @@ class TestLauncher < Sidekiq::Test
         @launcher.manager = @mgr
         @id = @launcher.identity
 
-        Sidekiq::Processor::WORKER_STATE['a'] = {'b' => 1}
+        Sidekiq::Processor::WORKER_STATE.set('a', {'b' => 1})
 
         @proctitle = $0
       end


### PR DESCRIPTION
On jruby, the Hash implementation is not threadsafe, and leads to jobs not being
deleted from the busy list.

See #3958