### PR TITLE
Fix: Ensure `strict` order is followed when queues without weights are specified via the `-q` option

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Unreleased
 - Ensure `Rack::ContentLength` is loaded as middleware for correct Web UI responses [#4541]
 - Avoid exception dumping SSL store in Redis connection logging [#4532]
 - Better error messages in Sidekiq::Client [#4549]
+- Ensure `strict` order is followed when queues without weights are specified via the `-q` option [#4554]
 
 6.0.7
 ---------

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -20,6 +20,7 @@ module Sidekiq
     labels: [],
     concurrency: 10,
     require: ".",
+    strict: true,
     environment: nil,
     timeout: 25,
     poll_interval_average: nil,

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -229,7 +229,6 @@ module Sidekiq
 
       # set defaults
       opts[:queues] = ["default"] if opts[:queues].nil? || opts[:queues].empty?
-      opts[:strict] = true if opts[:strict].nil?
       opts[:concurrency] = Integer(ENV["RAILS_MAX_THREADS"]) if opts[:concurrency].nil? && ENV["RAILS_MAX_THREADS"]
 
       # merge with defaults
@@ -379,6 +378,7 @@ module Sidekiq
 
     def parse_queue(opts, queue, weight = nil)
       opts[:queues] ||= []
+      opts[:strict] = true if opts[:strict].nil?
       raise ArgumentError, "queues: #{queue} cannot be defined twice" if opts[:queues].include?(queue)
       [weight.to_i, 1].max.times { opts[:queues] << queue }
       opts[:strict] = false if weight.to_i > 0

--- a/test/config_queues_without_weights.yml
+++ b/test/config_queues_without_weights.yml
@@ -1,0 +1,4 @@
+---
+:queues:
+  - [queue_1]
+  - [queue_2]

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -228,6 +228,99 @@ describe Sidekiq::CLI do
               assert_equal 7, Sidekiq.options[:queues].count { |q| q == 'often' }
               assert_equal 3, Sidekiq.options[:queues].count { |q| q == 'seldom' }
             end
+
+            describe 'when the config file specifies queues with weights' do
+              describe 'when -q specifies queues without weights' do
+                it 'sets strictly ordered queues' do
+                  subject.parse(%w[sidekiq -C ./test/config.yml
+                                        -r ./test/fake_env.rb
+                                        -q foo -q bar])
+
+                  assert_equal true, !!Sidekiq.options[:strict]
+                end
+              end
+
+              describe 'when -q specifies no queues' do
+                it 'does not set strictly ordered queues' do
+                  subject.parse(%w[sidekiq -C ./test/config.yml
+                                        -r ./test/fake_env.rb])
+
+                  assert_equal false, !!Sidekiq.options[:strict]
+                end
+              end
+
+              describe 'when -q specifies queues with weights' do
+                it 'does not set strictly ordered queues' do
+                  subject.parse(%w[sidekiq -C ./test/config.yml
+                                        -r ./test/fake_env.rb
+                                        -q foo,2 -q bar,3])
+
+                  assert_equal false, !!Sidekiq.options[:strict]
+                end
+              end
+            end
+
+            describe 'when the config file specifies queues without weights' do
+              describe 'when -q specifies queues without weights' do
+                it 'sets strictly ordered queues' do
+                  subject.parse(%w[sidekiq -C ./test/config_queues_without_weights.yml
+                                        -r ./test/fake_env.rb
+                                        -q foo -q bar])
+
+                  assert_equal true, !!Sidekiq.options[:strict]
+                end
+              end
+
+              describe 'when -q specifies no queues' do
+                it 'sets strictly ordered queues' do
+                  subject.parse(%w[sidekiq -C ./test/config_queues_without_weights.yml
+                                        -r ./test/fake_env.rb])
+
+                  assert_equal true, !!Sidekiq.options[:strict]
+                end
+              end
+
+              describe 'when -q specifies queues with weights' do
+                it 'does not set strictly ordered queues' do
+                  subject.parse(%w[sidekiq -C ./test/config_queues_without_weights.yml
+                                        -r ./test/fake_env.rb
+                                        -q foo,2 -q bar,3])
+
+                  assert_equal false, !!Sidekiq.options[:strict]
+                end
+              end
+            end
+
+            describe 'when the config file specifies no queues' do
+              describe 'when -q specifies queues without weights' do
+                it 'sets strictly ordered queues' do
+                  subject.parse(%w[sidekiq -C ./test/config_empty.yml
+                                        -r ./test/fake_env.rb
+                                        -q foo -q bar])
+
+                  assert_equal true, !!Sidekiq.options[:strict]
+                end
+              end
+
+              describe 'when -q specifies no queues' do
+                it 'sets strictly ordered queues' do
+                  subject.parse(%w[sidekiq -C ./test/config_empty.yml
+                                        -r ./test/fake_env.rb])
+
+                  assert_equal true, !!Sidekiq.options[:strict]
+                end
+              end
+
+              describe 'when -q specifies queues with weights' do
+                it 'does not set strictly ordered queues' do
+                  subject.parse(%w[sidekiq -C ./test/config_empty.yml
+                                        -r ./test/fake_env.rb
+                                        -q foo,2 -q bar,3])
+
+                  assert_equal false, !!Sidekiq.options[:strict]
+                end
+              end
+            end
           end
 
           describe 'default config file' do


### PR DESCRIPTION
## Background

In sidekiq, the queues specified via `-q` takes precedence over the queues mentioned via the `config` file.

> Options passed on the command line will also override options specified in the config file.

Also, Sidekiq follows "strict ordering" for queues, if the queues are specified without weights. This means that jobs in the next queue are processed only if the previous queues are empty. This is tracked internally using `Sidekiq.options[:strict]`

> If you want queues always processed in a specific order, just declare them in order without weights: As arguments...

> sidekiq -q critical -q default -q low

## Bug

In a scenario where the config file contains weighted queues, but non-weighted queue names are specified via the `-q` option, Sidekiq currently does not set the value of `Sidekiq.options[:strict]` correctly.

Eg:
`config.yml`
```yml
---
:concurrency:  50
:queues:
  - [very, 2]
  - [seldom, 1]
```

And sidekiq is booted as:

`sidekiq -q very -q seldom -q my_queue -C config.yml`.

Expected behaviour: `Sidekiq.options[:strict]` is set to `true`
Current behaviour: `Sidekiq.options[:strict]` is set to `false`, that is, it is set as per the weights present in `config.yml` and the fact that "queues specified via -q should take precedence over the ones mentioned in config" is not being respected.

## Fix

1. Set `strict` to be `true` in Sidekiq defaults. This is done so that in the case where no queues are specified by both `-q` or the config file, the ordering will default to `strict` (so that strict ordering will be followed for the `default` queue we add internally, in case no queues are specified).
2. I've added a fix to set `options[:strict]` to `true` by default, before starting to parse the queue config. This makes sure that `options[:strict]` will always have a `true` value (and not `nil`) and hence the merging of config file options and command line options work as expected [here](https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/cli.rb#L228).
3. In the case where at least one queue is specified by either `-q` or the `config` file, the correct value of `strict` will be set during the parsing phase and this value will override the Sidekiq's default value upon executing [this](https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/cli.rb#L236) line.
4. I've also added a few more tests to make sure that the changes work as expected in multiple scenarios.