### PR TITLE
Faster Hash duping in #json_clone

### DIFF
--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -278,10 +278,10 @@ module Sidekiq
     # the job fails, what is pushed back onto Redis hasn't
     # been mutated by the worker.
     def json_clone(obj)
-      if Integer === obj || Float === obj || TrueClass === obj || FalseClass === obj || NilClass === obj
-        obj
-      elsif String === obj
+      if String === obj
         obj.dup
+      elsif Integer === obj || Float === obj || TrueClass === obj || FalseClass === obj || NilClass === obj
+        obj
       elsif Array === obj
         obj.map { |e| json_clone(e) }
       elsif Hash === obj

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -285,8 +285,8 @@ module Sidekiq
       elsif Array === obj
         obj.map { |e| json_clone(e) }
       elsif Hash === obj
-        duped = obj.dup
-        duped.each_pair do |key, value|
+        duped = {}
+        obj.each_pair do |key, value|
           duped[key] = json_clone(value)
         end
         duped


### PR DESCRIPTION
Another 20% speedup.
```ruby
# frozen_string_literal: true

require "benchmark/ips"

def deep_dup(obj)
  if Integer === obj || Float === obj || TrueClass === obj || FalseClass === obj || NilClass === obj
    return obj
  elsif String === obj
    return obj.dup
  elsif Array === obj
    duped = Array.new(obj.size)
    obj.each_with_index do |value, index|
      duped[index] = deep_dup(value)
    end
  elsif Hash === obj
    duped = obj.dup
    duped.each_pair do |key, value|
      duped[key] = deep_dup(value)
    end
  else
    duped = obj.dup
  end

  duped
end

def deep_dup_optimized_hash(obj)
  if Integer === obj || Float === obj || TrueClass === obj || FalseClass === obj || NilClass === obj
    return obj
  elsif String === obj
    return obj.dup
  elsif Array === obj
    duped = Array.new(obj.size)
    obj.each_with_index do |value, index|
      duped[index] = deep_dup_optimized_hash(value)
    end
  elsif Hash === obj
    duped = {}
    obj.each_pair do |key, value|
      duped[key] = deep_dup_optimized_hash(value)
    end
  else
    duped = obj.dup
  end

  duped
end


obj = { "class" => "FooWorker", "args" => [1, 2, 3, "foobar"], "jid" => "123987123" }

Benchmark.ips do |x|
  x.report("deep_dup") do
    deep_dup(obj)
  end

  x.report("deep_dup_optimized_hash") do
    deep_dup_optimized_hash(obj)
  end

  x.compare!
end
```

```
Warming up --------------------------------------
            deep_dup    17.844k i/100ms
deep_dup_optimized_hash
                        21.410k i/100ms
Calculating -------------------------------------
            deep_dup    201.132k (± 2.2%) i/s -      1.017M in   5.059471s
deep_dup_optimized_hash
                        236.528k (± 5.6%) i/s -      1.178M in   5.001678s

Comparison:
deep_dup_optimized_hash:   236527.5 i/s
            deep_dup:   201132.1 i/s - 1.18x  slower
```

cc @eregon 