### PR TITLE
Format latency

### DIFF
--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -17,7 +17,7 @@
           <% end %>
         </td>
         <td><%= number_with_delimiter(queue.size) %> </td>
-        <td><%= relative_time(Time.at(queue.latency.seconds.ago)) %> </td>
+        <td><%= queue.latency == 0 ? '' : relative_time(Time.at(queue.latency.seconds.ago)) %> </td>
         <td class="delete-confirm">
           <form action="<%=root_path %>queues/<%= CGI.escape(queue.name) %>" method="post">
             <%= csrf_tag %>

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -17,7 +17,7 @@
           <% end %>
         </td>
         <td><%= number_with_delimiter(queue.size) %> </td>
-        <td><% queue_latency = queue.latency %><%= number_with_delimiter(queue_latency.round(2)) %><%= (queue_latency < 60) ? '' : " (#{relative_time(Time.at(queue_latency.seconds.ago))})" %> </td>
+        <td><% queue_latency = queue.latency %><%= number_with_delimiter(queue_latency.round(2)) %><%= (queue_latency < 60) ? '' : " (#{relative_time(Time.at(Time.now.to_f - queue_latency))})" %> </td>
         <td class="delete-confirm">
           <form action="<%=root_path %>queues/<%= CGI.escape(queue.name) %>" method="post">
             <%= csrf_tag %>

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -17,7 +17,7 @@
           <% end %>
         </td>
         <td><%= number_with_delimiter(queue.size) %> </td>
-        <td><%= number_with_delimiter(queue.latency.round(2)) %><%= (queue.latency < 60) ? '' : " (#{relative_time(Time.at(queue.latency.seconds.ago))})" %> </td>
+        <td><% queue_latency = queue.latency %><%= number_with_delimiter(queue_latency.round(2)) %><%= (queue_latency < 60) ? '' : " (#{relative_time(Time.at(queue_latency.seconds.ago))})" %> </td>
         <td class="delete-confirm">
           <form action="<%=root_path %>queues/<%= CGI.escape(queue.name) %>" method="post">
             <%= csrf_tag %>

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -17,7 +17,7 @@
           <% end %>
         </td>
         <td><%= number_with_delimiter(queue.size) %> </td>
-        <td><%= queue.latency == 0 ? '' : relative_time(Time.at(queue.latency.seconds.ago)) %> </td>
+        <td><%= number_with_delimiter(queue.latency.round(2)) %><%= (queue.latency < 60) ? '' : " (#{relative_time(Time.at(queue.latency.seconds.ago))})" %> </td>
         <td class="delete-confirm">
           <form action="<%=root_path %>queues/<%= CGI.escape(queue.name) %>" method="post">
             <%= csrf_tag %>

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -17,7 +17,7 @@
           <% end %>
         </td>
         <td><%= number_with_delimiter(queue.size) %> </td>
-        <td><%= number_with_delimiter(queue.latency.round(2)) %> </td>
+        <td><%= relative_time(Time.at(queue.latency.seconds.ago)) %> </td>
         <td class="delete-confirm">
           <form action="<%=root_path %>queues/<%= CGI.escape(queue.name) %>" method="post">
             <%= csrf_tag %>


### PR DESCRIPTION
The latency time for queues when viewing /sidekiq/queues was previously listed in seconds.  This pull request formats this time in seconds, minutes, or hours, using the same code that is used elsewhere (ie. /sidekiq/busy) for formatting time.