### PR TITLE
Optimize stringify item before pushing it

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -201,12 +201,9 @@ module Sidekiq
 
     # Merge options with current params, filter safe params, and stringify to query string
     def qparams(options)
-      # stringify
-      options.keys.each do |key|
-        options[key.to_s] = options.delete(key)
-      end
+      stringified_options = options.transform_keys(&:to_s)
 
-      to_query_string(params.merge(options))
+      to_query_string(params.merge(stringified_options))
     end
 
     def to_query_string(params)

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -235,12 +235,9 @@ module Sidekiq
 
       def client_push(item) # :nodoc:
         pool = Thread.current[:sidekiq_via_pool] || get_sidekiq_options["pool"] || Sidekiq.redis_pool
-        # stringify
-        item.keys.each do |key|
-          item[key.to_s] = item.delete(key)
-        end
+        stringified_item = item.transform_keys(&:to_s)
 
-        Sidekiq::Client.new(pool).push(item)
+        Sidekiq::Client.new(pool).push(stringified_item)
       end
     end
   end


### PR DESCRIPTION
We were debugging something when found this piece of code in the `Sidekiq::Worker` class:
```ruby
# stringify
item.keys.each do |key|
  item[key.to_s] = item.delete(key)
end
```

Since the oldest supported version now is Ruby v2.5 and this version added the `Hash#transform_keys` method, we considered changing it to use the standard method, easier to read. Also, it looks like it brings some performance improvements, from 0 to 20% depending on the execution.

Here the benchmark code:
```ruby
# frozen_string_literal: true

require "benchmark/ips"

def stringify(item)
  item.keys.each do |key|
    item[key.to_s] = item.delete(key)
  end
end

def stringify_optimized(item)
  item.transform_keys(&:to_s)
end

item = {:queue=>"low", "class"=>"RandomWorker", "args"=>["foo", "bar"], "at"=>1590166226.951523}

10.times do |i|
  puts("Report ##{i}")
  Benchmark.ips do |x|
    x.report("stringify") do
      stringify(item)
    end
    x.report("stringify_optimized") do
      stringify_optimized(item)
    end
    x.compare!
  end
end
```

And one of the reports:
```txt
Report #9
Warming up --------------------------------------
           stringify    75.241k i/100ms
 stringify_optimized    74.384k i/100ms
Calculating -------------------------------------
           stringify    869.794k (±15.0%) i/s -      4.213M in   5.034072s
 stringify_optimized      1.056M (± 4.5%) i/s -      5.281M in   5.011056s
Comparison:
 stringify_optimized:  1056329.3 i/s
           stringify:   869793.5 i/s - 1.21x  slower
```

