### PR TITLE
Remove a redundant`.empty?` check before setting `default` queue

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Unreleased
 - Ensure `Rack::ContentLength` is loaded as middleware for correct Web UI responses [#4541]
 - Avoid exception dumping SSL store in Redis connection logging [#4532]
 - Better error messages in Sidekiq::Client [#4549]
+- Refactor `Sidekiq::CLI` to remove a redundant `.empty?` method call [#4552]
 
 6.0.7
 ---------

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -228,7 +228,7 @@ module Sidekiq
       opts = parse_config(opts[:config_file]).merge(opts) if opts[:config_file]
 
       # set defaults
-      opts[:queues] = ["default"] if opts[:queues].nil? || opts[:queues].empty?
+      opts[:queues] = ["default"] if opts[:queues].nil?
       opts[:strict] = true if opts[:strict].nil?
       opts[:concurrency] = Integer(ENV["RAILS_MAX_THREADS"]) if opts[:concurrency].nil? && ENV["RAILS_MAX_THREADS"]
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -117,10 +117,20 @@ describe Sidekiq::CLI do
           end
 
           describe 'when queues are empty' do
-            it "sets 'default' queue" do
-              subject.parse(%w[sidekiq -r ./test/fake_env.rb])
+            describe 'when no queues are specified via -q' do
+              it "sets 'default' queue" do
+                subject.parse(%w[sidekiq -r ./test/fake_env.rb])
 
-              assert_equal ['default'], Sidekiq.options[:queues]
+                assert_equal ['default'], Sidekiq.options[:queues]
+              end
+            end
+
+            describe 'when no queues are specified via the config file' do
+              it "sets 'default' queue" do
+                subject.parse(%w[sidekiq -C ./test/config_empty.yml -r ./test/fake_env.rb])
+
+                assert_equal ['default'], Sidekiq.options[:queues]
+              end
             end
           end
         end


### PR DESCRIPTION
### Why?

This change has been made because:

By default, sidekiq sets a `default` queue when no queue has been specified via `-q` or the `config.yml` file.

To set this `default` queue, we currently a`.empty?` check on `opts[:queues]` after performing a `.nil?` on the same object.

But, this `.empty?` check is redundant, because according to the current code and its execution flow, `opts[:queues]` cannot be `empty`, it can only be `nil`

#### History:

In the beginning: There was only a `.empty?` check: 
Eg: https://github.com/mperham/sidekiq/blob/v5.0.0/lib/sidekiq/cli.rb#L278

Here, `.empty?` was a valid check, because the queues specified via `-q` or the `config.yml` file was already merged with the [default sidekiq options](https://github.com/mperham/sidekiq/blob/v5.0.0/lib/sidekiq.rb#L19) (which has `queues` set to `[]` by default), so in a scenario where no queues have been specified, the value of `options[:queues] ` would be `[]`, which responds to `.empty?`.

And then came: https://github.com/mperham/sidekiq/commit/1d835551f0174a31697a5203e27148d61372cb25#diff-411201f0104d91346964914342a07cefR252,

where we started setting the `default` queue, even before the user-supplied configs were merged with the sidekiq defaults.

This change rightly added the `opts[:queues].nil?` check, but did not remove the existing`opts[:queues].empty?` check.


#### Changes:

At this point, the `.empty?` check is redundant, because when no queues are specified and before merging with Sidekiq defaults, the value of `opts[:queues]` will always be `nil`.

Hence:

1. The `opts[:queues].empty?` check has been removed.
2. An additional test case has been added, where it asserts that a `default` queue is added when no queues are specified via the `config` file.

### Further:

In a further iteration, would it make sense to have Sidekiq config have the `default` queue by default?, so like

```ruby
module Sidekiq
  NAME = "Sidekiq"
  LICENSE = "See LICENSE and the LGPL-3.0 for licensing details."

  DEFAULTS = {
    queues: ['default'],
    labels: [],
   ...
}


