### PR TITLE
Prefer the faster and more idiomatic Array#map in json_clone

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -279,9 +279,9 @@ module Sidekiq
     # been mutated by the worker.
     def json_clone(obj)
       if Integer === obj || Float === obj || TrueClass === obj || FalseClass === obj || NilClass === obj
-        return obj
+        obj
       elsif String === obj
-        return obj.dup
+        obj.dup
       elsif Array === obj
         obj.map { |e| json_clone(e) }
       elsif Hash === obj
@@ -289,11 +289,10 @@ module Sidekiq
         duped.each_pair do |key, value|
           duped[key] = json_clone(value)
         end
+        duped
       else
-        duped = obj.dup
+        obj.dup
       end
-
-      duped
     end
   end
 end

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -283,10 +283,7 @@ module Sidekiq
       elsif String === obj
         return obj.dup
       elsif Array === obj
-        duped = Array.new(obj.size)
-        obj.each_with_index do |value, index|
-          duped[index] = json_clone(value)
-        end
+        obj.map { |e| json_clone(e) }
       elsif Hash === obj
         duped = obj.dup
         duped.each_pair do |key, value|


### PR DESCRIPTION
Prefer the faster Array#map to a manual implementation
* On the benchmark from #4303 on MRI 2.6.4,
  before 396657.9 i/s, after 461013.3 i/s (1.16x faster).
  This is also faster on JRuby and TruffleRuby.
  See for https://github.com/mperham/sidekiq/pull/4303#issuecomment-538761252 for more details.

* Use `duped` as the return value in the only branch it's needed
