### PR TITLE
Silence Ruby 2.7 warnings

### DIFF
--- a/lib/sidekiq/logger.rb
+++ b/lib/sidekiq/logger.rb
@@ -104,7 +104,7 @@ module Sidekiq
   class Logger < ::Logger
     include LoggingUtils
 
-    def initialize(*args)
+    def initialize(*args, **kwargs)
       super
       self.formatter = Sidekiq.log_formatter
     end

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -108,6 +108,14 @@ class TestLogger < Minitest::Test
     assert_equal "INFO", hash["lvl"]
   end
 
+  def test_forwards_logger_kwargs
+    assert_silent do
+      logger = Sidekiq::Logger.new('/dev/null', level: Logger::INFO)
+
+      assert_equal Logger::INFO, logger.level
+    end
+  end
+
   def reset(io)
     io.truncate(0)
     io.rewind


### PR DESCRIPTION
Since you can pass kwargs to Logger.new, you need to explicitly handle them in the subclass otherwise you get a warning.