### PR TITLE
[WIP] Filter arguments with matched keys in web UI

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -225,7 +225,7 @@ module Sidekiq
 
     def to_display(arg)
       begin
-        arg.inspect
+        filtered_arguments(arg).inspect
       rescue
         begin
           arg.to_s
@@ -233,6 +233,12 @@ module Sidekiq
           "Cannot display argument: [#{ex.class.name}] #{ex.message}"
         end
       end
+    end
+
+    def filtered_arguments(arg)
+      return arg unless arg.is_a?(Hash)
+
+      arg.merge(arg.select { |key, _| key.to_s =~ /password/i }.transform_values { '[FILTERED]' })
     end
 
     RETRY_JOB_KEYS = Set.new(%w(


### PR DESCRIPTION
Sidekiq prints the arguments of jobs on the "Retries" page which might contain sensitive data like passwords. There was already a discussion about this issue in ticket #2794. I played around a bit to filter out the values of matched keys in the web ui and wanted to get an opinion on this (if it's something that could be added to Sidekiq).

This code is just a quick implementation which filters out arguments for a matched key in a Hash. I could imagine extending it to also filter out arguments in the console and make the key arguments configurable (similar to Log Filtering in Rails).

@mperham WDYT?