### PR TITLE
Look for config file at ./config/sidekiq.yml by default (if no -r flag provided)

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -238,12 +238,14 @@ module Sidekiq
         if opts[:config_file] && !File.exist?(opts[:config_file])
           raise ArgumentError, "No such file #{opts[:config_file]}"
         end
+      elsif opts[:require] && File.directory?(opts[:require])
+        %w[config/sidekiq.yml config/sidekiq.yml.erb].each do |filename|
+          path = File.expand_path(filename, opts[:require])
+          opts[:config_file] ||= path if File.exist?(path)
+        end
       else
-        if opts[:require] && File.directory?(opts[:require])
-          %w[config/sidekiq.yml config/sidekiq.yml.erb].each do |filename|
-            path = File.expand_path(filename, opts[:require])
-            opts[:config_file] ||= path if File.exist?(path)
-          end
+        %w[config/sidekiq.yml config/sidekiq.yml.erb].each do |filename|
+          opts[:config_file] ||= filename if File.exist?(filename)
         end
       end
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -254,6 +254,15 @@ class TestCLI < Minitest::Test
               assert_equal 25, Sidekiq.options[:concurrency]
             end
           end
+
+          describe 'when no requirement path is provided' do
+            it 'tries ./config/sidekiq.yml' do
+              Dir.chdir("test/dummy") do
+                @cli.parse(%w[sidekiq])
+                assert_equal 'config/sidekiq.yml', Sidekiq.options[:config_file]
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #4075.

v5.2.4 changed Sidekiq's behaviour when no `-r` or `-C` flag was provided. Previously, it would look in the default locations for a config file, and this PR restores that behaviour.