### PR TITLE
Prefix every line in thread dump with TID

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -162,9 +162,12 @@ module Sidekiq
       },
       'TTIN' => ->(cli) {
         Thread.list.each do |thread|
-          Sidekiq.logger.warn "Thread TID-#{(thread.object_id ^ ::Process.pid).to_s(36)} #{thread['sidekiq_label']}"
+          prefix = "Thread TID-#{(thread.object_id ^ ::Process.pid).to_s(36)}"
+          Sidekiq.logger.warn "#{prefix} #{thread['sidekiq_label']}"
           if thread.backtrace
-            Sidekiq.logger.warn thread.backtrace.join("\n")
+            thread.backtrace.each do |trace_line|
+              Sidekiq.logger.warn "#{prefix} #{trace_line}"
+            end
           else
             Sidekiq.logger.warn "<no backtrace available>"
           end


### PR DESCRIPTION
Here's a little proposal, a small "UX-enhancement" when debugging Sidekiq processes/threads by sending the `TTIN` signal and reading through the produced thread dump.

As it's currently implemented, the order of the lines in the produced thread dump is the only thing that matches backtrace lines to threads.

The problem is when you, for some reason, can't rely on the order of log lines, it becomes really hard to make sense of the thread dump.

Example: you transport your Sidekiq logs via UDP and once they're stored in your logserver, the order is based on which UDP datagrams arrived first, not which line was produced first.

To make debugging easier in cases like this, this change
1. adds a the TID as a prefix to every printed line in the thread dump
2. uses the separate log line for each line in the backtrace so they're all prefixed with the local timestamps

Previously, the backtrace of a thread in the dump looked like this:

```
2018-10-11T07:33:33.080Z 45135 TID-ox6edc2y7 WARN: Thread TID-ox6ebvjn7 processor
2018-10-11T07:33:33.080Z 45135 TID-ox6edc2y7 WARN: /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/connection/ruby.rb:68:in `select'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/connection/ruby.rb:68:in `rescue in _read_from_socket'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/connection/ruby.rb:64:in `_read_from_socket'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/connection/ruby.rb:56:in `gets'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/connection/ruby.rb:363:in `read'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:263:in `block in read'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:251:in `io'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:262:in `read'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:118:in `block in call'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:232:in `block (2 levels) in process'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:370:in `ensure_connected'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:222:in `block in process'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:307:in `logging'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:221:in `process'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:118:in `call'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:210:in `block in call_with_timeout'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:281:in `with_socket_timeout'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:209:in `call_with_timeout'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis.rb:1172:in `block in _bpop'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis.rb:45:in `block in synchronize'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis.rb:45:in `synchronize'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis.rb:1169:in `_bpop'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis.rb:1214:in `brpop'
/Users/mrnugget/code/clones/sidekiq/lib/sidekiq/fetch.rb:36:in `block in retrieve_work'
/Users/mrnugget/code/clones/sidekiq/lib/sidekiq.rb:95:in `block in redis'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/connection_pool-2.2.2/lib/connection_pool.rb:65:in `block (2 levels) in with'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/connection_pool-2.2.2/lib/connection_pool.rb:64:in `handle_interrupt'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/connection_pool-2.2.2/lib/connection_pool.rb:64:in `block in with'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/connection_pool-2.2.2/lib/connection_pool.rb:61:in `handle_interrupt'
/Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/connection_pool-2.2.2/lib/connection_pool.rb:61:in `with'
/Users/mrnugget/code/clones/sidekiq/lib/sidekiq.rb:92:in `redis'
/Users/mrnugget/code/clones/sidekiq/lib/sidekiq/fetch.rb:36:in `retrieve_work'
/Users/mrnugget/code/clones/sidekiq/lib/sidekiq/processor.rb:89:in `get_one'
/Users/mrnugget/code/clones/sidekiq/lib/sidekiq/processor.rb:99:in `fetch'
/Users/mrnugget/code/clones/sidekiq/lib/sidekiq/processor.rb:82:in `process_one'
/Users/mrnugget/code/clones/sidekiq/lib/sidekiq/processor.rb:71:in `run'
/Users/mrnugget/code/clones/sidekiq/lib/sidekiq/util.rb:16:in `watchdog'
/Users/mrnugget/code/clones/sidekiq/lib/sidekiq/util.rb:25:in `block in safe_thread'

```

With this change, it looks like this:

```
2018-10-11T07:20:52.721Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx processor
2018-10-11T07:20:52.722Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/connection/ruby.rb:68:in `select'
2018-10-11T07:20:52.722Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/connection/ruby.rb:68:in `rescue in _read_from_socket'
2018-10-11T07:20:52.722Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/connection/ruby.rb:64:in `_read_from_socket'
2018-10-11T07:20:52.722Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/connection/ruby.rb:56:in `gets'
2018-10-11T07:20:52.722Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/connection/ruby.rb:363:in `read'
2018-10-11T07:20:52.722Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:263:in `block in read'
2018-10-11T07:20:52.729Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:251:in `io'
2018-10-11T07:20:52.729Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:262:in `read'
2018-10-11T07:20:52.729Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:118:in `block in call'
2018-10-11T07:20:52.729Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:232:in `block (2 levels) in process'
2018-10-11T07:20:52.729Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:370:in `ensure_connected'
2018-10-11T07:20:52.730Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:222:in `block in process'
2018-10-11T07:20:52.730Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:307:in `logging'
2018-10-11T07:20:52.730Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:221:in `process'
2018-10-11T07:20:52.730Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:118:in `call'
2018-10-11T07:20:52.730Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:210:in `block in call_with_timeout'
2018-10-11T07:20:52.731Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:281:in `with_socket_timeout'
2018-10-11T07:20:52.731Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis/client.rb:209:in `call_with_timeout'
2018-10-11T07:20:52.731Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis.rb:1172:in `block in _bpop'
2018-10-11T07:20:52.731Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis.rb:45:in `block in synchronize'
2018-10-11T07:20:52.731Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'
2018-10-11T07:20:52.731Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis.rb:45:in `synchronize'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis.rb:1169:in `_bpop'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/redis-4.0.2/lib/redis.rb:1214:in `brpop'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/code/clones/sidekiq/lib/sidekiq/fetch.rb:36:in `block in retrieve_work'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/code/clones/sidekiq/lib/sidekiq.rb:95:in `block in redis'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/connection_pool-2.2.2/lib/connection_pool.rb:65:in `block (2 levels) in with'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/connection_pool-2.2.2/lib/connection_pool.rb:64:in `handle_interrupt'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/connection_pool-2.2.2/lib/connection_pool.rb:64:in `block in with'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/connection_pool-2.2.2/lib/connection_pool.rb:61:in `handle_interrupt'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/connection_pool-2.2.2/lib/connection_pool.rb:61:in `with'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/code/clones/sidekiq/lib/sidekiq.rb:92:in `redis'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/code/clones/sidekiq/lib/sidekiq/fetch.rb:36:in `retrieve_work'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/code/clones/sidekiq/lib/sidekiq/processor.rb:89:in `get_one'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/code/clones/sidekiq/lib/sidekiq/processor.rb:99:in `fetch'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/code/clones/sidekiq/lib/sidekiq/processor.rb:82:in `process_one'
2018-10-11T07:20:52.732Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/code/clones/sidekiq/lib/sidekiq/processor.rb:71:in `run'
2018-10-11T07:20:52.733Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/code/clones/sidekiq/lib/sidekiq/util.rb:16:in `watchdog'
2018-10-11T07:20:52.733Z 44689 TID-oxtmzvjn9 WARN: Thread TID-oxtn2jdtx /Users/mrnugget/code/clones/sidekiq/lib/sidekiq/util.rb:25:in `block in safe_thread'
```

Let me know what you think!