### PR TITLE
Use MultiJson to dump/load json, so users can control which json coder is used

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    sidekiq (6.0.2)
+    sidekiq (6.0.3)
       connection_pool (>= 2.2.2)
+      multi_json
       rack (>= 2.0.0)
       rack-protection (>= 2.0.0)
       redis (>= 4.1.0)
@@ -93,6 +94,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    multi_json (1.14.1)
     nio4r (2.5.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
@@ -194,3 +196,6 @@ DEPENDENCIES
   sqlite3
   standard
   toxiproxy
+
+BUNDLED WITH
+   2.0.2

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -175,11 +175,11 @@ module Sidekiq
   end
 
   def self.load_json(string)
-    JSON.parse(string)
+    MultiJson.load(string)
   end
 
   def self.dump_json(object)
-    JSON.generate(object)
+    MultiJson.dump(object)
   end
 
   def self.log_formatter

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -624,7 +624,7 @@ module Sidekiq
     def find_job(jid)
       Sidekiq.redis do |conn|
         conn.zscan_each(name, match: "*#{jid}*", count: 100) do |entry, score|
-          job = JSON.parse(entry)
+          job = MultiJson.load(entry)
           matched = job["jid"] == jid
           return SortedEntry.new(self, score, entry) if matched
         end
@@ -645,7 +645,7 @@ module Sidekiq
         elements = conn.zrangebyscore(name, score, score)
         elements.each do |element|
           if element.index(jid)
-            message = Sidekiq.load_json(element)
+            message = MultiJson.load(element)
             if message["jid"] == jid
               ret = conn.zrem(name, element)
               @_size -= 1 if ret

--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "redis", ">= 4.1.0"
   gem.add_dependency "connection_pool", ">= 2.2.2"
+  gem.add_dependency "multi_json"
   gem.add_dependency "rack", ">= 2.0.0"
   gem.add_dependency "rack-protection", ">= 2.0.0"
 end

--- a/test/test_job_logger.rb
+++ b/test/test_job_logger.rb
@@ -53,7 +53,7 @@ class TestJobLogger < Minitest::Test
     a, b = @output.string.lines
     assert a
     assert b
-    hsh = JSON.parse(a)
+    hsh = MultiJson.load(a)
     keys = hsh.keys.sort
     assert_equal(["ctx", "lvl", "msg", "pid", "tid", "ts"], keys)
     keys = hsh["ctx"].keys.sort

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -94,13 +94,13 @@ class TestLogger < Minitest::Test
       @logger.info("json format")
     end
     a, b = @output.string.lines
-    hash = JSON.parse(a)
+    hash = MultiJson.load(a)
     keys = hash.keys.sort
     assert_equal ["lvl", "msg", "pid", "tid", "ts"], keys
     assert_nil hash["ctx"]
     assert_equal hash["lvl"], "DEBUG"
 
-    hash = JSON.parse(b)
+    hash = MultiJson.load(b)
     keys = hash.keys.sort
     assert_equal ["ctx", "lvl", "msg", "pid", "tid", "ts"], keys
     refute_nil hash["ctx"]


### PR DESCRIPTION
It would be really great, if users could control which json coder is used. Using `MultiJson` gives this flexibility.

I personally have various issues with default `JSON` coder, and prefer to use `oj`, which is faster and can handle encoding issues and work on non UTF-8 strings.