### PR TITLE
Respect rails' generators `test_framework` option and gracefully handle extra `worker` suffix on generator

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 HEAD
 ---------
 
+- Respect rails' generators `test_framework` option and gracefully handle extra `worker` suffix on generator [#4256]
 - Add ability to sort 'Enqueued' page on Web UI by position in the queue [#4248]
 - Support `Client.push_bulk` with different delays [#4243]
 ```ruby

--- a/lib/generators/sidekiq/worker_generator.rb
+++ b/lib/generators/sidekiq/worker_generator.rb
@@ -16,6 +16,8 @@ module Sidekiq
       end
 
       def create_test_file
+        return unless test_framework
+
         if defined?(RSpec)
           create_worker_spec
         else
@@ -41,6 +43,14 @@ module Sidekiq
           "#{file_name}_worker_test.rb"
         )
         template "worker_test.rb.erb", template_file
+      end
+
+      def file_name
+        @_file_name ||= super.sub(/_?worker\z/i, "")
+      end
+
+      def test_framework
+        ::Rails.application.config.generators.options[:rails][:test_framework]
       end
     end
   end

--- a/test/test_worker_generator.rb
+++ b/test/test_worker_generator.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require_relative 'helper'
+require_relative 'dummy/config/environment'
+require 'rails/generators/test_case'
+require 'generators/sidekiq/worker_generator'
+
+class WorkerGeneratorTest < Rails::Generators::TestCase
+  tests Sidekiq::Generators::WorkerGenerator
+  destination File.expand_path('../../tmp', __FILE__)
+  setup :prepare_destination
+
+  test 'all files are properly created' do
+    run_generator ['foo']
+    assert_file 'app/workers/foo_worker.rb'
+    assert_file 'test/workers/foo_worker_test.rb'
+  end
+
+  test 'gracefully handles extra worker suffix' do
+    run_generator ['foo_worker']
+    assert_no_file 'app/workers/foo_worker_worker.rb'
+    assert_no_file 'test/workers/foo_worker_worker_test.rb'
+
+    assert_file 'app/workers/foo_worker.rb'
+    assert_file 'test/workers/foo_worker_test.rb'
+  end
+
+  test 'respects rails config test_framework option' do
+    Rails.application.config.generators do |g|
+      g.test_framework false
+    end
+
+    run_generator ['foo']
+
+    assert_file 'app/workers/foo_worker.rb'
+    assert_no_file 'test/workers/foo_worker_test.rb'
+  ensure
+    Rails.application.config.generators do |g|
+      g.test_framework :test_case
+    end
+  end
+end


### PR DESCRIPTION
Currently, when tests generation is disabled for a rails app, sidekiq nevertheless generates ones. 

And this pr also fixes (like rails itself does) extra suffix generation for worker name.
```diff
$ rails generate sidekiq:worker stripe_worker
Running via Spring preloader in process 62280
-      create  app/workers/stripe_worker_worker.rb
+      create  app/workers/stripe_worker.rb
-      create  test/workers/stripe_worker_worker_test.rb
+      create  test/workers/stripe_worker_test.rb
```