### PR TITLE
Fix not-clickable link to 6.0 upgrade notes

### DIFF
--- a/Pro-Changes.md
+++ b/Pro-Changes.md
@@ -15,7 +15,7 @@ Please see [http://sidekiq.org/](http://sidekiq.org/) for more details and how t
 
 - There is no significant migration from Sidekiq Pro 4.0 to 5.0
   but make sure you read the [update notes for Sidekiq
-6.0](/mperham/sidekiq/blob/master/6.0-Upgrade.md).
+6.0](https://github.com/mperham/sidekiq/blob/master/6.0-Upgrade.md).
 - Removed various deprecated APIs and associated warnings.
 - **BREAKING CHANGE** Remove the `Sidekiq::Batch::Status#dead_jobs` API in favor of
   `Sidekiq::Batch::Status#dead_jids`. [#4217]


### PR DESCRIPTION
This fixes the fact that the 6.0 upgrade note link is broken when viewed on GitHub.com. I assume this file is meant to be read on GitHub and not somewhere else, which means that the links should work on GitHub and point to GitHub. If that's not the case, then I'm not sure what the target should be (or if it needs to be fixed at all).