### PR TITLE
Easier way to test enqueuing specific ActionMailer and ActiveRecord delayed jobs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,11 @@
 HEAD
 ---------
 
+- Easier way to test enqueuing specific ActionMailer and ActiveRecord delayed jobs. Instead of manually
+  parsing embedded class, you can now test by fetching jobs for specific classes. [fatkodima, #4292]
+```ruby
+assert_equal 1, Sidekiq::Extensions::DelayedMailer.jobs_for(FooMailer).size
+```
 - **Dark Mode support in Web UI** (further design polish welcome!) [#4227, mperham,
   fatkodima, silent-e]
 - **Job-specific log levels**, allowing you to turn on debugging for

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -323,6 +323,18 @@ module Sidekiq
       end
     end
   end
+
+  module TestingExtensions
+    def jobs_for(klass)
+      jobs.select do |job|
+        marshalled = job["args"][0]
+        marshalled.index(klass.to_s) && YAML.load(marshalled)[0] == klass
+      end
+    end
+  end
+
+  Sidekiq::Extensions::DelayedMailer.extend(TestingExtensions)
+  Sidekiq::Extensions::DelayedModel.extend(TestingExtensions)
 end
 
 if defined?(::Rails) && Rails.respond_to?(:env) && !Rails.env.test?

--- a/test/test_testing_fake.rb
+++ b/test/test_testing_fake.rb
@@ -78,6 +78,21 @@ describe 'Sidekiq::Testing.fake' do
       Something.delay.foo(Date.today)
       assert_equal 1, Sidekiq::Extensions::DelayedClass.jobs.size
     end
+
+    class BarMailer < ActionMailer::Base
+      def foo(str)
+        str
+      end
+    end
+
+    it 'returns enqueued jobs for specific classes' do
+      assert_equal 0, Sidekiq::Extensions::DelayedClass.jobs.size
+      FooMailer.delay.bar('hello!')
+      BarMailer.delay.foo('hello!')
+      assert_equal 2, Sidekiq::Extensions::DelayedMailer.jobs.size
+      assert_equal 1, Sidekiq::Extensions::DelayedMailer.jobs_for(FooMailer).size
+      assert_equal 1, Sidekiq::Extensions::DelayedMailer.jobs_for(BarMailer).size
+    end
   end
 
   it 'stubs the enqueue call' do


### PR DESCRIPTION
I have found this problem was discussed before in [2934](https://github.com/mperham/sidekiq/issues/2934)

I also disabled rubocop check (failing, but not relevant to this pr), because `ensure` can not be used inside curly braces. Personally, I don't see much value in that cop. 