### PR TITLE
Reduce allocated objects

### DIFF
--- a/lib/sidekiq/logger.rb
+++ b/lib/sidekiq/logger.rb
@@ -9,7 +9,7 @@ module Sidekiq
       ctx.merge!(hash)
       yield
     ensure
-      hash.keys.each { |key| ctx.delete(key) }
+      hash.each_key { |key| ctx.delete(key) }
     end
 
     def ctx

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -269,13 +269,15 @@ module Sidekiq
     end
 
     def constantize(str)
+      return Object.const_get(str) unless str.include?("::")
+
       names = str.split("::")
       names.shift if names.empty? || names.first.empty?
 
       names.inject(Object) do |constant, name|
         # the false flag limits search for name to under the constant namespace
         #   which mimics Rails' behaviour
-        constant.const_defined?(name, false) ? constant.const_get(name, false) : constant.const_missing(name)
+        constant.const_get(name, false)
       end
     end
   end


### PR DESCRIPTION
Using `bin/sidekiqload` with `memory_profiler` I got:

**Before**:
```
Total allocated: 952250916 bytes (10115468 objects)
Total retained:  12802918 bytes (2000 objects)
```

**After**:
```
Total allocated: 934688905 bytes (9715635 objects)
Total retained:  12822122 bytes (2185 objects)
```

Memory savings = `(952250916 - 934688905) / 952250916.0 * 100 ~ 2%`
Object allocations reduced by = `(10115468 - 9715635) / 10115468.0 * 100 ~ 4%`
And time savings i have seen are also `~4%`.

Those savings are a bit smaller than in previous pr, but taking into account the simple changes, I think it's worth considering. 

Also line
```ruby
constant.const_defined?(name, false) ? constant.const_get(name, false) : constant.const_missing(name)
``` 
is a bit redundant, since `const_get(name, false)` calls `const_missing` when it can not find a constant.