### PR TITLE
Check if session hash not empty in csrf token validation

### DIFF
--- a/lib/sidekiq/web/csrf_protection.rb
+++ b/lib/sidekiq/web/csrf_protection.rb
@@ -90,6 +90,11 @@ module Sidekiq
         end
 
         sess = session(env)
+
+        # Checks that Rack::Session::Cookie did not return empty session
+        # object in case the digest verification failed
+        return false if sess.empty?
+
         localtoken = sess[:csrf]
 
         # Rotate the session token after every use


### PR DESCRIPTION
`Sidekiq::Web::CsrfProtection.valid_token?` now checking if the session hash is not empty.

Fixes #4671 