### PR TITLE
Compress jobs backtraces

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 HEAD
 ---------
 
+- Compress jobs backtraces before pushing into Redis [#4272]
 - Support display of ActiveJob 6.0 payloads in the Web UI [#4263]
 - Add `SortedSet#scan` for pattern based scanning. For large sets this API will be **MUCH** faster
   than standard iteration using each.

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -254,6 +254,12 @@ describe 'API' do
       assert_equal [1,2,3], x.display_args
     end
 
+    it 'handles old jobs error_backtrace format' do
+      add_retry
+      job = Sidekiq::RetrySet.new.first
+      assert_equal ['line1', 'line2'], job.error_backtrace
+    end
+
     describe "Rails unwrapping" do
       SERIALIZED_JOBS = {
         "5.x" => [
@@ -587,7 +593,7 @@ describe 'API' do
     end
 
     def add_retry(jid = 'bob', at = Time.now.to_f)
-      payload = Sidekiq.dump_json('class' => 'ApiWorker', 'args' => [1, 'mike'], 'queue' => 'default', 'jid' => jid, 'retry_count' => 2, 'failed_at' => Time.now.to_f)
+      payload = Sidekiq.dump_json('class' => 'ApiWorker', 'args' => [1, 'mike'], 'queue' => 'default', 'jid' => jid, 'retry_count' => 2, 'failed_at' => Time.now.to_f, 'error_backtrace' => ['line1', 'line2'])
       Sidekiq.redis do |conn|
         conn.zadd('retry', at.to_s, payload)
       end

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -3,6 +3,7 @@
 require_relative 'helper'
 require 'sidekiq/scheduled'
 require 'sidekiq/job_retry'
+require 'sidekiq/api'
 
 describe Sidekiq::JobRetry do
   describe 'middleware' do
@@ -116,8 +117,10 @@ describe Sidekiq::JobRetry do
           c = caller(0); raise "kerblammo!"
         end
       end
-      assert job["error_backtrace"]
-      assert_equal c[0], job["error_backtrace"][0]
+
+      job = Sidekiq::RetrySet.new.first
+      assert job.error_backtrace
+      assert_equal c[0], job.error_backtrace[0]
     end
 
     it 'saves partial backtraces' do
@@ -127,8 +130,10 @@ describe Sidekiq::JobRetry do
           c = caller(0)[0...3]; raise "kerblammo!"
         end
       end
-      assert job["error_backtrace"]
-      assert_equal c, job["error_backtrace"]
+
+      job = Sidekiq::RetrySet.new.first
+      assert job.error_backtrace
+      assert_equal c, job.error_backtrace
       assert_equal 3, c.size
     end
 

--- a/web/views/dead.erb
+++ b/web/views/dead.erb
@@ -14,11 +14,11 @@
         <th><%= t('ErrorMessage') %></th>
         <td><%= h(@dead['error_message']) %></td>
       </tr>
-      <% if !@dead['error_backtrace'].nil? %>
+      <% if @dead.error_backtrace %>
         <tr>
           <th><%= t('ErrorBacktrace') %></th>
           <td>
-            <code><%= @dead['error_backtrace'].join("<br/>") %></code>
+            <code><%= @dead.error_backtrace.join("<br/>") %></code>
           </td>
         </tr>
       <% end %>

--- a/web/views/retry.erb
+++ b/web/views/retry.erb
@@ -14,11 +14,11 @@
         <th><%= t('ErrorMessage') %></th>
         <td><%= h(@retry['error_message']) %></td>
       </tr>
-      <% if !@retry['error_backtrace'].nil? %>
+      <% if @retry.error_backtrace %>
         <tr>
           <th><%= t('ErrorBacktrace') %></th>
           <td>
-            <code><%= @retry['error_backtrace'].join("<br/>") %></code>
+            <code><%= @retry.error_backtrace.join("<br/>") %></code>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
About implementation: Originally, I was thinking about implementing ability to enable/disable this feature (globally and per worker), allowing to configure threshold when to consider compressing (also globally and per worker). But this quickly became more complicated than needed. And i realized, I can't imagine real use cases when it would have benefit to disable compression or change its compression threshold instead of *always* do the compression.

So I chose the easy and simple way of always do the compression. My implementation will also handle jobs having error_backtrace in previous (array) format.

So lets firstly discuss implementation, then i would add tests and changelog entry.  

Closes #4270 