### PR TITLE
Avoid pushing TIMEOUT information to the end of the array of queues

### DIFF
--- a/test/test_fetch.rb
+++ b/test/test_fetch.rb
@@ -30,10 +30,23 @@ describe Sidekiq::BasicFetch do
     assert_nil uow.acknowledge
   end
 
-  it 'retrieves with strict setting' do
-    fetch = Sidekiq::BasicFetch.new(:queues => ['basic', 'bar', 'bar'], :strict => true)
-    cmd = fetch.queues_cmd
-    assert_equal cmd, ['queue:basic', 'queue:bar', Sidekiq::BasicFetch::TIMEOUT]
+  describe 'retrieves with strict setting' do
+    describe 'with strict: true' do
+      it 'fetches queues in strict order' do
+        fetch = Sidekiq::BasicFetch.new(:queues => ['basic', 'bar', 'bar'], strict: true)
+        queues = fetch.queues_cmd
+        assert_equal queues, ['queue:basic', 'queue:bar']
+      end
+    end
+
+    describe 'with strict: false' do
+      it 'fetches queues in shuffled order' do
+        fetch = Sidekiq::BasicFetch.new(:queues => ['basic', 'bar', 'bar'], strict: false)
+        queues = fetch.queues_cmd
+        assert_includes queues, 'queue:basic'
+        assert_includes queues, 'queue:bar'
+      end
+    end
   end
 
   it 'bulk requeues' do


### PR DESCRIPTION
## Background

To fetch job data contained in the queues, Sidekiq uses the `redis` command `brpop`, which blocks the connection when there are no elements to pop from the given list of queues.

However, we do not want to always block the connection (Sidekiq will just work on forever in that case), so we also supply a `TIMEOUT`  (of 2 seconds) to prevent this.

## Change

Right now, `TIMEOUT` is also pushed to the end of array once, if the queues are strictly ordered.
In case of queues that are not strictly ordered, `TIMEOUT` data is being pushed to the end of the array every time a call to the `queues_cmd` method is made. 

While inserts to the end of the array are `O(1)`, we could avoid pushing the timeout information to this array completely, and instead just pass the timeout information as an argument to the redis client 
directly. This appears to be the recommended way as per the [docs](https://github.com/redis/redis-rb/blob/master/lib/redis.rb#L1220).

PS: It also appears that passing `timeout` information as the last element in the array *could* be deprecated by Redis client sometime in the future. [Source](https://github.com/redis/redis-rb/blob/f597f21a6b954b685cf939febbc638f6c803e3a7/lib/redis/distributed.rb#L409)