### PR TITLE
Raise if the user supplies a -C param and it doesn’t exist

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -343,6 +343,9 @@ module Sidekiq
         end
 
         o.on '-C', '--config PATH', "path to YAML config file" do |arg|
+          if !File.exist?(arg)
+            raise ArgumentError, "can't find config file #{arg}"
+          end
           opts[:config_file] = arg
         end
 


### PR DESCRIPTION
Added config file existence check as discussed in comments of #3735.

At first I tried to move config file fallback logic from `config_parse`, because it's not really parsing of a config. But then I thought that it would be more straightforward to just check file existence when optparse catches `-C`: easier to understand the error when it happens, easier to preserve config file fallback, and easier to understand this logic when/if modifying it later.