### PR TITLE
Validate that job arguments being passed to `push_bulk` is an Array of Arrays

### DIFF
--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -162,6 +162,14 @@ describe Sidekiq::Client do
       result = Sidekiq::Client.push_bulk('class' => 'QueuedWorker', 'args' => [])
       assert_equal 0, result.size
     end
+
+    describe 'errors' do
+      it 'raises ArgumentError with invalid params' do
+        assert_raises ArgumentError do
+          Sidekiq::Client.push_bulk('class' => 'QueuedWorker', 'args' => [[1], 2])
+        end
+      end
+    end
   end
 
   class BaseWorker


### PR DESCRIPTION
## Background

Sidekiq allows to bulk push jobs into Redis via the `push_bulk` methods. One of the requirements for using this feature is that the job arguments being passed to this method call should be an "Array of Arrays".

## Problem

For some reason, the validation being done to make sure that the argument is an Array of Arrays was only checking if the first element of the array was an array. 

It is currently not checking if the `2nd` to `nth` element are arrays too.

## Change

This change adds:
- Validation that all elements of the array are of `Array` datatype.
- Tests to make sure that the new validation works as expected.

