### PR TITLE
Do not reset the whole logger when format changes

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -192,7 +192,7 @@ module Sidekiq
 
   def self.log_formatter=(log_formatter)
     @log_formatter = log_formatter
-    @logger = nil
+    logger.formatter = log_formatter
   end
 
   def self.logger


### PR DESCRIPTION
I ran tests locally and encountered a lot of noise in output
<details>
<summary>click</summary>

```
.......omitted......

/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:360:in `on_signal'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:347:in `with_info_handler'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:319:in `run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:159:in `block in __run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:159:in `map'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:159:in `__run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:136:in `run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:63:in `block in autorun'
2019-09-08T00:21:50.930Z pid=97982 tid=ovfji9o56 WARN: {"context":"Exception during Sidekiq lifecycle event.","event":"startup"}
2019-09-08T00:21:50.930Z pid=97982 tid=ovfji9o56 WARN: RuntimeError: boom
2019-09-08T00:21:50.931Z pid=97982 tid=ovfji9o56 WARN: /Users/fatkodima/Desktop/oss/sidekiq/test/test_util.rb:17:in `block in test_event_firing'
/Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/util.rb:61:in `block in fire_event'
/Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/util.rb:60:in `each'
/Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/util.rb:60:in `fire_event'
/Users/fatkodima/Desktop/oss/sidekiq/test/test_util.rb:19:in `block in test_event_firing'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest/assertions.rb:326:in `assert_raises'
/Users/fatkodima/Desktop/oss/sidekiq/test/test_util.rb:18:in `test_event_firing'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest/test.rb:98:in `block (3 levels) in run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest/test.rb:195:in `capture_exceptions'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest/test.rb:95:in `block (2 levels) in run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:265:in `time_it'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest/test.rb:94:in `block in run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:360:in `on_signal'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest/test.rb:211:in `with_info_handler'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest/test.rb:93:in `run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:960:in `run_one_method'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:334:in `run_one_method'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:321:in `block (2 levels) in run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:320:in `each'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:320:in `block in run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:360:in `on_signal'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:347:in `with_info_handler'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:319:in `run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:159:in `block in __run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:159:in `map'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:159:in `__run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:136:in `run'
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/minitest-5.11.3/lib/minitest.rb:63:in `block in autorun'
..........2019-09-08T00:21:50.954Z pid=97982 tid=ovfji9o56 class=MockWorker INFO: start
2019-09-08T00:21:50.954Z pid=97982 tid=ovfji9o56 class=MockWorker elapsed=0.0 INFO: done
.......2019-09-08T00:21:50.960Z pid=97982 tid=ovfji9o56 INFO: Pushed 3 jobs back to Redis
.../Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32454: warning: statement not reached
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32615: warning: statement not reached
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32651: warning: statement not reached
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32740: warning: statement not reached
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32756: warning: statement not reached
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32822: warning: statement not reached
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32863: warning: statement not reached
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:32888: warning: statement not reached
/Users/fatkodima/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/mail-2.7.1/lib/mail/parsers/address_lists_parser.rb:31984: warning: assigned but unused variable - testEof
......2019-09-08T00:21:51.527Z pid=97982 tid=ovfji9o56 INFO: Booting Sidekiq 6.0.0 with redis options {:path=>"/var/run/redis.sock", :id=>"Sidekiq-server-PID-97982", :url=>nil}
.2019-09-08T00:21:51.528Z pid=97982 tid=ovfji9o56 INFO: Booting Sidekiq 6.0.0 with redis options {:path=>"/var/run/redis.sock", :db=>8, :id=>"Sidekiq-server-PID-97982", :url=>nil}
........

Finished in 3.656988s, 91.0585 runs/s, 281.1057 assertions/s.
333 runs, 1028 assertions, 0 failures, 0 errors, 0 skips
```
</details>


The culprit is the last code change. So is it needed to reset the whole logger, when really only formatter should be changed? 
This code change also fixes mentioned test noise.