### PR TITLE
Removing fetcher and stopped? methods

### DIFF
--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -19,7 +19,7 @@ module Sidekiq
       proc { |me, data| "stopping" if me.stopping? },
     ]
 
-    attr_accessor :manager, :poller, :fetcher
+    attr_accessor :manager, :poller
 
     def initialize(options)
       @manager = Sidekiq::Manager.new(options)

--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -97,10 +97,6 @@ module Sidekiq
       end
     end
 
-    def stopped?
-      @done
-    end
-
     private
 
     def hard_shutdown


### PR DESCRIPTION
Hey, I noticed that the `fetcher` attr_accessor in launcher.rb seems to not be used anymore. I'm proposing to remove it along with the `stopped?` in `manager.rb` method which is not used as well. 