### PR TITLE
Cleanup Gem Spec

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -1,5 +1,4 @@
-# -*- encoding: utf-8 -*-
-require File.expand_path('../lib/sidekiq/version', __FILE__)
+require_relative 'lib/sidekiq/version'
 
 Gem::Specification.new do |gem|
   gem.authors       = ["Mike Perham"]
@@ -11,13 +10,12 @@ Gem::Specification.new do |gem|
 
   gem.executables   = ['sidekiq', 'sidekiqctl']
   gem.files         = `git ls-files | grep -Ev '^(test|myapp|examples)'`.split("\n")
-  gem.test_files    = []
   gem.name          = "sidekiq"
-  gem.require_paths = ["lib"]
   gem.version       = Sidekiq::VERSION
   gem.required_ruby_version = ">= 2.2.2"
 
   gem.add_dependency 'redis', '>= 3.3.5', '< 5'
   gem.add_dependency 'connection_pool', '~> 2.2', '>= 2.2.2'
+  gem.add_dependency 'rack', '>= 1.5.0'
   gem.add_dependency 'rack-protection', '>= 1.5.0'
 end


### PR DESCRIPTION
All changes conform require ruby version `>= 2.2.2`
- `# -*- encoding: utf-8 -*-` source encoding UTF-8 is a default since Ruby `1.9+`
- `require_relative 'lib/sidekiq/version'` is a shorter version
- `gem.test_files` spec option is not used anymore
- `gem.require_paths = ["lib"]` is a spec option [default](https://guides.rubygems.org/specification-reference/#require_paths=)
- Add `rack` gem as an explicit runtime dendency, because Web UI actually dependes on `rack` builder and `rack-protection` is only a part of that stack, which is responsible for security.