### PR TITLE
Rescue StandardErrors raised from exception's message

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -245,13 +245,14 @@ module Sidekiq
         exception_caused_by_shutdown?(e.cause, checked_causes)
     end
 
+    # Extract message from exception.
+    # Set a default if the message raises an error
     def exception_message(exception)
       begin
         # App code can stuff all sorts of crazy binary data into the error message
         # that won't convert to JSON.
         exception.message.to_s[0, 10_000]
       rescue StandardError => e
-        # If the message raises a StandardError, set a default
         "!!! ERROR MESSAGE THREW AN ERROR !!!"
       end
     end

--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -142,7 +142,7 @@ module Sidekiq
 
       # App code can stuff all sorts of crazy binary data into the error message
       # that won't convert to JSON.
-      m = exception.message.to_s[0, 10_000]
+      m = exception.message.to_s[0, 10_000] rescue nil
       if m.respond_to?(:scrub!)
         m.force_encoding("utf-8")
         m.scrub!

--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -252,7 +252,7 @@ module Sidekiq
         exception.message.to_s[0, 10_000]
       rescue StandardError => e
         # If the message raises a StandardError, set a default
-        "!!! ERROR HANDLER THREW AN ERROR !!!"
+        "!!! ERROR MESSAGE THREW AN ERROR !!!"
       end
     end
 

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -83,15 +83,16 @@ class TestRetry < Minitest::Test
 
     # In the rare event that an error message raises an error itself,
     # allow the job to retry. This will likely only happen for custom
-    # error classes.
+    # error classes that override #message
     it 'handles error message that raises an error' do
       assert_raises RuntimeError do
         handler.local(worker, job, 'default') do
           raise BadErrorMessage.new
         end
       end
+
       assert_equal 1, Sidekiq::RetrySet.new.size
-      assert_nil job["error_message"]
+      refute_nil job["error_message"]
     end
 
     it 'allows a max_retries option in initializer' do


### PR DESCRIPTION
When developers create custom error classes, there is potential for the `message` method to raise an error. Exception Inception!

```ruby
class BadError < StandardError

  def message
    # This will raise a NameError when trying to read this exception's message
    "Hello World" + foo
  end

end
```

Of course, this is not the fault of Sidekiq, however we do [rescue errors that an error handler may throw when logging](https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/exception_handler.rb#L22). Other error handling libraries do not account for these mistakes, but Sidekiq jobs that throw errors with bad messages will end up not retrying ever.