### PR TITLE
Refactor some tests

### DIFF
--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -22,15 +22,11 @@ describe Sidekiq::Client do
       end
 
       assert_raises ArgumentError do
-        Sidekiq::Client.push('queue' => 'foo', 'class' => MyWorker, 'args' => 1)
+        Sidekiq::Client.push('queue' => 'foo', 'class' => MyWorker, 'args' => :not_an_array)
       end
 
       assert_raises ArgumentError do
-        Sidekiq::Client.push('queue' => 'foo', 'class' => MyWorker, 'args' => [1], 'at' => Time.now)
-      end
-
-      assert_raises ArgumentError do
-        Sidekiq::Client.push('queue' => 'foo', 'class' => MyWorker, 'args' => [1, 2], 'at' => [Time.now.to_f, :not_a_numeric])
+        Sidekiq::Client.push('queue' => 'foo', 'class' => MyWorker, 'args' => [1], 'at' => :not_a_numeric)
       end
 
       assert_raises ArgumentError do
@@ -167,6 +163,10 @@ describe Sidekiq::Client do
       it 'raises ArgumentError with invalid params' do
         assert_raises ArgumentError do
           Sidekiq::Client.push_bulk('class' => 'QueuedWorker', 'args' => [[1], 2])
+        end
+
+        assert_raises ArgumentError do
+          Sidekiq::Client.push_bulk('class' => 'QueuedWorker', 'args' => [[1], [2]], 'at' => [Time.now.to_f, :not_a_numeric])
         end
       end
     end


### PR DESCRIPTION
## Problem

I noticed that one of the tests that validate that `ArgumentError` is thrown, does not throw the error because of the nature of arguments passed in the test case. It fails with the same error, but for a different reason.

```ruby
Sidekiq::Client.push('queue' => 'foo', 'class' => MyWorker, 'args' => [1, 2], 'at' => [Time.now.to_f, :not_a_numeric])
```

This throws `ArgumentError`, but not because all the elements of `at` is not `Numeric`, it is because `at` for `push` cannot be anything other than `Numeric`(it is an `Array` here.). It feels like this test case does not reveal the true reason for the error being raised.

I think this was originally intended as a test for `push_bulk`, but it ended up being a test for `push`, and since the same type of error was thrown, it did not reveal itself as a problem.

## Change

I have now shifted this test to the tests of `push_bulk`.

Some minor refactoring too: I've changed arguments to `:not_an_array`, `:not_a_numeric` etc, just to make sure that the reason for the error being raised is a little more understandable while reading code, even for first-timers.