### PR TITLE
Ensure Rack::ContentLength is loaded as middleware

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 Unreleased
 ---------
 
+- Ensure `Rack::ContentLength` is loaded as middleware for correct Web UI responses [#4541]
 - Avoid exception dumping SSL store in Redis connection logging [#4532]
 
 6.0.7

--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -12,6 +12,7 @@ require "sidekiq/web/action"
 require "sidekiq/web/application"
 
 require "rack/protection"
+require "rack/content_length"
 
 require "rack/builder"
 require "rack/file"
@@ -171,6 +172,13 @@ module Sidekiq
         options = options.merge(s.to_hash) if s.respond_to? :to_hash
 
         middlewares.unshift [[::Rack::Session::Cookie, options], nil]
+      end
+
+      # Since Sidekiq::WebApplication no longer calculates its own
+      # Content-Length response header, we must ensure that the Rack middleware
+      # that does this is loaded
+      unless using? ::Rack::ContentLength
+        middlewares.unshift [[::Rack::ContentLength], nil]
       end
     end
 


### PR DESCRIPTION
6.0.5 removed `Sidekiq::WebApplication`'s own Content-Length header calculation, expecting Rack to do it instead via some middleware (https://github.com/mperham/sidekiq/commit/675e40c32684a7e89987673b82b5241545763fcb). This was to fix an issue where New Relic would inject content into Sidekiq's Web UI after the hand crafted content length was calculated (#4440). While such middleware exists, it's not enabled by default (at least in a Rails app) and so the HTTP response doesn't have the header at all.

The absence of the header has caused unexpected behaviour in an nginx and HAProxy setup we use in production systems, causing each page load to take exactly 20 seconds. The suspicion is that, without the Content-Length response header, HAProxy waits a preset amount of time before deciding the body must have surely by finished and then responds.