### PR TITLE
Fix SimpleCov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 
 group :test do
   gem "minitest"
-  gem "simplecov"
+  gem "simplecov", "~> 0.17.1"
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 
 group :test do
   gem "minitest"
+  # https://github.com/codeclimate/test-reporter/issues/413
   gem "simplecov", "~> 0.17.1"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
     jaro_winkler (1.5.4)
     jaro_winkler (1.5.4-java)
     jdbc-sqlite3 (3.28.0)
+    json (2.3.0)
+    json (2.3.0-java)
     loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -162,10 +164,11 @@ GEM
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
-    simplecov (0.18.2)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -204,7 +207,7 @@ DEPENDENCIES
   rake
   redis-namespace
   sidekiq!
-  simplecov
+  simplecov (~> 0.17.1)
   sqlite3
   standard
   toxiproxy


### PR DESCRIPTION
SimpleCov 0.18+ is not yet supported by CodeClimate
https://docs.codeclimate.com/docs/configuring-test-coverage#supported-languages-and-formats