### PR TITLE
Document APP_ENV changes in 6.0.5

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ HEAD
 - Fix broken Web UI response when using NewRelic and Rack 2.1.2+. [#4440]
 - Update APIs to use `UNLINK`, not `DEL`. [#4449]
 - Fix Ruby 2.7 warnings [#4412]
+- Add support for `APP_ENV` [[95fa5d9]](https://github.com/mperham/sidekiq/commit/95fa5d90192148026e52ca2902f1b83c70858ce8)
 
 6.0.4
 ---------


### PR DESCRIPTION
Hello,

First of all, thanks so much for Sidekiq; it's a wonderful piece of software.

Unfortunately upgrading from `6.0.4` to `6.0.5` was a breaking change for us. We, regrettably, vary `APP_ENV` between Staging & Production environments as a basic feature-flag, but not `RAILS_ENV` (which is always production).

This is a foible in our codebase, however we didn't spot this the changlog section when updating via Dependabot, so I've added it to hopefully save someone else the same potential issue.

Thanks again 😃 