### PR TITLE
Dump error backtraces as json before compressing

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -254,7 +254,7 @@ module Sidekiq
     end
 
     def compress_backtrace(backtrace)
-      serialized = Marshal.dump(backtrace)
+      serialized = Sidekiq.dump_json(backtrace)
       compressed = Zlib::Deflate.deflate(serialized)
       Base64.encode64(compressed)
     end


### PR DESCRIPTION
**For not so large backtrace**:
```
bin/sidekiqload:33:in `perform'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:193:in `execute_job'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:161:in `block (2 levels) in process'
/Users/mikeperham/src/sidekiq/lib/sidekiq/middleware/chain.rb:133:in `invoke'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:160:in `block in process'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:133:in `block (6 levels) in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/job_retry.rb:107:in `local'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:132:in `block (5 levels) in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq.rb:37:in `block in <module:Sidekiq>'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:128:in `block (4 levels) in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:254:in `stats'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:123:in `block (3 levels) in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/job_logger.rb:13:in `call'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:122:in `block (2 levels) in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/job_retry.rb:75:in `global'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:121:in `block in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/logger.rb:10:in `with_context'
/Users/mikeperham/src/sidekiq/lib/sidekiq/job_logger.rb:27:in `with_job_hash_context'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:120:in `dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:159:in `process'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:78:in `process_one'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:68:in `run'
/Users/mikeperham/src/sidekiq/lib/sidekiq/util.rb:17:in `watchdog'
/Users/mikeperham/src/sidekiq/lib/sidekiq/util.rb:26:in `block in safe_thread'
```

Before: 582 bytes
After: 488 bytes
Redis memory savings: `(582 - 488) / 582.0 * 100 = 16%`

**For gigantic ActiveJob backtrace**:
```
/Users/mikeperham/src/sidekiq/myapp/app/jobs/some_job.rb:7:in `perform'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/execution.rb:39:in `block in perform_now'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:112:in `block in run_callbacks'
/Users/mikeperham/.gem/ruby/2.5.1/gems/i18n-1.6.0/lib/i18n.rb:297:in `with_locale'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/translation.rb:9:in `block (2 levels) in <module:Translation>'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:121:in `instance_exec'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/core_ext/time/zones.rb:66:in `use_zone'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/timezones.rb:9:in `block (2 levels) in <module:Timezones>'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:121:in `instance_exec'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/logging.rb:25:in `block (4 levels) in <module:Logging>'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/notifications.rb:180:in `block in instrument'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/notifications.rb:180:in `instrument'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/logging.rb:24:in `block (3 levels) in <module:Logging>'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/logging.rb:45:in `block in tag_logger'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/tagged_logging.rb:80:in `block in tagged'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/tagged_logging.rb:28:in `tagged'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/tagged_logging.rb:80:in `tagged'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/logging.rb:45:in `tag_logger'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/logging.rb:21:in `block (2 levels) in <module:Logging>'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:121:in `instance_exec'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:139:in `run_callbacks'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/execution.rb:38:in `perform_now'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/execution.rb:24:in `block in execute'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:112:in `block in run_callbacks'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/railtie.rb:43:in `block (4 levels) in <class:Railtie>'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/execution_wrapper.rb:88:in `wrap'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/reloader.rb:72:in `block in wrap'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/execution_wrapper.rb:84:in `wrap'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/reloader.rb:71:in `wrap'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/railtie.rb:42:in `block (3 levels) in <class:Railtie>'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:121:in `instance_exec'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/callbacks.rb:139:in `run_callbacks'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/execution.rb:22:in `execute'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activejob-6.0.0/lib/active_job/queue_adapters/sidekiq_adapter.rb:42:in `perform'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:193:in `execute_job'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:161:in `block (2 levels) in process'
/Users/mikeperham/src/sidekiq/lib/sidekiq/middleware/chain.rb:133:in `invoke'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:160:in `block in process'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:133:in `block (6 levels) in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/job_retry.rb:110:in `local'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:132:in `block (5 levels) in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/rails.rb:43:in `block in call'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/execution_wrapper.rb:88:in `wrap'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/reloader.rb:72:in `block in wrap'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/execution_wrapper.rb:88:in `wrap'
/Users/mikeperham/.gem/ruby/2.5.1/gems/activesupport-6.0.0/lib/active_support/reloader.rb:71:in `wrap'
/Users/mikeperham/src/sidekiq/lib/sidekiq/rails.rb:42:in `call'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:128:in `block (4 levels) in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:254:in `stats'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:123:in `block (3 levels) in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/job_logger.rb:13:in `call'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:122:in `block (2 levels) in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/job_retry.rb:78:in `global'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:121:in `block in dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/logger.rb:10:in `with_context'
/Users/mikeperham/src/sidekiq/lib/sidekiq/job_logger.rb:27:in `with_job_hash_context'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:120:in `dispatch'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:159:in `process'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:78:in `process_one'
/Users/mikeperham/src/sidekiq/lib/sidekiq/processor.rb:68:in `run'
/Users/mikeperham/src/sidekiq/lib/sidekiq/util.rb:17:in `watchdog'
/Users/mikeperham/src/sidekiq/lib/sidekiq/util.rb:26:in `block in safe_thread'
```

Before: 1273 bytes
After: 1103 bytes
Redis memory savings: `(1273 - 1103) / 1273.0 * 100 = 13.5%`