### PR TITLE
(docs) YARD annotations

### DIFF
--- a/lib/sidekiq/extensions/active_record.rb
+++ b/lib/sidekiq/extensions/active_record.rb
@@ -6,9 +6,10 @@ module Sidekiq
   module Extensions
     ##
     # Adds 'delay', 'delay_for' and `delay_until` methods to ActiveRecord to offload instance method
-    # execution to Sidekiq.  Examples:
+    # execution to Sidekiq.
     #
-    # User.recent_signups.each { |user| user.delay.mark_as_awesome }
+    # @example
+    #   User.recent_signups.each { |user| user.delay.mark_as_awesome }
     #
     # Please note, this is not recommended as this will serialize the entire
     # object to Redis.  Your Sidekiq jobs should pass IDs, not entire instances.

--- a/lib/sidekiq/extensions/class_methods.rb
+++ b/lib/sidekiq/extensions/class_methods.rb
@@ -5,11 +5,12 @@ require "sidekiq/extensions/generic_proxy"
 module Sidekiq
   module Extensions
     ##
-    # Adds 'delay', 'delay_for' and `delay_until` methods to all Classes to offload class method
-    # execution to Sidekiq.  Examples:
+    # Adds `delay`, `delay_for` and `delay_until` methods to all Classes to offload class method
+    # execution to Sidekiq.
     #
-    # User.delay.delete_inactive
-    # Wikipedia.delay.download_changes_for(Date.today)
+    # @example
+    #   User.delay.delete_inactive
+    #   Wikipedia.delay.download_changes_for(Date.today)
     #
     class DelayedClass
       include Sidekiq::Worker

--- a/lib/sidekiq/sd_notify.rb
+++ b/lib/sidekiq/sd_notify.rb
@@ -85,7 +85,7 @@ module Sidekiq
       notify(FDSTORE, unset_env)
     end
 
-    # @param [Boolean] true if the service manager expects watchdog keep-alive
+    # @return [Boolean] true if the service manager expects watchdog keep-alive
     #   notification messages to be sent from this process.
     #
     # If the $WATCHDOG_USEC environment variable is set,


### PR DESCRIPTION
This PR improves a small part of the documentation using YARD annotations.

<img width="945" alt="bild" src="https://user-images.githubusercontent.com/211/81801358-96cb1e80-9514-11ea-80a2-94107b54d1d8.png">


  - use the Example functionality for syntax highlighting
  - use backticks for code in Markdown
  - fix a typo which made the `return` disappear