### PR TITLE
Fix logger level query methods

### DIFF
--- a/lib/sidekiq/logger.rb
+++ b/lib/sidekiq/logger.rb
@@ -31,23 +31,23 @@ module Sidekiq
     end
 
     def debug?
-      level >= 0
+      level <= 0
     end
 
     def info?
-      level >= 1
+      level <= 1
     end
 
     def warn?
-      level >= 2
+      level <= 2
     end
 
     def error?
-      level >= 3
+      level <= 3
     end
 
     def fatal?
-      level >= 4
+      level <= 4
     end
 
     def local_level

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -116,6 +116,18 @@ class TestLogger < Minitest::Test
     end
   end
 
+  def test_log_level_query_methods
+    logger = Sidekiq::Logger.new('/dev/null', level: Logger::INFO)
+
+    refute_predicate logger, :debug?
+    assert_predicate logger, :info?
+    assert_predicate logger, :warn?
+
+    logger.level = Logger::WARN
+    refute_predicate logger, :info?
+    assert_predicate logger, :warn?
+  end
+
   def reset(io)
     io.truncate(0)
     io.rewind


### PR DESCRIPTION
The `LoggingUtils` module has incorrect implementations of the level inspection methods.

These should return true if the current level is *lower* than the checked level (e.g. `info?` returns true if the current level is `Logger::DEBUG`).