### PR TITLE
Add suggestion to remove WatchdogSec=5 line for Sidekiq < 6.0.6

### DIFF
--- a/examples/systemd/sidekiq.service
+++ b/examples/systemd/sidekiq.service
@@ -31,7 +31,8 @@ After=syslog.target network.target
 #      !!!!  !!!!  !!!!
 #
 # As of v6.0.6, Sidekiq automatically supports systemd's `Type=notify` and watchdog service
-# monitoring. If you are using an earlier version of Sidekiq, change this to `Type=simple`.
+# monitoring. If you are using an earlier version of Sidekiq, change this to `Type=simple`
+# and remove the `WatchdogSec=5` line.
 #
 #      !!!!  !!!!  !!!!
 #


### PR DESCRIPTION
I'm not 100% sure if my comment in `sidekiq.service` is right but in my case (I'm using Sidekiq 5.x) my Sidekiq process kept getting restarted every 5 seconds until I removed the `WatchdogSec=5` line. Assuming that removing that line is the right move for Sidekiq < 6.0.6, it seems like it would be nice if there were instructions saying so.