### PR TITLE
Define Reloader class before callback that uses it

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -4,6 +4,22 @@ require "sidekiq/worker"
 
 module Sidekiq
   class Rails < ::Rails::Engine
+    class Reloader
+      def initialize(app = ::Rails.application)
+        @app = app
+      end
+
+      def call
+        @app.reloader.wrap do
+          yield
+        end
+      end
+
+      def inspect
+        "#<Sidekiq::Rails::Reloader @app=#{@app.class.name}>"
+      end
+    end
+
     # By including the Options module, we allow AJs to directly control sidekiq features
     # via the *sidekiq_options* class method and, for instance, not use AJ's retry system.
     # AJ retries don't show up in the Sidekiq UI Retries tab, save any error data, can't be
@@ -23,29 +39,11 @@ module Sidekiq
 
     # This hook happens after all initializers are run, just before returning
     # from config/environment.rb back to sidekiq/cli.rb.
-    # We have to add the reloader after initialize to see if cache_classes has
-    # been turned on.
     #
     # None of this matters on the client-side, only within the Sidekiq process itself.
     config.after_initialize do
       Sidekiq.configure_server do |_|
         Sidekiq.options[:reloader] = Sidekiq::Rails::Reloader.new
-      end
-    end
-
-    class Reloader
-      def initialize(app = ::Rails.application)
-        @app = app
-      end
-
-      def call
-        @app.reloader.wrap do
-          yield
-        end
-      end
-
-      def inspect
-        "#<Sidekiq::Rails::Reloader @app=#{@app.class.name}>"
       end
     end
   end


### PR DESCRIPTION
If the application has already been loaded before this file is required, the `after_initialize` callback runs immediately, but the Reloader class isn't defined yet.

In our case, this happens because we're preloading our application code before invoking Sidekiq Enterprise's sidekiqswarm command, to maximise the copy-on-write memory savings.

Also remove a comment about `cache_classes` that has been irrelevant since https://github.com/mperham/sidekiq/pull/3235.