### PR TITLE
Fetch API refactor, WIP

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ HEAD
 - Remove rack-protection, reimplement CSRF protection [#4588]
 - Require redis-rb 4.2 [#4591]
 - Update to jquery 1.12.4 [#4593]
+- Refactor internal fetch logic and API [#4602]
 
 6.0.7
 ---------

--- a/Pro-Changes.md
+++ b/Pro-Changes.md
@@ -10,6 +10,7 @@ HEAD
 - Remove `concurrent-ruby` gem dependency [#4586]
 - Update `constantize` for batch callbacks. [#4469]
 - Add queue tag to `jobs.recovered.fetch` metric [#4594]
+- Refactor Pro's fetch infrastructure [#4602]
 
 5.0.1
 ---------

--- a/lib/sidekiq/fetch.rb
+++ b/lib/sidekiq/fetch.rb
@@ -26,8 +26,9 @@ module Sidekiq
 
     def initialize(options)
       raise ArgumentError, "missing queue list" unless options[:queues]
-      @strictly_ordered_queues = !!options[:strict]
-      @queues = options[:queues].map { |q| "queue:#{q}" }
+      @options = options
+      @strictly_ordered_queues = !!@options[:strict]
+      @queues = @options[:queues].map { |q| "queue:#{q}" }
       if @strictly_ordered_queues
         @queues.uniq!
         @queues << TIMEOUT

--- a/lib/sidekiq/fetch.rb
+++ b/lib/sidekiq/fetch.rb
@@ -25,6 +25,7 @@ module Sidekiq
     }
 
     def initialize(options)
+      raise ArgumentError, "missing queue list" unless options[:queues]
       @strictly_ordered_queues = !!options[:strict]
       @queues = options[:queues].map { |q| "queue:#{q}" }
       if @strictly_ordered_queues
@@ -38,24 +39,9 @@ module Sidekiq
       UnitOfWork.new(*work) if work
     end
 
-    # Creating the Redis#brpop command takes into account any
-    # configured queue weights. By default Redis#brpop returns
-    # data from the first queue that has pending elements. We
-    # recreate the queue command each time we invoke Redis#brpop
-    # to honor weights and avoid queue starvation.
-    def queues_cmd
-      if @strictly_ordered_queues
-        @queues
-      else
-        queues = @queues.shuffle!.uniq
-        queues << TIMEOUT
-        queues
-      end
-    end
-
     # By leaving this as a class method, it can be pluggable and used by the Manager actor. Making it
     # an instance method will make it async to the Fetcher actor
-    def self.bulk_requeue(inprogress, options)
+    def bulk_requeue(inprogress, options)
       return if inprogress.empty?
 
       Sidekiq.logger.debug { "Re-queueing terminated jobs" }
@@ -75,6 +61,21 @@ module Sidekiq
       Sidekiq.logger.info("Pushed #{inprogress.size} jobs back to Redis")
     rescue => ex
       Sidekiq.logger.warn("Failed to requeue #{inprogress.size} jobs: #{ex.message}")
+    end
+
+    # Creating the Redis#brpop command takes into account any
+    # configured queue weights. By default Redis#brpop returns
+    # data from the first queue that has pending elements. We
+    # recreate the queue command each time we invoke Redis#brpop
+    # to honor weights and avoid queue starvation.
+    def queues_cmd
+      if @strictly_ordered_queues
+        @queues
+      else
+        queues = @queues.shuffle!.uniq
+        queues << TIMEOUT
+        queues
+      end
     end
   end
 end

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -22,6 +22,7 @@ module Sidekiq
     attr_accessor :manager, :poller, :fetcher
 
     def initialize(options)
+      options[:fetch] ||= BasicFetch.new(options)
       @manager = Sidekiq::Manager.new(options)
       @poller = Sidekiq::Scheduled::Poller.new
       @done = false
@@ -56,7 +57,7 @@ module Sidekiq
 
       # Requeue everything in case there was a worker who grabbed work while stopped
       # This call is a no-op in Sidekiq but necessary for Sidekiq Pro.
-      strategy = (@options[:fetch] || Sidekiq::BasicFetch)
+      strategy = @options[:fetch]
       strategy.bulk_requeue([], @options)
 
       clear_heartbeat

--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -35,7 +35,7 @@ module Sidekiq
       @done = false
       @workers = Set.new
       @count.times do
-        @workers << Processor.new(self)
+        @workers << Processor.new(self, options)
       end
       @plock = Mutex.new
     end
@@ -90,7 +90,7 @@ module Sidekiq
       @plock.synchronize do
         @workers.delete(processor)
         unless @done
-          p = Processor.new(self)
+          p = Processor.new(self, options)
           @workers << p
           p.start
         end
@@ -123,7 +123,7 @@ module Sidekiq
         # contract says that jobs are run AT LEAST once. Process termination
         # is delayed until we're certain the jobs are back in Redis because
         # it is worse to lose a job than to run it twice.
-        strategy = (@options[:fetch] || Sidekiq::BasicFetch)
+        strategy = @options[:fetch]
         strategy.bulk_requeue(jobs, @options)
       end
 

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -28,15 +28,15 @@ module Sidekiq
     attr_reader :thread
     attr_reader :job
 
-    def initialize(mgr)
+    def initialize(mgr, options)
       @mgr = mgr
       @down = false
       @done = false
       @job = nil
       @thread = nil
-      @strategy = (mgr.options[:fetch] || Sidekiq::BasicFetch).new(mgr.options)
-      @reloader = Sidekiq.options[:reloader]
-      @job_logger = (mgr.options[:job_logger] || Sidekiq::JobLogger).new
+      @strategy = options[:fetch]
+      @reloader = options[:reloader] || proc { |&block| block.call }
+      @job_logger = (options[:job_logger] || Sidekiq::JobLogger).new
       @retrier = Sidekiq::JobRetry.new
     end
 

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -419,6 +419,7 @@ describe Sidekiq::CLI do
 
     describe '#run' do
       before do
+        Sidekiq.options[:concurrency] = 2
         Sidekiq.options[:require] = './test/fake_env.rb'
       end
 

--- a/test/test_fetch.rb
+++ b/test/test_fetch.rb
@@ -52,7 +52,7 @@ describe Sidekiq::BasicFetch do
     assert_equal 0, q1.size
     assert_equal 0, q2.size
 
-    Sidekiq::BasicFetch.bulk_requeue(works, {:queues => []})
+    fetch.bulk_requeue(works, {:queues => []})
     assert_equal 2, q1.size
     assert_equal 1, q2.size
   end

--- a/test/test_manager.rb
+++ b/test/test_manager.rb
@@ -8,7 +8,7 @@ describe Sidekiq::Manager do
   end
 
   def new_manager(opts)
-    Sidekiq::Manager.new(opts)
+    Sidekiq::Manager.new(opts.merge(fetch: Sidekiq::BasicFetch.new(opts)))
   end
 
   it 'creates N processor instances' do

--- a/test/test_middleware.rb
+++ b/test/test_middleware.rb
@@ -78,10 +78,8 @@ describe Sidekiq::Middleware do
     end
 
     boss = Minitest::Mock.new
-    boss.expect(:options, {:queues => ['default'] }, [])
-    boss.expect(:options, {:queues => ['default'] }, [])
-    boss.expect(:options, {:queues => ['default'] }, [])
-    processor = Sidekiq::Processor.new(boss)
+    opts = {:queues => ['default'] }
+    processor = Sidekiq::Processor.new(boss, opts)
     boss.expect(:processor_done, nil, [processor])
     processor.process(Sidekiq::BasicFetch::UnitOfWork.new('queue:default', msg))
     assert_equal %w(2 before 3 before 1 before work_performed 1 after 3 after 2 after), $recorder.flatten


### PR DESCRIPTION
The existing fetch API grew organically to its current state but is less than optimal: you pass a class reference via the global options, making it hard to configure a fetcher instance and requiring some test gymnastics to set up that global config.

I'd like to change the fetch API to be instance-based. `bulk_requeue` will become an instance method. Feedback welcome.