### PR TITLE
Only trap USR2 on sidekiq pro

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -44,7 +44,7 @@ module Sidekiq
       self_read, self_write = IO.pipe
       sigs = %w[INT TERM TTIN TSTP]
       # USR1 and USR2 don't work on the JVM
-      sigs << "USR2" unless jruby?
+      sigs << "USR2" if Sidekiq.pro? && !jruby?
       sigs.each do |sig|
         trap sig do
           self_write.puts(sig)


### PR DESCRIPTION
We're trying to use SIGUSR2, but currently the handler is being overridden by sidekiq. In particular, it is overridden _after_ the app is loaded.

As far as I can tell, this signal is only used by sidekiq pro ([source](https://github.com/mperham/sidekiq/wiki/Ent-Rolling-Restarts)).

It would be great to free up this signal for other use when it is not being used. I guess an alternative workaround would be to hook into the `startup` event, so that we can set up our own handler later. But I figured I'd propose this nevertheless.