### PR TITLE
Consider Default Required Path on Config File Search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 services:
   - redis-server
 before_install:
-  - gem update --system
+  - gem install bundler -v '< 2'
 gemfile:
   - gemfiles/rails_4.gemfile
   - gemfiles/rails_5.gemfile

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -239,17 +239,22 @@ module Sidekiq
           raise ArgumentError, "No such file #{opts[:config_file]}"
         end
       else
-        if opts[:require] && File.directory?(opts[:require])
-          %w[config/sidekiq.yml config/sidekiq.yml.erb].each do |filename|
-            path = File.expand_path(filename, opts[:require])
-            opts[:config_file] ||= path if File.exist?(path)
-          end
+        config_dir = if File.directory?(opts[:require].to_s)
+          File.join(opts[:require], 'config')
+        else
+          File.join(options[:require], 'config')
+        end
+
+        %w[sidekiq.yml sidekiq.yml.erb].each do |config_file|
+          path = File.join(config_dir, config_file)
+          opts[:config_file] ||= path if File.exist?(path)
         end
       end
 
       # parse config file options
       opts = parse_config(opts[:config_file]).merge(opts) if opts[:config_file]
 
+      # set defaults
       opts[:queues] = Array(opts[:queues]) << 'default' if opts[:queues].nil? || opts[:queues].empty?
       opts[:strict] = true if opts[:strict].nil?
       opts[:concurrency] = Integer(ENV["RAILS_MAX_THREADS"]) if opts[:concurrency].nil? && ENV["RAILS_MAX_THREADS"]

--- a/test/dummy/config/sidekiq.yml
+++ b/test/dummy/config/sidekiq.yml
@@ -1,2 +1,3 @@
 ---
+:require: ./test/fake_env.rb
 :concurrency: 25

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -247,10 +247,32 @@ class TestCLI < Minitest::Test
 
         describe 'default config file' do
           describe 'when required path is a directory' do
-            it 'tries config/sidekiq.yml' do
+            it 'tries config/sidekiq.yml from required diretory' do
               @cli.parse(%w[sidekiq -r ./test/dummy])
 
-              assert_equal 'sidekiq.yml', File.basename(Sidekiq.options[:config_file])
+              assert_equal './test/dummy/config/sidekiq.yml', Sidekiq.options[:config_file]
+              assert_equal 25, Sidekiq.options[:concurrency]
+            end
+          end
+
+          describe 'when required path is a file' do
+            it 'tries config/sidekiq.yml from current diretory' do
+              Sidekiq.options[:require] = './test/dummy' # stub current dir – ./
+
+              @cli.parse(%w[sidekiq -r ./test/fake_env.rb])
+
+              assert_equal './test/dummy/config/sidekiq.yml', Sidekiq.options[:config_file]
+              assert_equal 25, Sidekiq.options[:concurrency]
+            end
+          end
+
+          describe 'without any required path' do
+            it 'tries config/sidekiq.yml from current diretory' do
+              Sidekiq.options[:require] = './test/dummy' # stub current dir – ./
+
+              @cli.parse(%w[sidekiq])
+
+              assert_equal './test/dummy/config/sidekiq.yml', Sidekiq.options[:config_file]
               assert_equal 25, Sidekiq.options[:concurrency]
             end
           end


### PR DESCRIPTION
Fixes #4075

To find out the config file dir we make the next assumptions with the corresponding precedence:

1. CLI `:require` option is an existing dir – take it for `config/sidekiq.yml`
2. CLI `:require` option is a file – take default Sidekiq`:require` option  – `.` (current directory)
3. CLI `:require` option is ommitted – take default Sidekiq`:require` option  – `.` (current directory)

In tests we stub default Sidekiq `:require` option (`.`) with the dummy app folder (`./test/dummy`).