### PR TITLE
Fix sidekiqload loading error

### DIFF
--- a/bin/sidekiqload
+++ b/bin/sidekiqload
@@ -5,7 +5,8 @@
 $TESTING = false
 
 #require 'ruby-prof'
-Bundler.require(:default)
+require 'bundler/setup'
+Bundler.require(:default, :load_test)
 
 require_relative '../lib/sidekiq/cli'
 require_relative '../lib/sidekiq/launcher'


### PR DESCRIPTION
```
$ bin/sidekiqload
Traceback (most recent call last):
bin/sidekiqload:8:in `<main>': uninitialized constant Bundler (NameError)
```

And `toxiproxy` and `hiredis` are not loaded from `load_test` Gemfile group