### PR TITLE
Allow to use different json coders through json_loader and json_dumper config options.

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -35,6 +35,8 @@ module Sidekiq
     dead_max_jobs: 10_000,
     dead_timeout_in_seconds: 180 * 24 * 60 * 60, # 6 months
     reloader: proc { |&block| block.call },
+    json_loader: proc { |string| JSON.parse(string) },
+    json_dumper: proc { |object| JSON.generate(object) },
   }
 
   DEFAULT_WORKER_OPTIONS = {
@@ -175,11 +177,11 @@ module Sidekiq
   end
 
   def self.load_json(string)
-    JSON.parse(string)
+    options[:json_loader].call(string)
   end
 
   def self.dump_json(object)
-    JSON.generate(object)
+    options[:json_dumper].call(object)
   end
 
   def self.log_formatter

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -624,7 +624,7 @@ module Sidekiq
     def find_job(jid)
       Sidekiq.redis do |conn|
         conn.zscan_each(name, match: "*#{jid}*", count: 100) do |entry, score|
-          job = JSON.parse(entry)
+          job = Sidekiq.load_json(entry)
           matched = job["jid"] == jid
           return SortedEntry.new(self, score, entry) if matched
         end


### PR DESCRIPTION
Alternative solution to fix problem described in https://github.com/mperham/sidekiq/pull/4359.

It allows users to use different json coders by specifying  `json_loader` and `json_dumper` through configuration options. Default values are set to `JSON` coder's methods (`JSON.parse` / `JSON.generate`).

Example to use different engine:
```ruby
Sidekiq.options[:json_loader] = ->(string) { Oj.load(string) }
Sidekiq.options[:json_dumper] = ->(object) { Oj.dump(object) }
```