### PR TITLE
Type=notify alternative in sidekiq.service systemd example

### DIFF
--- a/examples/systemd/sidekiq.service
+++ b/examples/systemd/sidekiq.service
@@ -25,6 +25,14 @@ After=syslog.target network.target
 # times! systemd is a critical tool for all developers to know and understand.
 #
 [Service]
+# You may want to use
+# Type=notify
+# to ensure service is not marked as started before it actually did.
+# Include sd_notify gem to send a message on sidekiq startup like
+#   Sidekiq.configure_server do |config|
+#     config.on(:startup) { SdNotify.ready }
+#   end
+# to let systemd know when the service is actually started.
 Type=simple
 WorkingDirectory=/opt/myapp/current
 # If you use rbenv:


### PR DESCRIPTION
With `Type=simple` systemd marks the service as started immediately.
Together with instant restart, it may fool monitoring tools and deployment scripts in case of a problem with sidekiq, resulting in all workers being considered as deployed, but actually failed.

Add a comment describing an alternative configuration with `Type=notify` and a reference to configuration that will notify systemd when sidekiq workers have actually started and are ready to process jobs. With this configuration `systemctl start sidekiq` command will actually wait for sidekiq worker to be able to process jobs.

@mperham WDYT?