### PR TITLE
Refactor Processor to avoid costly json cloning

### DIFF
--- a/test/test_retry_exhausted.rb
+++ b/test/test_retry_exhausted.rb
@@ -55,7 +55,7 @@ describe 'sidekiq_retries_exhausted' do
   end
 
   def job(options={})
-    @job ||= {'class' => 'Bob', 'args' => [1, 2, 'foo']}.merge(options)
+    @job ||= Sidekiq.dump_json({'class' => 'Bob', 'args' => [1, 2, 'foo']}.merge(options))
   end
 
   it 'does not run exhausted block when job successful on first run' do


### PR DESCRIPTION
These are the easiest changes that I figured out. But I'm wondering, won't we broke something changing `#dispatch` method's signature?

**Cpu**
**Before**:
```
==================================
  Mode: cpu(200)
  Samples: 59013 (1.43% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     26104  (44.2%)       26104  (44.2%)     Hiredis::Ext::Connection#read
      6377  (10.8%)        6377  (10.8%)     #<Module:0x00007f882c32be58>.parse  <==========
     34450  (58.4%)        4886   (8.3%)     Redis#_bpop
      3218   (5.5%)        3218   (5.5%)     Redis::Connection::Hiredis#write
      2788   (4.7%)        2788   (4.7%)     Sidekiq::Processor#json_clone <===========
      2585   (4.4%)        2585   (4.4%)     Sidekiq::Processor#constantize
     40383  (68.4%)        2292   (3.9%)     ConnectionPool#with
      1722   (2.9%)        1722   (2.9%)     Sidekiq::BasicFetch#queues_cmd
      1734   (2.9%)        1626   (2.8%)     ConnectionPool#checkout
      1413   (2.4%)        1413   (2.4%)     Sidekiq::BasicFetch::UnitOfWork#acknowledge
     18457  (31.3%)        1042   (1.8%)     Sidekiq::Processor#process
      1121   (1.9%)         913   (1.5%)     Sidekiq::JobLogger#elapsed_time_context
       610   (1.0%)         610   (1.0%)     Sidekiq::Processor::SharedWorkerState#set
```

**After**:
```
  Mode: cpu(200)
  Samples: 51854 (1.14% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     34815  (67.1%)       34815  (67.1%)     Hiredis::Ext::Connection#read
     41530  (80.1%)        3342   (6.4%)     Redis#_bpop
      3193   (6.2%)        3193   (6.2%)     #<Module:0x00007fbb413b3b58>.parse  <========
      3054   (5.9%)        3054   (5.9%)     Redis::Connection::Hiredis#write
     45107  (87.0%)        1330   (2.6%)     ConnectionPool#with
      1089   (2.1%)        1089   (2.1%)     Sidekiq::BasicFetch#queues_cmd
       958   (1.8%)         958   (1.8%)     Sidekiq::Processor#constantize
      1066   (2.1%)         937   (1.8%)     ConnectionPool#checkout
       801   (1.5%)         801   (1.5%)     Sidekiq::BasicFetch::UnitOfWork#acknowledge
       413   (0.8%)         413   (0.8%)     Sidekiq::Processor::SharedWorkerState#set
```

So, `(10.8 + 4.7) - 6.2 = 9%` cpu savings.

**Memory**
**Before**:
```
Total allocated: 791162313 bytes (8204869 objects)
Total retained:  12760248 bytes (1096 objects)
```

**After**:
```
Total allocated: 742302988 bytes (7604373 objects)
Total retained:  12759849 bytes (1086 objects)
```

Memory savings: `(791162313 - 742302988) / 791162313.0 * 100 = 6%`

**Actual time to process 100_000 jobs**:
**Before**:
```
$ bin/sidekiqload
2019-10-07T23:34:07.565Z pid=7282 tid=ox1ou89zm ERROR: Created 100000 jobs
2019-10-07T23:34:20.158Z pid=7282 tid=ox1pc1za2 ERROR: Done, 100000 jobs in 12.592829 sec
```

**After**:
```
bin/sidekiqload
2019-10-07T23:32:53.266Z pid=6724 tid=oxorzg0bg ERROR: Created 100000 jobs
2019-10-07T23:33:03.390Z pid=6724 tid=oxos41o7w ERROR: Done, 100000 jobs in 10.122964 sec
```