### PR TITLE
Use options reader to fetch queue name in test

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -257,7 +257,7 @@ module Sidekiq
     module ClassMethods
       # Queue for this worker
       def queue
-        sidekiq_options["queue"]
+        get_sidekiq_options["queue"]
       end
 
       # Jobs queued for this worker


### PR DESCRIPTION
### Problem

I noticed that the `Sidekiq::Worker.queue` defined by `sidekiq/testing` was using the `sidekiq_options` writer instead of the `get_sidekiq_options` reader. This could be a problem if an implementor expected to use `sidekiq_options` only as a writer.

Here's a contrived example of an implementor ensuring that a queue is always explicitly configured:

```ruby
require "sidekiq"

class MyBaseWorker
  include Sidekiq::Worker

  def self.sidekiq_options(**opts)
    raise "always specify queue!" unless opts.key?(:queue)
    super
  end
end

class MyWorker < MyBaseWorker
  sidekiq_options retry: 3, queue: :my_queue
end

class MyQueuelessWorker < MyBaseWorker
  sidekiq_options retry: 3             # 💣 always specify queue! (expected)
end

require "sidekiq/testing"
puts MyWorker.queue                    # 💣 always specify queue! (unexpected)
```

### Solution

We can use the available reader `get_sidekiq_options` instead.

Let me know if you want me to write a test for this since it wasn't specifically tested before, but I'd be happy to add one if you'd like.