### PR TITLE
Allow middleware to yield arguments

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ HEAD
 ---------
 
 - Fix Web UI crash with corrupt session [#4672]
+- Allow middleware to yield arguments [#4673, @eugeneius]
 
 6.1.1
 ---------

--- a/lib/sidekiq/middleware/chain.rb
+++ b/lib/sidekiq/middleware/chain.rb
@@ -133,7 +133,7 @@ module Sidekiq
         return yield if empty?
 
         chain = retrieve.dup
-        traverse_chain = lambda do
+        traverse_chain = proc do
           if chain.empty?
             yield
           else

--- a/test/test_middleware.rb
+++ b/test/test_middleware.rb
@@ -41,6 +41,12 @@ describe Sidekiq::Middleware do
     end
   end
 
+  class ArgumentYieldingMiddleware
+    def call(*args)
+      yield 1
+    end
+  end
+
   class AnotherCustomMiddleware
     def initialize(name, recorder)
       @name = name
@@ -111,6 +117,15 @@ describe Sidekiq::Middleware do
     chain.invoke { final_action = true }
     assert_nil final_action
     assert_equal [], recorder
+  end
+
+  it 'allows middleware to yield arguments' do
+    chain = Sidekiq::Middleware::Chain.new
+    chain.add ArgumentYieldingMiddleware
+
+    final_action = nil
+    chain.invoke { final_action = true }
+    assert_equal true, final_action
   end
 
   describe 'I18n' do


### PR DESCRIPTION
I noticed that our application has several middleware that wrap the job in a method that yields:

```ruby
class TaggedLoggingMiddleware
  def call(*)
    Rails.logger.tagged("my cool job") { yield }
  end
end
```

To save a stack frame, I rewrote them to pass the given block directly to the method:

```ruby
class TaggedLoggingMiddleware
  def call(*, &block)
    Rails.logger.tagged("my cool job", &block)
  end
end
```

I even made a change to RuboCop (https://github.com/rubocop-hq/rubocop/pull/8455) so that they could be rewritten automatically.

When I deployed the change, every job started to fail with:

> ArgumentError: wrong number of arguments (given 1, expected 0)

😩 

This happened because [lambdas have strict argument checking](https://ruby-doc.org/core-2.6.6/Proc.html#class-Proc-label-Lambda+and+non-lambda+semantics), and `Rails.logger.tagged` [yields the logger](https://github.com/rails/rails/blob/v6.0.3.2/activesupport/lib/active_support/tagged_logging.rb#L80). We had unit tests for the middleware, but they called it with a proc, so they didn't catch the issue.

I don't think strict argument checking makes sense here; any yielded arguments should be accepted and ignored.