### PR TITLE
Introduce the ability to pause queue from the UI

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -191,6 +191,10 @@ module Sidekiq
     Sidekiq::Logging.logger = log
   end
 
+  def self.pro?
+    defined?(Sidekiq::Pro)
+  end
+
   # How frequently Redis should be checked by a random Sidekiq process for
   # scheduled and retriable jobs. Each individual process will take turns by
   # waiting some multiple of this value.

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -242,17 +242,9 @@ module Sidekiq
       Sidekiq.redis { |con| con.llen(@rname) }
     end
 
-    # Sidekiq Pro overrides pause?, pause! and unpause! functions
+    # Sidekiq Pro overrides this
     def paused?
       false
-    end
-
-    def pause!
-      nil
-    end
-
-    def unpause!
-      nil
     end
 
     ##

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -242,9 +242,17 @@ module Sidekiq
       Sidekiq.redis { |con| con.llen(@rname) }
     end
 
-    # Sidekiq Pro overrides this
+    # Sidekiq Pro overrides pause?, pause! and unpause! functions
     def paused?
       false
+    end
+
+    def pause!
+      nil
+    end
+
+    def unpause!
+      nil
     end
 
     ##

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -91,7 +91,13 @@ module Sidekiq
     end
 
     post "/queues/:name" do
-      Sidekiq::Queue.new(route_params[:name]).clear
+      if params['pause']
+        Sidekiq::Queue.new(route_params[:name]).pause!
+      elsif params['unpause']
+        Sidekiq::Queue.new(route_params[:name]).unpause!
+      else
+        Sidekiq::Queue.new(route_params[:name]).clear
+      end
 
       redirect "#{root_path}queues"
     end

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -91,9 +91,9 @@ module Sidekiq
     end
 
     post "/queues/:name" do
-      if params['pause']
+      if Sidekiq.pro? && params['pause']
         Sidekiq::Queue.new(route_params[:name]).pause!
-      elsif params['unpause']
+      elsif Sidekiq.pro? && params['unpause']
         Sidekiq::Queue.new(route_params[:name]).unpause!
       else
         Sidekiq::Queue.new(route_params[:name]).clear

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -91,12 +91,14 @@ module Sidekiq
     end
 
     post "/queues/:name" do
+      queue = Sidekiq::Queue.new(route_params[:name])
+
       if Sidekiq.pro? && params['pause']
-        Sidekiq::Queue.new(route_params[:name]).pause!
+        queue.pause!
       elsif Sidekiq.pro? && params['unpause']
-        Sidekiq::Queue.new(route_params[:name]).unpause!
+        queue.unpause!
       else
-        Sidekiq::Queue.new(route_params[:name]).clear
+        queue.clear
       end
 
       redirect "#{root_path}queues"

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -149,8 +149,46 @@ describe Sidekiq::Web do
   end
 
   it 'can attempt to pause a queue' do
+    Sidekiq.stub(:pro?, true) do
+      mock = Minitest::Mock.new
+      mock.expect :pause!, true
+
+      stub = lambda do |queue_name|
+        assert_equal 'foo', queue_name
+        mock
+      end
+
+      Sidekiq::Queue.stub :new, stub do
+        post '/queues/foo', 'pause' => 'pause'
+        assert_equal 302, last_response.status
+      end
+
+      assert_mock mock
+    end
+  end
+
+  it 'can attempt to unpause a queue' do
+    Sidekiq.stub(:pro?, true) do
+      mock = Minitest::Mock.new
+      mock.expect :unpause!, true
+
+      stub = lambda do |queue_name|
+        assert_equal 'foo', queue_name
+        mock
+      end
+
+      Sidekiq::Queue.stub :new, stub do
+        post '/queues/foo', 'unpause' => 'unpause'
+        assert_equal 302, last_response.status
+      end
+
+      assert_mock mock
+    end
+  end
+
+  it 'ignores to attempt to pause a queue with pro disabled' do
     mock = Minitest::Mock.new
-    mock.expect :pause!, true
+    mock.expect :clear, true
 
     stub = lambda do |queue_name|
       assert_equal 'foo', queue_name
@@ -165,9 +203,9 @@ describe Sidekiq::Web do
     assert_mock mock
   end
 
-  it 'can attempt to unpause a queue' do
+  it 'ignores to attempt to unpause a queue with pro disabled' do
     mock = Minitest::Mock.new
-    mock.expect :unpause!, true
+    mock.expect :clear, true
 
     stub = lambda do |queue_name|
       assert_equal 'foo', queue_name

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -148,6 +148,40 @@ describe Sidekiq::Web do
     end
   end
 
+  it 'can attempt to pause a queue' do
+    mock = Minitest::Mock.new
+    mock.expect :pause!, true
+
+    stub = lambda do |queue_name|
+      assert_equal 'foo', queue_name
+      mock
+    end
+
+    Sidekiq::Queue.stub :new, stub do
+      post '/queues/foo', 'pause' => 'pause'
+      assert_equal 302, last_response.status
+    end
+
+    assert_mock mock
+  end
+
+  it 'can attempt to unpause a queue' do
+    mock = Minitest::Mock.new
+    mock.expect :unpause!, true
+
+    stub = lambda do |queue_name|
+      assert_equal 'foo', queue_name
+      mock
+    end
+
+    Sidekiq::Queue.stub :new, stub do
+      post '/queues/foo', 'unpause' => 'unpause'
+      assert_equal 302, last_response.status
+    end
+
+    assert_mock mock
+  end
+
   it 'can delete a job' do
     Sidekiq.redis do |conn|
       conn.rpush('queue:foo', "{\"args\":[]}")

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -24,9 +24,13 @@ en: # <---- change this to your locale code
   ShowAll: Show All
   CurrentMessagesInQueue: Current jobs in <span class='title'>%{queue}</span>
   Delete: Delete
+  Pause: Pause
+  Unpause: Unpause
   AddToQueue: Add to queue
   AreYouSureDeleteJob: Are you sure you want to delete this job?
   AreYouSureDeleteQueue: Are you sure you want to delete the %{queue} queue?
+  AreYouSurePauseQueue: Are you sure you want to pause the %{queue} queue?
+  AreYouSureUnpauseQueue: Are you sure you want to unpause the %{queue} queue?
   Queues: Queues
   Size: Size
   Actions: Actions

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -24,13 +24,9 @@ en: # <---- change this to your locale code
   ShowAll: Show All
   CurrentMessagesInQueue: Current jobs in <span class='title'>%{queue}</span>
   Delete: Delete
-  Pause: Pause
-  Unpause: Unpause
   AddToQueue: Add to queue
   AreYouSureDeleteJob: Are you sure you want to delete this job?
   AreYouSureDeleteQueue: Are you sure you want to delete the %{queue} queue?
-  AreYouSurePauseQueue: Are you sure you want to pause the %{queue} queue?
-  AreYouSureUnpauseQueue: Are you sure you want to unpause the %{queue} queue?
   Queues: Queues
   Size: Size
   Actions: Actions
@@ -83,3 +79,5 @@ en: # <---- change this to your locale code
   CreatedAt: Created At
   BackToApp: Back to App
   Latency: Latency
+  Pause: Pause
+  Unpause: Unpause

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -24,9 +24,9 @@
             <input class="btn btn-danger btn-xs" type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteQueue', :queue => h(queue.name)) %>" />
 
             <% if queue.paused? %>
-              <input class="btn btn-danger btn-xs" type="submit" name="unpause" value="<%= t('Unpause') %>" data-confirm="<%= t('AreYouSureUnpauseQueue', :queue => h(queue.name)) %>" />
+              <input class="btn btn-danger btn-xs" type="submit" name="unpause" value="<%= t('Unpause') %>" />
             <% else %>
-              <input class="btn btn-danger btn-xs" type="submit" name="pause" value="<%= t('Pause') %>" data-confirm="<%= t('AreYouSurePauseQueue', :queue => h(queue.name)) %>" />
+              <input class="btn btn-danger btn-xs" type="submit" name="pause" value="<%= t('Pause') %>" />
             <% end %>
           </form>
         </td>

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -22,6 +22,12 @@
           <form action="<%=root_path %>queues/<%= CGI.escape(queue.name) %>" method="post">
             <%= csrf_tag %>
             <input class="btn btn-danger btn-xs" type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteQueue', :queue => h(queue.name)) %>" />
+
+            <% if queue.paused? %>
+              <input class="btn btn-danger btn-xs" type="submit" name="unpause" value="<%= t('Unpause') %>" data-confirm="<%= t('AreYouSureUnpauseQueue', :queue => h(queue.name)) %>" />
+            <% else %>
+              <input class="btn btn-danger btn-xs" type="submit" name="pause" value="<%= t('Pause') %>" data-confirm="<%= t('AreYouSurePauseQueue', :queue => h(queue.name)) %>" />
+            <% end %>
           </form>
         </td>
       </tr>

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -23,10 +23,12 @@
             <%= csrf_tag %>
             <input class="btn btn-danger btn-xs" type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteQueue', :queue => h(queue.name)) %>" />
 
-            <% if queue.paused? %>
-              <input class="btn btn-danger btn-xs" type="submit" name="unpause" value="<%= t('Unpause') %>" />
-            <% else %>
-              <input class="btn btn-danger btn-xs" type="submit" name="pause" value="<%= t('Pause') %>" />
+            <% if Sidekiq.pro? %>
+              <% if queue.paused? %>
+                <input class="btn btn-danger btn-xs" type="submit" name="unpause" value="<%= t('Unpause') %>" />
+              <% else %>
+                <input class="btn btn-danger btn-xs" type="submit" name="pause" value="<%= t('Pause') %>" />
+              <% end %>
             <% end %>
           </form>
         </td>


### PR DESCRIPTION
Considering sidekiq web UI allow to perform complex tasks with ease.
Having the ability to pause a queue during an emergency (or operational intense)
scenarios would come in quite handy.

This PR introduces a new button to under the "Actions" column on `sidekiq/queues` pages,
right next to the `Delete` button. Depending on the state of the queue, it will according
show the `Pause` or `Unpause` text, with appropriate form element that `POST`s to the same
endpoint. The endpoint logic is updated to handle the new cases. Added some relevant unit tests.

Adding mock `Sidekiq::Queue#pause!` and `Sidekiq::Queue#unpause!` functions to
the API, which I believe will be overridden by sidekiq pro.

Original request: https://github.com/mperham/sidekiq/issues/4343

**Examples**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/1100970/68793248-b8009000-0601-11ea-812d-c3c21b710a7c.png">
<img width="1416" alt="image" src="https://user-images.githubusercontent.com/1100970/68793332-dc5c6c80-0601-11ea-9500-64fdc69fde02.png">

**Open questions**
- [ ] `Sidekiq::Queue#pause!` is a feature on sidekiq pro. Showing the `pause` button in the UI on regular sidekiq could be misleading, since it would be a no-op? 
  - Maybe it should be hidden through some custom check/feature-flag-esque behavior? And/or ported to sidekiq pro?
- [ ] Added new copy to `en.yml`, translations would need to be accordingly handled?