### PR TITLE
Allow newer rack version due to directory traversal security bug

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'redis', '>= 3.3.5', '< 5'
   gem.add_dependency 'connection_pool', '~> 2.2', '>= 2.2.2'
-  gem.add_dependency 'rack', '< 2.1.0'
+  gem.add_dependency 'rack', '< 2.2.0'
   gem.add_dependency 'rack-protection', '>= 1.5.0'
 end


### PR DESCRIPTION
[[CVE-2020-8161] Directory traversal in Rack::Directory](https://groups.google.com/d/msg/ruby-security-ann/T4ZIsfRf2eA/h32aSPjcBAAJ)