### PR TITLE
Add `SortedSet#scan` for pattern based scanning

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,14 @@
 HEAD
 ---------
 
+- Add `SortedSet#scan` for pattern based scanning. For large sets this API will be **MUCH** faster
+  than standard iteration using each.
+```ruby
+  Sidekiq::DeadSet.new.scan("UnreliableApi") do |job|
+    job.retry
+  end
+```
+
 - Dramatically speed up SortedSet#find\_job(jid) by using Redis's ZSCAN
   support, approx 10x faster. [#4259]
 ```

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -540,6 +540,17 @@ module Sidekiq
       Sidekiq.redis { |c| c.zcard(name) }
     end
 
+    def scan(match, count: 100)
+      return to_enum(:scan, match) unless block_given?
+
+      match = "*#{match}*" unless match.include?("*")
+      Sidekiq.redis do |conn|
+        conn.zscan_each(name, match: match, count: count) do |entry, score|
+          yield SortedEntry.new(self, score, entry)
+        end
+      end
+    end
+
     def clear
       Sidekiq.redis do |conn|
         conn.del(name)

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -468,6 +468,15 @@ describe 'API' do
       assert_equal 0, r.size
     end
 
+    it 'can scan retries' do
+      add_retry
+      add_retry('test')
+      r = Sidekiq::RetrySet.new
+      assert_instance_of Enumerator, r.scan('Worker')
+      assert_equal 2, r.scan('ApiWorker').to_a.size
+      assert_equal 1, r.scan('*test*').to_a.size
+    end
+
     it 'can enumerate processes' do
       identity_string = "identity_string"
       odata = {


### PR DESCRIPTION
```ruby
Sidekiq::DeadSet.new.scan("UnreliableApi") do |job|
   job.retry
end
```

For large sets this API will be much faster than using `each`.