### PR TITLE
Optimize cloning of job payload

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -265,7 +265,7 @@ module Sidekiq
     # the job fails, what is pushed back onto Redis hasn't
     # been mutated by the worker.
     def cloned(thing)
-      Marshal.load(Marshal.dump(thing))
+      deep_dup(thing)
     end
 
     def constantize(str)
@@ -279,6 +279,28 @@ module Sidekiq
         #   which mimics Rails' behaviour
         constant.const_get(name, false)
       end
+    end
+
+    def deep_dup(obj)
+      if Integer === obj || Float === obj || TrueClass === obj || FalseClass === obj || NilClass === obj
+        return obj
+      elsif String === obj
+        return obj.dup
+      elsif Array === obj
+        duped = Array.new(obj.size)
+        obj.each_with_index do |value, index|
+          duped[index] = deep_dup(value)
+        end
+      elsif Hash === obj
+        duped = obj.dup
+        duped.each_pair do |key, value|
+          duped[key] = deep_dup(value)
+        end
+      else
+        duped = obj.dup
+      end
+
+      duped
     end
   end
 end


### PR DESCRIPTION
Profiling `bin/sidekiqload`, I got:

For cpu:
**Before**:
```
==================================
  Mode: cpu(1000)
  Samples: 15951 (1.51% miss rate)
  GC: 1804 (11.31%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     10483  (65.7%)       10483  (65.7%)     Hiredis::Ext::Connection#read
      2226  (14.0%)        2226  (14.0%)     Sidekiq::Processor#cloned
      1804  (11.3%)        1804  (11.3%)     (garbage collection)
       704   (4.4%)         704   (4.4%)     #<Module:0x00007fd0ae32f718>.parse
       137   (0.9%)         107   (0.7%)     Sidekiq::LoggingUtils#add
        75   (0.5%)          75   (0.5%)     Redis::Connection::Hiredis#write
        67   (0.4%)          67   (0.4%)     Sidekiq::Processor#constantize
        59   (0.4%)          59   (0.4%)     Redis::Connection::Hiredis#timeout=
     10792  (67.7%)          32   (0.2%)     ConnectionPool#with
```

**After**:
```
==================================
  Mode: cpu(1000)
  Samples: 14098 (1.34% miss rate)
  GC: 1528 (10.84%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      9625  (68.3%)        9625  (68.3%)     Hiredis::Ext::Connection#read
      1528  (10.8%)        1528  (10.8%)     (garbage collection)
      1281   (9.1%)        1281   (9.1%)     Sidekiq::Processor#deep_dup
       656   (4.7%)         656   (4.7%)     #<Module:0x00007f94bcbeb768>.parse
       187   (1.3%)         127   (0.9%)     Sidekiq::LoggingUtils#add
        79   (0.6%)          79   (0.6%)     Redis::Connection::Hiredis#write
        68   (0.5%)          68   (0.5%)     Sidekiq::Processor#constantize
      9834  (69.8%)          62   (0.4%)     Redis#_bpop
```
So, `14.0 - 9.1 = 5%` ⚡️  cpu savings

For object allocations:
**Before**:
```
==================================
  Mode: object(1)
  Samples: 8206264 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
   2300072  (28.0%)     2300072  (28.0%)     Sidekiq::Processor#cloned
   1500042  (18.3%)     1500042  (18.3%)     #<Module:0x00007fc3751fb568>.parse
   4000164  (48.7%)      900028  (11.0%)     Sidekiq::Processor#dispatch
   2304025  (28.1%)      500591   (6.1%)     ConnectionPool#with
    400898   (4.9%)      400898   (4.9%)     Redis::Connection::Hiredis#write
   1200326  (14.6%)      400052   (4.9%)     Redis#_bpop
```

**After**:
```
==================================
  Mode: object(1)
  Samples: 7105331 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
   1500042  (21.1%)     1500042  (21.1%)     #<Module:0x00007ff923367648>.parse
   1200036  (16.9%)     1200036  (16.9%)     Sidekiq::Processor#deep_dup
   2900112  (40.8%)      900028  (12.7%)     Sidekiq::Processor#dispatch
   2303422  (32.4%)      500491   (7.0%)     ConnectionPool#with
    400749   (5.6%)      400749   (5.6%)     Redis::Connection::Hiredis#write
   1200306  (16.9%)      400052   (5.6%)     Redis#_bpop
```

So, `28.0 - 16.9 = 11%` memory savings.


Profiling with `memory_profiler`, I got more accurate results for memory:
**Before**:
```
Total allocated: 695737343 bytes (6904607 objects)
Total retained:  12702768 bytes (972 objects)
```

**After**:
```
Total allocated: 606804659 bytes (5704475 objects)
Total retained:  12699800 bytes (962 objects)
```

So, savings in bytes: `(695737343 - 606804659) / 695737343.0 * 100 = 13%` ⚡️ 
Savings in objects:    `(6904607  - 5704475) / 6904607.0 * 100 = 17.5%` ⚡️ 


Another isolated benchmark:
```ruby
# frozen_string_literal: true

require "benchmark/ips"

def deep_dup(obj)
  case obj
  when Integer, Float, TrueClass, FalseClass, NilClass
    return obj
  when String
    return obj.dup
  when Array
    duped = Array.new(obj.size)
    duped.each_with_index do |value, index|
      duped[index] = deep_dup(value)
    end
  when Hash
    duped = obj.dup
    duped.each_pair do |key, value|
      duped[key] = deep_dup(value)
    end
  else
    duped = obj.dup
  end

  duped
end

def deep_dup_without_case(obj)
  if Integer === obj || Float === obj || TrueClass === obj || FalseClass === obj || NilClass === obj
    return obj
  elsif String === obj
    return obj.dup
  elsif Array === obj
    duped = Array.new(obj.size)
    obj.each_with_index do |value, index|
      duped[index] = deep_dup_without_case(value)
    end
  elsif Hash === obj
    duped = obj.dup
    duped.each_pair do |key, value|
      duped[key] = deep_dup_without_case(value)
    end
  else
    duped = obj.dup
  end

  duped
end


obj = { "class" => "FooWorker", "args" => [1, 2, 3, "foobar"], "jid" => "123987123" }

Benchmark.ips do |x|
  x.report("marshal") do
    Marshal.load(Marshal.dump(obj))
  end

  x.report("deep_dup") do
    deep_dup(obj)
  end

  x.report("deep_dup_without_case") do
    deep_dup_without_case(obj)
  end

  x.compare!
end
```

Results:
```
Warming up --------------------------------------
             marshal    11.146k i/100ms
            deep_dup    13.970k i/100ms
deep_dup_without_case
                        16.752k i/100ms
Calculating -------------------------------------
             marshal    105.758k (±13.8%) i/s -    523.862k in   5.083462s
            deep_dup    178.748k (± 3.3%) i/s -    894.080k in   5.008318s
deep_dup_without_case
                        200.419k (± 2.0%) i/s -      1.005M in   5.017126s

Comparison:
deep_dup_without_case:   200419.0 i/s
            deep_dup:   178748.4 i/s - 1.12x  slower
             marshal:   105758.2 i/s - 1.90x  slower
```

So while it seems that if-else is a bit uglier than case/when, it is much faster.