### PR TITLE
Remove wrong comment on instance method

### DIFF
--- a/lib/sidekiq/fetch.rb
+++ b/lib/sidekiq/fetch.rb
@@ -40,8 +40,6 @@ module Sidekiq
       UnitOfWork.new(*work) if work
     end
 
-    # By leaving this as a class method, it can be pluggable and used by the Manager actor. Making it
-    # an instance method will make it async to the Fetcher actor
     def bulk_requeue(inprogress, options)
       return if inprogress.empty?
 


### PR DESCRIPTION
Within #4602 this method was changed from a class- to instance-method. The comment should be removed as the method is not a class-method anymore.