### PR TITLE
raise ArgumentError if 'at' size is wrong

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -96,6 +96,7 @@ module Sidekiq
 
       at = items.delete("at")
       raise ArgumentError, "Job 'at' must be a Numeric or an Array of Numeric timestamps" if at && (Array(at).empty? || !Array(at).all?(Numeric))
+      raise ArgumentError, "Job 'at' Array must have same size as 'args' Array" if at.is_a?(Array) && at.size != args.size
 
       normed = normalize_item(items)
       payloads = args.map.with_index { |job_args, index|

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -168,6 +168,14 @@ describe Sidekiq::Client do
         assert_raises ArgumentError do
           Sidekiq::Client.push_bulk('class' => 'QueuedWorker', 'args' => [[1], [2]], 'at' => [Time.now.to_f, :not_a_numeric])
         end
+
+        assert_raises ArgumentError do
+          Sidekiq::Client.push_bulk('class' => QueuedWorker, 'args' => [[1], [2]], 'at' => [Time.now.to_f])
+        end
+
+        assert_raises ArgumentError do
+          Sidekiq::Client.push_bulk('class' => QueuedWorker, 'args' => [[1]], 'at' => [Time.now.to_f, Time.now.to_f])
+        end
       end
     end
   end


### PR DESCRIPTION
In `Sidekiq::Client.bulk_push`, now 'at' size must be the same size as 'args' (or just be a single numeric).

Fixes #4601