### PR TITLE
Add unsafe-inline CSP to allow bucket graph to display

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -17,7 +17,7 @@ module Sidekiq
       "manifest-src 'self'",
       "media-src 'self'",
       "object-src 'none'",
-      "script-src 'self' https: http:",
+      "script-src 'self' https: http: 'unsafe-inline'",
       "style-src 'self' https: http: 'unsafe-inline'",
       "worker-src 'self'",
       "base-uri 'self'"


### PR DESCRIPTION
The current CSP policy for Sidekiq Web appears to block the inline
script that renders the history charts for bucket limits.

This change updates the script CSP rules to match the style CSP rules to
allow the chart to successfully render. In our application this change
made the bucket charts load successfully.

cc: #3913, #4030 

CSP warnings before fix:
![screenshot 2018-11-28 14 27 38](https://user-images.githubusercontent.com/319471/49176867-cfc00500-f319-11e8-9289-66bb48bfce16.png)