### PR TITLE
Do not connect to redis at exit if not needed

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 HEAD
 ---------
 
+- Fix: Do not connect to redis at ruby vm exit when not needed. [#4502] 
 - Remove Redis connection naming [#4479]
 
 6.0.6


### PR DESCRIPTION
A fix for https://github.com/mperham/sidekiq/issues/4498 introduced a callback that is executed at ruby VM exit and tries to connect to redis.

This callback is also executed in CI runs and in all other cases where sidekiq is loaded but not used with real redis.

As a work-around, keep the at_exit hook but communicate to redis only if there is something to send, i.e. the number of processed or failed jobs is greater than zero