### PR TITLE
Pluggable Log Formatter

### DIFF
--- a/6.0-Upgrade.md
+++ b/6.0-Upgrade.md
@@ -1,24 +1,30 @@
 # Welcome to Sidekiq 6.0!
 
 Sidekiq 6.0 contains some breaking changes which streamline proper operation
-of Sidekiq.  It also drops support for EOL versions of Ruby and Rails.
+of Sidekiq. It also drops support for EOL versions of Ruby and Rails.
 
 ## What's New
 
 This release has major breaking changes.  Read and test carefully in production.
 
-- Logging has been redesigned to allow pluggable formats and several
+- Logging has been redesigned to allow pluggable formatters and several
   formats ship with Sidekiq:
   * default - your typical output on macOS
-  * json - a new format with key=value pairs for search indexing
   * heroku - a Heroku-specific formatter
+  * json - a new format with key=value pairs for search indexing
+  
 Sidekiq will enable the best formatter for the detected environment but
-you can override it by configuring the log format explicitly:
+you can override it by configuring the log formatter explicitly:
+
 ```
 Sidekiq.configure_server do |config|
-  config.log_formatter = :json # or nil for default
+  config.log_formatter = AcmeCorp::PlainLogFormatter.new
+  # Sidekiq::Logger::Formatters::Pretty.new (default)
+  # Sidekiq::Logger::Formatters::WhitoutTimestamp.new
+  # Sidekiq::Logger::Formatters::JSON.new
 end
 ```
+
 - **Remove the daemonization, logfile and pidfile command line arguments**.
   I've [noted for years](https://www.mikeperham.com/2014/09/22/dont-daemonize-your-daemons/)
  how modern services should be managed with a proper init system.

--- a/6.0-Upgrade.md
+++ b/6.0-Upgrade.md
@@ -16,7 +16,7 @@ Sidekiq will enable the best formatter for the detected environment but
 you can override it by configuring the log format explicitly:
 ```
 Sidekiq.configure_server do |config|
-  config.log_format = :json # or nil for default
+  config.log_formatter = :json # or nil for default
 end
 ```
 - **Remove the daemonization, logfile and pidfile command line arguments**.

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -179,7 +179,7 @@ module Sidekiq
   end
 
   class << self
-    attr_accessor :log_format
+    attr_accessor :log_formatter
   end
 
   def self.logger

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -174,12 +174,21 @@ module Sidekiq
   def self.load_json(string)
     JSON.parse(string)
   end
+
   def self.dump_json(object)
     JSON.generate(object)
   end
 
-  class << self
-    attr_accessor :log_formatter
+  def self.log_formatter
+    @log_formatter ||= if ENV['DYNO']
+      Sidekiq::Logger::Formatters::WithoutTimestamp.new
+    else
+      Sidekiq::Logger::Formatters::Pretty.new
+    end
+  end
+
+  def self.log_formatter=(log_formatter)
+    @log_formatter = log_formatter
   end
 
   def self.logger

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -34,7 +34,9 @@ module Sidekiq
     # test coverage of Sidekiq::CLI are welcomed.
     def run
       boot_system
-      print_banner if environment == 'development' && $stdout.tty? && Sidekiq.log_formatter == nil
+      if environment == 'development' && $stdout.tty? && Sidekiq.log_formatter.is_a?(Sidekiq::Logger::Formatters::Pretty)
+        print_banner
+      end
 
       self_read, self_write = IO.pipe
       sigs = %w(INT TERM TTIN TSTP)

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -34,7 +34,7 @@ module Sidekiq
     # test coverage of Sidekiq::CLI are welcomed.
     def run
       boot_system
-      print_banner if environment == 'development' && $stdout.tty? && Sidekiq.log_format == nil
+      print_banner if environment == 'development' && $stdout.tty? && Sidekiq.log_formatter == nil
 
       self_read, self_write = IO.pipe
       sigs = %w(INT TERM TTIN TSTP)

--- a/lib/sidekiq/logger.rb
+++ b/lib/sidekiq/logger.rb
@@ -9,7 +9,7 @@ module Sidekiq
     def initialize(*args)
       super
 
-      formatter_class = case Sidekiq.log_format
+      formatter_class = case Sidekiq.log_formatter
       when :json
         Formatters::JSON
       else

--- a/lib/sidekiq/logger.rb
+++ b/lib/sidekiq/logger.rb
@@ -9,14 +9,7 @@ module Sidekiq
     def initialize(*args)
       super
 
-      formatter_class = case Sidekiq.log_formatter
-      when :json
-        Formatters::JSON
-      else
-        ENV['DYNO'] ? Formatters::WithoutTimestamp : Formatters::Pretty
-      end
-
-      self.formatter = formatter_class.new
+      self.formatter = Sidekiq.log_formatter
     end
 
     def with_context(hash)

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -27,10 +27,10 @@ class TestLogger < Minitest::Test
     end
 
     begin
-      Sidekiq.log_format = :json
+      Sidekiq.log_formatter = :json
       assert_kind_of Sidekiq::Logger::Formatters::JSON, Sidekiq::Logger.new(STDOUT).formatter
     ensure
-      Sidekiq.log_format = nil
+      Sidekiq.log_formatter = nil
     end
   end
 


### PR DESCRIPTION
Close #4081

It's reasonable to keep the same configuration option name as in Rails – `log_formatter`. I'd consider "format" as something like this `"%s tem %s plate"`, and "formatter" is an instance that operates on the format.