### PR TITLE
Add Queue#delete_jobs_from

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -261,6 +261,12 @@ module Sidekiq
       end
     end
 
+    def delete_jobs_from(klass)
+      each do |job|
+        job.delete if job.klass == klass
+      end
+    end
+
     ##
     # Find the job with the given JID within this queue.
     #

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -234,6 +234,17 @@ describe 'API' do
       assert_equal 0, q.size
     end
 
+    it 'can delete jobs by klass' do
+      q = Sidekiq::Queue.new
+      Time.stub(:now, Time.new(2012, 12, 26)) do
+        10.times { ApiWorker.perform_async(1, 'mike') }
+        assert_equal 10, q.size
+
+        q.delete_jobs_from('ApiWorker')
+        assert_equal 0, q.size
+      end
+    end
+
     it 'enumerates jobs in descending score order' do
       # We need to enqueue more than 50 items, which is the page size when retrieving
       # from Redis to ensure everything is sorted: the pages and the items withing them.


### PR DESCRIPTION
This makes it a bit easier to cleanup and repair a queue from a bad job. Which tends to be the most common case for using the `Sidekiq::Queue#each` method in my experience. This is crucial when you're in a hurry and said bad job is hammering a datastore to the point where it's impacting your whole application.

Before this addition, you had to do the following:

```ruby
queue.each { |job| job.delete if job.klass == "BadWorker" }
```

While definitely not bad, this is a bit of a contortion. My goal for this new API was to be shorter to type than the original, have no block or conditional and be easier to remember. Hence the following:

```ruby
queue.delete_jobs_from "BadWorker"
```

This also avoids having to know about the `Sidekiq::Job` API.

---

@mperham I notice too late that you prefer having an issue first before opening a PR. But given I already made the commit, I thought I would open this as a PR immediately anyway and we can discuss the legitimacy of this new feature here. Feel free to close if not in line with your design goals.