### PR TITLE
Backwards compatibility for options in rails 5.1

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -233,6 +233,9 @@ module Sidekiq
       # merge in the default sidekiq_options for the item's class and/or wrapped element
       # this allows ActiveJobs to control sidekiq_options too.
       defaults = normalized_hash(item["class"])
+      if item["wrapped"].is_a?(String)
+        item["wrapped"] = item["wrapped"].constantize
+      end
       defaults = defaults.merge(item["wrapped"].get_sidekiq_options) if item["wrapped"].respond_to?("get_sidekiq_options")
       item = defaults.merge(item)
 


### PR DESCRIPTION
This commit https://github.com/rails/rails/commit/0e64348ccaf513de731f403259ec5b49e7b3f028
 moves from passing a string in the wrapper key to passing a class.
Therefore in rails 5.1 the following does not show a backtrace in the sidekiq UI

```
class FuckedJob < ApplicationJob
  sidekiq_options retry: 0,  backtrace: 50
  def perform
    raise "NOOOOOOOOOO"
  end
end
```

We are a bit weary of moving to rails 6 on this one client project because code coverage isn't all that great yet. 
Maybe someone else has the same problem so here you go!


