### PR TITLE
Add TID to procname

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -18,6 +18,7 @@ module Sidekiq
     PROCTITLES = [
       proc { 'sidekiq' },
       proc { Sidekiq::VERSION },
+      proc { |me, data| "[#{Sidekiq::Logging.tid}]" },
       proc { |me, data| data['tag'] },
       proc { |me, data| "[#{Processor::WORKER_STATE.size} of #{data['concurrency']} busy]" },
       proc { |me, data| "stopping" if me.stopping? },

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -50,7 +50,7 @@ class TestLauncher < Sidekiq::Test
         end
 
         it 'sets useful info to proctitle' do
-          assert_equal "sidekiq #{Sidekiq::VERSION} myapp [1 of 3 busy] xyz", $0
+          assert_equal "sidekiq #{Sidekiq::VERSION} [#{Sidekiq::Logging.tid}] myapp [1 of 3 busy] xyz", $0
         end
 
         it 'stores process info in redis' do
@@ -72,7 +72,7 @@ class TestLauncher < Sidekiq::Test
         #end
 
         it 'indicates stopping status in proctitle' do
-          assert_equal "sidekiq #{Sidekiq::VERSION} myapp [1 of 3 busy] stopping", $0
+          assert_equal "sidekiq #{Sidekiq::VERSION} [#{Sidekiq::Logging.tid}] myapp [1 of 3 busy] stopping", $0
         end
 
         it 'stores process info in redis' do


### PR DESCRIPTION
I've run into issues where some jobs were locking up my database using https://wiki.postgresql.org/wiki/Lock_Monitoring it was possible to print out the application name's that were holding the locks.  These were inevitably `sidekiq version app_name [n of m busy]`.  It was possible to trace them down using by looking at the IP and port that was connected but it would be much easier if each process had the TID as part of the name. 

I've put the TID after the version and in `[]` as a start.  Is this something you would consider?  Would you prefer if it was optional, e.g. `sidekiq --add-tid-name`?


Regards 