### PR TITLE
Follow generator configuration to determine the resulting test file

### DIFF
--- a/lib/generators/sidekiq/worker_generator.rb
+++ b/lib/generators/sidekiq/worker_generator.rb
@@ -18,7 +18,7 @@ module Sidekiq
       def create_test_file
         return unless test_framework
 
-        if defined?(RSpec)
+        if test_framework == :rspec
           create_worker_spec
         else
           create_worker_test

--- a/test/test_worker_generator.rb
+++ b/test/test_worker_generator.rb
@@ -38,4 +38,19 @@ class WorkerGeneratorTest < Rails::Generators::TestCase
       g.test_framework :test_case
     end
   end
+
+  test 'respects rails config test_framework option for rspec' do
+    Rails.application.config.generators do |g|
+      g.test_framework :rspec
+    end
+
+    run_generator ['foo']
+
+    assert_file 'app/workers/foo_worker.rb'
+    assert_file 'spec/workers/foo_worker_spec.rb'
+  ensure
+    Rails.application.config.generators do |g|
+      g.test_framework :test_case
+    end
+  end
 end


### PR DESCRIPTION
Verifying that `RSpec` is defined assumes that the library is loaded on
the same environment that the generator is running.

It is often common to not have the rspec gem required on development,
which is the default environment to run the generator from.

Following the configured generator removes the assumption and works as
expected without breaking expectations.