### PR TITLE
Use error handler(s) from CLI launch failure

### DIFF
--- a/bin/sidekiq
+++ b/bin/sidekiq
@@ -31,7 +31,12 @@ begin
   cli.run
 rescue => e
   raise e if $DEBUG
-  STDERR.puts e.message
-  STDERR.puts e.backtrace.join("\n")
+  if Sidekiq.error_handlers.length === 0
+    STDERR.puts e.message
+    STDERR.puts e.backtrace.join("\n")
+  else
+    cli.handle_exception e
+  end
+
   exit 1
 end

--- a/bin/sidekiq
+++ b/bin/sidekiq
@@ -31,7 +31,7 @@ begin
   cli.run
 rescue => e
   raise e if $DEBUG
-  if Sidekiq.error_handlers.length === 0
+  if Sidekiq.error_handlers.length == 0
     STDERR.puts e.message
     STDERR.puts e.backtrace.join("\n")
   else


### PR DESCRIPTION
**Problem**

Sometimes, the sidekiq workers of our app fail to launch by the Redis connectivity issue, and if that happens, it spits multiple lines of stack trace, regardless of configured `Sidekiq.error_handlers`. This patch will use the error handlers, if it's configured.