### PR TITLE
Add Lithuanian locale

### DIFF
--- a/web/locales/lt.yml
+++ b/web/locales/lt.yml
@@ -1,0 +1,83 @@
+# elements like %{queue} are variables and should not be translated
+lt:
+  Dashboard: Valdymo skydas
+  Status: Būsena
+  Time: Laikas
+  Namespace: Vardų erdvė
+  Realtime: Realiu laiku
+  History: Istorija
+  Busy: Užimti
+  Processed: Įvykdyti
+  Failed: Nepavykę
+  Scheduled: Suplanuoti
+  Retries: Kartojami
+  Enqueued: Eilėje
+  Worker: Darbuotojas
+  LivePoll: Užklausti gyvai
+  StopPolling: Stabdyti užklausas
+  Queue: Eilė
+  Class: Klasė
+  Job: Darbas
+  Arguments: Parametrai
+  Extras: Papildomi
+  Started: Pradėti
+  ShowAll: Rodyti Visus
+  CurrentMessagesInQueue: Esami darbai eilėje <span class='title'>%{queue}</span>
+  Delete: Pašalinti
+  AddToQueue: Pridėti į eilę
+  AreYouSureDeleteJob: Ar tikrai norite pašalinti šį darbą?
+  AreYouSureDeleteQueue: Ar tikrai norite pašalinti šią eilę %{queue}?
+  Queues: Eilės
+  Size: Dydis
+  Actions: Veiksmai
+  NextRetry: Sekantis Kartojimas
+  RetryCount: Kartojimų Skaičius
+  RetryNow: Kartoti Dabar
+  Kill: Priverstinai Nutraukti
+  LastRetry: Paskutinis Kartojimas
+  OriginallyFailed: Iš pradžių Nepavykę
+  AreYouSure: Ar jūs įsitikinę?
+  DeleteAll: Pašalinti Visus
+  RetryAll: Kartoti Visus
+  KillAll: Priverstinai Nutraukti Visus
+  NoRetriesFound: Nerasta kartojimų
+  Error: Klaida
+  ErrorClass: Klaidos Klasė
+  ErrorMessage: Klaidos Žinutė
+  ErrorBacktrace: Klaidos Pėdsakai
+  GoBack: ← Atgal
+  NoScheduledFound: Planuojamų darbų nerasta
+  When: Kada
+  ScheduledJobs: Planuojami Darbai
+  idle: neveiksnus
+  active: aktyvus
+  Version: Versija
+  Connections: Ryšiai
+  MemoryUsage: Atminties Vartojimas
+  PeakMemoryUsage: Atminties Vartojimo Pikas
+  Uptime: Gyvavimo laikas (dienomis)
+  OneWeek: 1 savaitė
+  OneMonth: 1 mėnuo
+  ThreeMonths: 3 mėnesiai
+  SixMonths: 6 mėnesiai
+  Failures: Nesėkmingi vykdymai
+  DeadJobs: Negyvi Darbai
+  NoDeadJobsFound: Negyvų darbų nerasta
+  Dead: Negyvi
+  Processes: Procesai
+  Thread: Gija
+  Threads: Gijos
+  Jobs: Darbai
+  Paused: Pristabdytas
+  Stop: Sustabdyti
+  Quiet: Nutildyti
+  StopAll: Sustbadyti Visus
+  QuietAll: Nutildyti Visus
+  PollingInterval: Užklausimų intervalas
+  Plugins: Įskiepiai
+  NotYetEnqueued: Dar neįtraukti į eilę
+  CreatedAt: Sukurta
+  BackToApp: Atgal į Aplikaciją
+  Latency: Vėlavimas
+  Pause: Pristabdyti
+  Unpause: Pratęsti


### PR DESCRIPTION
I was inspired by the Russian OSS community when I saw the Sidekiq dashboard localized in Russian. 

Hence I decided to provide locales for my fellow Lithuanian colleagues working with Sidekiq.

Adding a screenshot too:

![image](https://user-images.githubusercontent.com/3352737/75976650-8169c080-5ee3-11ea-8824-0c602f7a77f2.png)
