### PR TITLE
Match Redis connection pool size verification with defaults

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -10,6 +10,7 @@ require 'fileutils'
 require 'sidekiq'
 require 'sidekiq/util'
 require 'sidekiq/launcher'
+require 'sidekiq/redis_connection'
 
 module Sidekiq
   class CLI
@@ -76,7 +77,7 @@ module Sidekiq
       # Since the user can pass us a connection pool explicitly in the initializer, we
       # need to verify the size is large enough or else Sidekiq's performance is dramatically slowed.
       cursize = Sidekiq.redis_pool.size
-      needed = Sidekiq.options[:concurrency] + 2
+      needed = Sidekiq.options[:concurrency] + RedisConnection::AUXILIARY_CONNECTIONS
       raise "Your pool of #{cursize} Redis connections is too small, please increase the size to at least #{needed}" if cursize < needed
 
       # cache process identity

--- a/test/test_redis_connection.rb
+++ b/test/test_redis_connection.rb
@@ -83,6 +83,12 @@ class TestRedisConnection < Minitest::Test
           ENV.delete('RAILS_MAX_THREADS')
         end
       end
+
+      it "raises if the server pool size is too small to support other features" do
+        Sidekiq.options[:concurrency] = 6
+
+        assert_raises(ArgumentError) { server_connection(size: 10) }
+      end
     end
 
     it "disables client setname with nil id" do


### PR DESCRIPTION
When debugging some issues we were having with Sidekiq processes hanging, I noticed that the verification of the Redis connection pool size is different than the code that adds the 5 additional connections to the pool by default.

This synchronizes them, while also adjusting the math check to take into account the additional connections needed for Sidekiq's built-in features.