### PR TITLE
Fixes CI build

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -103,10 +103,8 @@ module Sidekiq
         if scrubbed_options[:password]
           scrubbed_options[:password] = redacted
         end
-        if scrubbed_options[:sentinels]
-          scrubbed_options[:sentinels].each do |sentinel|
-            sentinel[:password] = redacted if sentinel[:password]
-          end
+        scrubbed_options[:sentinels]&.each do |sentinel|
+          sentinel[:password] = redacted if sentinel[:password]
         end
         if Sidekiq.server?
           Sidekiq.logger.info("Booting Sidekiq #{Sidekiq::VERSION} with redis options #{scrubbed_options}")


### PR DESCRIPTION
Use SafeNavigation for possible missing value

Context: CI was failing because of StandardRB Rules
```
#!/bin/bash -eo pipefail
bundle exec rake
standard: Use Ruby Standard Style (https://github.com/testdouble/standard)
standard: Run `rake standard:fix` to automatically fix some problems.
  lib/sidekiq/redis_connection.rb:106:9: Style/SafeNavigation: Use safe navigation (`&.`) instead of checking if an object exists before calling the method.
```