### PR TITLE
Fix RealTime Graphs Reset on Window Height Change

### DIFF
--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -299,7 +299,17 @@ var debounce = function(fn, timeout)
 };
 
 window.onresize = debounce(function() {
-    clearInterval(poller);
-    resetGraphs();
-    renderGraphs();
-}, 125);
+  var prevWidth = window.innerWidth;
+  
+  return function () {
+    var currWidth = window.innerWidth;
+    
+    if (prevWidth !== currWidth) {
+      prevWidth = currWidth
+      
+      clearInterval(poller);
+      resetGraphs();
+      renderGraphs();
+    }
+  }
+}(), 125);

--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -305,7 +305,7 @@ window.onresize = function() {
     var currWidth = window.innerWidth;
     
     if (prevWidth !== currWidth) {
-      prevWidth = currWidth
+      prevWidth = currWidth;
       
       clearInterval(poller);
       resetGraphs();

--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -298,10 +298,10 @@ var debounce = function(fn, timeout)
   }
 };
 
-window.onresize = debounce(function() {
+window.onresize = function() {
   var prevWidth = window.innerWidth;
   
-  return function () {
+  return debounce(function () {
     var currWidth = window.innerWidth;
     
     if (prevWidth !== currWidth) {
@@ -311,5 +311,5 @@ window.onresize = debounce(function() {
       resetGraphs();
       renderGraphs();
     }
-  }
-}(), 125);
+  }, 125);
+}();


### PR DESCRIPTION
### Description
Sidekiq dashboard resets the graph on `resize` events whether it is a height change or a width change. This causes some unexpected behaviours. 
- When the direction of the scroll changes on a mobile browser say Chrome for Android, the browser automatically hides/displays the address bar. This change triggers a resize event (due to height changes), which in-turn resets the realtime graph on the main dashboard page.
- The same behaviour can be observed on desktop browsers in full screen mode on a Mac, when the menubar is hidden and then displayed on hovering over it.

### Fix
- Almost all of the times, we need to reset the graphs only when the width changes. So, we can trigger the reset functionality only when the `innerWidth` of the window changes. This way we can remove the unexpected/unwanted resets, when the height of the window changes.