### PR TITLE
fix content security policy

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -10,7 +10,7 @@ module Sidekiq
       "default-src 'self' https: http:",
       "child-src 'self'",
       "connect-src 'self' https: http: wss: ws:",
-      "font-src 'self' https: http:",
+      "font-src 'self' https: http: data:",
       "frame-src 'self'",
       "img-src 'self' https: http: data:",
       "manifest-src 'self'",


### PR DESCRIPTION
I see a lot of errors in the developer web console 
![image](https://user-images.githubusercontent.com/2146069/74036023-8747b100-49cc-11ea-9b9b-0f2c69a90e52.png)
this PR fixes it.