### PR TITLE
Do not allow to set  internal options via the config file

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -357,6 +357,12 @@ module Sidekiq
       Sidekiq.logger.level = ::Logger::DEBUG if options[:verbose]
     end
 
+    INTERNAL_OPTIONS = [
+      # These are options that are set internally and cannot be
+      # set via the config file or command line arguments.
+      :strict
+    ]
+
     def parse_config(path)
       opts = YAML.load(ERB.new(File.read(path)).result) || {}
 
@@ -367,6 +373,8 @@ module Sidekiq
       end
 
       opts = opts.merge(opts.delete(environment.to_sym) || {})
+      opts.delete(*INTERNAL_OPTIONS)
+
       parse_queues(opts, opts.delete(:queues) || [])
 
       opts

--- a/test/config_with_internal_options.yml
+++ b/test/config_with_internal_options.yml
@@ -1,0 +1,11 @@
+---
+:verbose:      false
+:timeout:      10
+:require:      ./test/fake_env.rb
+:concurrency:  50
+:tag:          tag
+:queues:
+  - [often]
+  - [seldom]
+
+:strict:       false

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -62,6 +62,16 @@ describe Sidekiq::CLI do
           end
         end
 
+        describe 'setting internal options via the config file' do
+          describe 'setting the `strict` option via the config file' do
+            it 'discards the `strict` option specified via the config file' do
+              subject.parse(%w[sidekiq -C ./test/config_with_internal_options.yml])
+
+              assert_equal true, !!Sidekiq.options[:strict]
+            end
+          end
+        end
+
         describe 'queues' do
           it 'accepts with -q' do
             subject.parse(%w[sidekiq -q foo -r ./test/fake_env.rb])


### PR DESCRIPTION
## Background

Sidekiq allows to set config options via the `config.yml` file. However, presently any `key` present in the config file will be parsed and it's value will be set while reading the config file.

While this is harmless for the most part, there are some options which are set internally, based on internal logic - these options should not be allowed to be set via the `config` file, as the value specified via the config file could be different from what would have been set via Sidekiq's internal logic.

One such option is `strict` - which specifies whether Sidekiq should follow strict ordering for the queues when processing jobs.

In a scenario where we specify non-weighted queues, `strict` is supposed to be set to `true`.

## Problem

Currently, it is possible to set `strict` via the `config` file. As an example, imagine the scenario where we define non-weighted queues, but also define `strict: false`.

```yml
---
:concurrency:  50
:queues:
  - [often]
  - [seldom]

:strict: false

```

This would be problematic because Sidekiq is always supposed to follow strict ordering for non-weighted queues.

## Fix

I've tried to fix this behaviour by setting up a `block-list` of attributes named `INTERNAL_OPTIONS`. Currently, this contains only `strict`.

This block-list is supposed to contain all options that are not supposed to be set via the command line or the config file.

Once the config file is parsed, the options specified in the block list are removed, so that only Sidekiq's internal logic can set these options.