### PR TITLE
Dark mode fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@
 Unreleased
 ---------
 
-- Web UI - Dark Mode fixes [#4543]
+- Web UI - Dark Mode fixes [#4543, natematykiewicz]
 - Ensure `Rack::ContentLength` is loaded as middleware for correct Web UI responses [#4541]
 - Avoid exception dumping SSL store in Redis connection logging [#4532]
 

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 Unreleased
 ---------
 
+- Web UI - Dark Mode fixes [#4543]
 - Ensure `Rack::ContentLength` is loaded as middleware for correct Web UI responses [#4541]
 - Avoid exception dumping SSL store in Redis connection logging [#4532]
 

--- a/web/assets/stylesheets/application-dark.css
+++ b/web/assets/stylesheets/application-dark.css
@@ -1,5 +1,5 @@
-body {
-  background-color: #000;
+html, body {
+  background-color: #070707 !important;
   color: #ccc;
 }
 
@@ -51,7 +51,7 @@ table.table-white {
 }
 
 .alert-success {
-  background-color: #000;
+  background-color: #182d11;
 }
 
 a:link,
@@ -66,8 +66,12 @@ a.btn {
 }
 
 .summary_bar .summary {
-  background-color: #000;
+  background-color: #111;
   border: 1px solid #333;
+
+  -webkit-box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
+  -moz-box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
+  box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
 }
 
 .navbar-default {
@@ -114,6 +118,13 @@ a.btn {
 
 .btn-warn {
   color: #333;
+}
+
+.rickshaw_graph .detail {
+  background: rgba(255, 255, 255, .1)
+}
+.rickshaw_graph .x_tick {
+  border-color: rgba(255, 255, 255, .2);
 }
 
 .rickshaw_graph .y_ticks.glow text {

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -469,6 +469,11 @@ span.current-interval {
 
 div.interval-slider input {
   width: 160px;
+  -webkit-appearance: none;
+  height: 3px;
+  margin-top: 5px;
+  border-radius: 2px;
+  background: currentcolor;
 }
 
 #realtime-legend,


### PR DESCRIPTION
* "Polling Interval" slider not visible in Safari / Firefox
* Dark background not full height in Firefox
  (add color to html tag, use !important since default is !important)
* "Success" banner not visible
* Graph vertical bars (both static and hover bars) not visible
* Make UI a little more consistent with light mode
  * Slightly lighten background, for a differing color between
    header/footer and body.
  * Add shadow and different color to "status" bar

_Note: The slider on light mode subtly changed, to support dark mode consistently_

# Dark Dashboard - Before
<img width="1735" alt="dark dashboard - before" src="https://user-images.githubusercontent.com/5104186/80295702-94a64900-873a-11ea-9561-e15838625a3b.png">

# Dark Dashboard - After
<img width="1735" alt="dark dashboard - after" src="https://user-images.githubusercontent.com/5104186/80295661-3da07400-873a-11ea-8d64-767e092f1bd1.png">

# Dark Success - Before
<img width="1735" alt="dark success - before" src="https://user-images.githubusercontent.com/5104186/80295670-485b0900-873a-11ea-9d2b-eca0aacbd00a.png">

# Dark Success - After
<img width="1735" alt="dark success - after" src="https://user-images.githubusercontent.com/5104186/80295674-4e50ea00-873a-11ea-9663-078fa6ef6948.png">

# Light Dashboard - Before
![light - before](https://user-images.githubusercontent.com/5104186/80295678-56108e80-873a-11ea-856e-abca695ba814.png)

# Light Dashboard - After
![light - after](https://user-images.githubusercontent.com/5104186/80295680-5c9f0600-873a-11ea-8997-0e55d54cfc49.png)

