### PR TITLE
Use `unlink`, not `del`, for performance

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ HEAD
 ---------
 
 - Fix broken Web UI response when using NewRelic and Rack 2.1.2+. [#4440]
+- Update APIs to use `UNLINK`, not `DEL`.
 
 6.0.4
 ---------

--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,7 @@ HEAD
 ---------
 
 - Fix broken Web UI response when using NewRelic and Rack 2.1.2+. [#4440]
-- Update APIs to use `UNLINK`, not `DEL`.
+- Update APIs to use `UNLINK`, not `DEL`. [#4449]
 
 6.0.4
 ---------

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -273,7 +273,7 @@ module Sidekiq
     def clear
       Sidekiq.redis do |conn|
         conn.multi do
-          conn.del(@rname)
+          conn.unlink(@rname)
           conn.srem("queues", name)
         end
       end
@@ -562,7 +562,7 @@ module Sidekiq
 
     def clear
       Sidekiq.redis do |conn|
-        conn.del(name)
+        conn.unlink(name)
       end
     end
     alias_method :💣, :clear

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -83,7 +83,7 @@ module Sidekiq
       Sidekiq.redis do |conn|
         conn.pipelined do
           conn.srem("processes", identity)
-          conn.del("#{identity}:workers")
+          conn.unlink("#{identity}:workers")
         end
       end
     rescue
@@ -118,7 +118,7 @@ module Sidekiq
             conn.incrby("stat:failed:#{nowdate}", fails)
             conn.expire("stat:failed:#{nowdate}", STATS_TTL)
 
-            conn.del(workers_key)
+            conn.unlink(workers_key)
             curstate.each_pair do |tid, hash|
               conn.hset(workers_key, tid, Sidekiq.dump_json(hash))
             end


### PR DESCRIPTION
This makes deleting/clearing large queues much faster.