### PR TITLE
Fixes regression after refactoring (Closes #4456)

### DIFF
--- a/lib/sidekiq/ctl.rb
+++ b/lib/sidekiq/ctl.rb
@@ -18,10 +18,10 @@ class Sidekiq::Ctl
     puts
     puts "       <pidfile> is path to a pidfile"
     puts "       <kill_timeout> is number of seconds to wait until Sidekiq exits"
-    puts "       (default: #{Sidekiqctl::DEFAULT_KILL_TIMEOUT}), after which Sidekiq will be KILL'd"
+    puts "       (default: #{Sidekiq::Ctl::DEFAULT_KILL_TIMEOUT}), after which Sidekiq will be KILL'd"
     puts
     puts "       <section> (optional) view a specific section of the status output"
-    puts "       Valid sections are: #{Sidekiqctl::Status::VALID_SECTIONS.join(', ')}"
+    puts "       Valid sections are: #{Sidekiq::Ctl::Status::VALID_SECTIONS.join(', ')}"
     puts
     puts "Be sure to set the kill_timeout LONGER than Sidekiq's -t timeout.  If you want"
     puts "to wait 60 seconds for jobs to finish, use `sidekiq -t 60` and `sidekiqctl stop"


### PR DESCRIPTION
With the refactoring done in the commit 4d883194350cf9202ff5c1650730dfa5ee3d2e06, the `sidekiqctl` command was crashing with the error `NameError: uninitialized constant Sidekiq::Ctl::Sidekiqctl` which this commit solve.

This PR solves the issue #4456.