### PR TITLE
Improve fault tolerance of rescheduling jobs using API

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -471,8 +471,9 @@ module Sidekiq
     end
 
     def reschedule(at)
-      delete
-      @parent.schedule(at, item)
+      Sidekiq.redis do |conn|
+        conn.zincrby(@parent.name, at - @score, Sidekiq.dump_json(@item))
+      end
     end
 
     def add_to_queue


### PR DESCRIPTION
This eliminates probability of job being lost when `delete` succeeds but `schedule` fails, and reduces redis roundtrips to 1. 