### PR TITLE
Move Proctitle from CLI to Launcher

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -16,14 +16,6 @@ module Sidekiq
     include Util
     include Singleton unless $TESTING
 
-    PROCTITLES = [
-      proc { 'sidekiq' },
-      proc { Sidekiq::VERSION },
-      proc { |me, data| data['tag'] },
-      proc { |me, data| "[#{Processor::WORKER_STATE.size} of #{data['concurrency']} busy]" },
-      proc { |me, data| "stopping" if me.stopping? },
-    ]
-
     attr_accessor :launcher
     attr_accessor :environment
 

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -1,93 +1,97 @@
 # frozen_string_literal: true
+
 require_relative 'helper'
 require 'sidekiq/launcher'
-require 'sidekiq/cli'
 
 class TestLauncher < Minitest::Test
+  describe Sidekiq::Launcher do
+    subject { Sidekiq::Launcher.new(options) }
 
-  describe 'launcher' do
+    let(:options) do
+      {
+        concurrency: 3,
+        queues: ['default'],
+        tag: 'myapp'
+      }
+    end
+
     before do
-      Sidekiq.redis {|c| c.flushdb }
+      Sidekiq.redis { |c| c.flushdb }
+      Sidekiq::Processor::WORKER_STATE.set('tid', { queue: 'queue', payload: 'job_hash', run_at: Time.now.to_i })
+      @proctitle = $0
     end
 
-    def new_manager(opts)
-      Sidekiq::Manager.new(opts)
+    after do
+      Sidekiq::Processor::WORKER_STATE.clear
+      $0 = @proctitle
     end
 
-    describe 'heartbeat' do
-      before do
-        @mgr = new_manager(options)
-        @launcher = Sidekiq::Launcher.new(options)
-        @launcher.manager = @mgr
-        @id = @launcher.identity
+    describe '#heartbeat' do
+      describe 'run' do
+        it 'sets sidekiq version, tag and the number of busy workers to proctitle' do
+          subject.heartbeat
 
-        Sidekiq::Processor::WORKER_STATE.set('a', {'b' => 1})
-
-        @proctitle = $0
-      end
-
-      after do
-        Sidekiq::Processor::WORKER_STATE.clear
-        $0 = @proctitle
-      end
-
-      it 'fires new heartbeat events' do
-        i = 0
-        Sidekiq.on(:heartbeat) do
-          i += 1
-        end
-        assert_equal 0, i
-        @launcher.heartbeat
-        assert_equal 1, i
-        @launcher.heartbeat
-        assert_equal 1, i
-      end
-
-      describe 'when manager is active' do
-        before do
-          Sidekiq::CLI::PROCTITLES << proc { "xyz" }
-          @launcher.heartbeat
-          Sidekiq::CLI::PROCTITLES.pop
-        end
-
-        it 'sets useful info to proctitle' do
-          assert_equal "sidekiq #{Sidekiq::VERSION} myapp [1 of 3 busy] xyz", $0
+          assert_equal "sidekiq #{Sidekiq::VERSION} myapp [1 of 3 busy]", $0
         end
 
         it 'stores process info in redis' do
-          info = Sidekiq.redis { |c| c.hmget(@id, 'busy') }
-          assert_equal ["1"], info
-          expires = Sidekiq.redis { |c| c.pttl(@id) }
+          subject.heartbeat
+
+          workers = Sidekiq.redis { |c| c.hmget(subject.identity, 'busy') }
+
+          assert_equal ["1"], workers
+
+          expires = Sidekiq.redis { |c| c.pttl(subject.identity) }
+
           assert_in_delta 60000, expires, 500
+        end
+
+        describe 'events' do
+          before do
+            @cnt = 0
+
+            Sidekiq.on(:heartbeat) do
+              @cnt += 1
+            end
+          end
+
+          it 'fires start heartbeat event only once' do
+            assert_equal 0, @cnt
+
+            subject.heartbeat
+
+            assert_equal 1, @cnt
+
+            subject.heartbeat
+
+            assert_equal 1, @cnt
+          end
         end
       end
 
-      describe 'when manager is stopped' do
+      describe 'quite' do
         before do
-          @launcher.quiet
-          @launcher.heartbeat
+          subject.quiet
         end
 
-        #after do
-          #puts system('redis-cli -n 15 keys  "*" | while read LINE ; do TTL=`redis-cli -n 15 ttl "$LINE"`; if [ "$TTL" -eq -1 ]; then echo "$LINE"; fi; done;')
-        #end
+        it 'sets stopping proctitle' do
+          subject.heartbeat
 
-        it 'indicates stopping status in proctitle' do
           assert_equal "sidekiq #{Sidekiq::VERSION} myapp [1 of 3 busy] stopping", $0
         end
 
         it 'stores process info in redis' do
-          info = Sidekiq.redis { |c| c.hmget(@id, 'busy') }
+          subject.heartbeat
+
+          info = Sidekiq.redis { |c| c.hmget(subject.identity, 'busy') }
+
           assert_equal ["1"], info
-          expires = Sidekiq.redis { |c| c.pttl(@id) }
+
+          expires = Sidekiq.redis { |c| c.pttl(subject.identity) }
+
           assert_in_delta 60000, expires, 50
         end
       end
     end
-
-    def options
-      { :concurrency => 3, :queues => ['default'], :tag => 'myapp' }
-    end
-
   end
 end


### PR DESCRIPTION
Here are not actually breaking changes, just a refactoring we agreed before. Proctitles should be inside the `Sidekiq::Launcher` class as it starts/updates heartbeat, which is responsible for the process title updates. I've refactored tests a little bit either, gonna add some more in the nearest future.