### PR TITLE
Exclude :ssl_params from Redis options clone without ActiveSupport

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -97,7 +97,12 @@ module Sidekiq
         redacted = "REDACTED"
 
         # deep clone so we can muck with these options all we want
-        scrubbed_options = Marshal.load(Marshal.dump(options.except(:ssl_params)))
+        #
+        # exclude SSL params from dump-and-load because some information isn't
+        # safely dumpable in current Rubies
+        keys = options.keys
+        keys.delete(:ssl_params)
+        scrubbed_options = Marshal.load(Marshal.dump(options.slice(*keys)))
         if scrubbed_options[:url] && (uri = URI.parse(scrubbed_options[:url])) && uri.password
           uri.password = redacted
           scrubbed_options[:url] = uri.to_s


### PR DESCRIPTION
In dd0a8476 we started filtering out SSL params from the Redis options
cloning for logging purposes to prevent an undumpable
`OpenSSL::X509::Store` from raising an exception. The fix used
ActiveSupport's `Hash#except` to exclude the `:ssl_params` key from the
hash before cloning the options hash by dumping and reloading.

As ActiveSupport is not a requirement for Sidekiq, we need a more
generally-available solution. This change removes the key using
`Hash#slice` by including every top-level options key _except_
`:ssl_params`.

See https://github.com/mperham/sidekiq/pull/4532#issuecomment-620894721

cc: #4532