### PR TITLE
Improve dark Web UI

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 HEAD
 ---------
 
+- Improve contrast in dark mode Web UI
 - Fix Web UI crash with corrupt session [#4672]
 
 6.1.1

--- a/web/assets/stylesheets/application-dark.css
+++ b/web/assets/stylesheets/application-dark.css
@@ -33,8 +33,8 @@ span.current-interval,
   border-color: #555;
 }
 
-table.table-white {
-  background-color: #222;
+table {
+  background-color: #282828;
 }
 
 .table-striped > tbody > tr:nth-of-type(odd) {

--- a/web/assets/stylesheets/application-dark.css
+++ b/web/assets/stylesheets/application-dark.css
@@ -38,7 +38,7 @@ table {
 }
 
 .table-striped > tbody > tr:nth-of-type(odd) {
-  background-color: #444;
+  background-color: #333;
 }
 
 .table-bordered,
@@ -52,7 +52,7 @@ table {
 }
 
 .table-hover > tbody > tr:hover {
-  background-color: #555;
+  background-color: #444;
 }
 
 .alert {

--- a/web/assets/stylesheets/application-dark.css
+++ b/web/assets/stylesheets/application-dark.css
@@ -1,34 +1,44 @@
 html, body {
-  background-color: #070707 !important;
-  color: #ccc;
+  background-color: #333 !important;
+  color: #ddd;
 }
 
 a,
 .title,
 .summary_bar ul .count,
+span.current-interval,
 .navbar .navbar-brand {
-  color: #af0014;
+  color: #c04;
+}
+
+.history-graph + .active,
+.beacon .dot {
+  background-color: #c04;
 }
 
 .navbar .navbar-brand:hover {
-  color: #ccc;
+  color: #ddd;
 }
 
 .navbar .navbar-brand .status {
-  color: #ccc;
+  color: #ddd;
+}
+
+.navbar-default .navbar-nav > li > a {
+  color: #ddd;
 }
 
 .navbar-inverse {
-  background-color: #000;
-  border-color: #333;
+  background-color: #222;
+  border-color: #555;
 }
 
 table.table-white {
-  background-color: #111;
+  background-color: #222;
 }
 
 .table-striped > tbody > tr:nth-of-type(odd) {
-  background-color: #222;
+  background-color: #444;
 }
 
 .table-bordered,
@@ -38,27 +48,27 @@ table.table-white {
 .table-bordered > tfoot > tr > th,
 .table-bordered > thead > tr > td,
 .table-bordered > thead > tr > th {
-  border: 1px solid #333;
+  border: 1px solid #555;
 }
 
 .table-hover > tbody > tr:hover {
-  background-color: #333;
+  background-color: #555;
 }
 
 .alert {
   border: none;
-  color: #ccc;
+  color: #ddd;
 }
 
 .alert-success {
-  background-color: #182d11;
+  background-color: #484;
 }
 
 a:link,
 a:active,
 a:hover,
 a:visited {
-  color: #63798c;
+  color: #ddd;
 }
 
 a.btn {
@@ -66,8 +76,8 @@ a.btn {
 }
 
 .summary_bar .summary {
-  background-color: #111;
-  border: 1px solid #333;
+  background-color: #222;
+  border: 1px solid #555;
 
   -webkit-box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
   -moz-box-shadow: 0 0 5px rgba(255, 255, 255, 0.1);
@@ -75,27 +85,27 @@ a.btn {
 }
 
 .navbar-default {
-  background-color: #000;
-  border-color: #3d3d3d;
+  background-color: #222;
+  border-color: #555;
 }
 
 .navbar-default .navbar-nav > .active > a,
 .navbar-default .navbar-nav > .active > a:focus,
 .navbar-default .navbar-nav > .active > a:hover {
-  color: #ccc;
-  background-color: #282828;
+  color: #ddd;
+  background-color: #333;
 }
 
 .navbar-default .navbar-nav > li > a:hover {
-  color: #ccc;
+  color: #ddd;
 }
 
 .pagination > li > a,
 .pagination > li > a:hover,
 .pagination > li > span {
-  color: #ccc;
-  background-color: #282828;
-  border-color: #353535;
+  color: #ddd;
+  background-color: #333;
+  border-color: #555;
 }
 .pagination > .disabled > a,
 .pagination > .disabled > a:focus,
@@ -103,9 +113,9 @@ a.btn {
 .pagination > .disabled > span,
 .pagination > .disabled > span:focus,
 .pagination > .disabled > span:hover {
-  color: #a5a5a5;
-  background-color: #282828;
-  border-color: #353535;
+  color: #ddd;
+  background-color: #333;
+  border-color: #555;
 }
 
 .stat {
@@ -113,11 +123,11 @@ a.btn {
 }
 
 #live-poll {
-  color: #ccc;
+  color: #ddd;
 }
 
 .btn-warn {
-  color: #333;
+  color: #444;
 }
 
 .rickshaw_graph .detail {
@@ -128,6 +138,6 @@ a.btn {
 }
 
 .rickshaw_graph .y_ticks.glow text {
-  fill: #ccc;
-  color: #ccc;
+  fill: #ddd;
+  color: #ddd;
 }

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -177,10 +177,6 @@ header.row .pagination {
   overflow: overlay;
 }
 
-table.table-white {
-  background-color: #fff;
-}
-
 .queues form {
   margin: 0;
 }

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -758,7 +758,7 @@ div.interval-slider input {
     font-family: Arial, sans-serif;
     border-radius: 3px;
     padding: 6px;
-    opacity: .5;
+    opacity: .7;
     border: 1px solid #e0e0e0;
     font-size: 12px;
     position: absolute;
@@ -973,7 +973,7 @@ div.interval-slider input {
 }
 .rickshaw_graph .y_ticks text,
 .rickshaw_graph .x_ticks_d3 text {
-    opacity: .5;
+    opacity: .7;
     font-size: 12px;
     pointer-events: none
 }

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -14,7 +14,7 @@
 </div>
 
 <div class="table_container">
-  <table class="processes table table-hover table-bordered table-striped table-white">
+  <table class="processes table table-hover table-bordered table-striped">
     <thead>
       <th><%= t('Name') %></th>
       <th><%= t('Started') %></th>
@@ -68,7 +68,7 @@
 </div>
 
 <div class="table_container">
-  <table class="workers table table-hover table-bordered table-striped table-white">
+  <table class="workers table table-hover table-bordered table-striped">
     <thead>
       <th><%= t('Process') %></th>
       <th><%= t('TID') %></th>

--- a/web/views/morgue.erb
+++ b/web/views/morgue.erb
@@ -14,7 +14,7 @@
   <form action="<%= root_path %>morgue" method="post">
     <%= csrf_tag %>
     <div class="table_container">
-      <table class="table table-striped table-bordered table-white">
+      <table class="table table-striped table-bordered">
         <thead>
           <tr>
             <th class="table-checkbox checkbox-column">

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -1,7 +1,7 @@
 <h3><%= t('Queues') %></h3>
 
 <div class="table_container">
-  <table class="queues table table-hover table-bordered table-striped table-white">
+  <table class="queues table table-hover table-bordered table-striped">
     <thead>
       <th><%= t('Queue') %></th>
       <th><%= t('Size') %></th>

--- a/web/views/retries.erb
+++ b/web/views/retries.erb
@@ -14,7 +14,7 @@
   <form action="<%= root_path %>retries" method="post">
     <%= csrf_tag %>
     <div class="table_container">
-      <table class="table table-striped table-bordered table-white">
+      <table class="table table-striped table-bordered">
         <thead>
           <tr>
             <th class="table-checkbox checkbox-column">

--- a/web/views/scheduled.erb
+++ b/web/views/scheduled.erb
@@ -15,7 +15,7 @@
   <form action="<%= root_path %>scheduled" method="post">
     <%= csrf_tag %>
     <div class="table_container">
-      <table class="table table-striped table-bordered table-white">
+      <table class="table table-striped table-bordered">
         <thead>
           <tr>
             <th class="checkbox-column">


### PR DESCRIPTION
Add a lot more contrast to various UI elements. This is a lot more usable to my old eyes.

# Queue

## Before
<img width="1198" alt="Screen Shot 2020-08-24 at 12 28 12 PM" src="https://user-images.githubusercontent.com/2911/91087815-e508b700-e605-11ea-85d5-7b9bd23a8f02.png">

## After
<img width="1191" alt="Screen Shot 2020-08-24 at 12 35 18 PM" src="https://user-images.githubusercontent.com/2911/91088134-5c3e4b00-e606-11ea-8a9b-4b3df0e76c17.png">

# Dashboard
## Before
<img width="1192" alt="Screen Shot 2020-08-24 at 12 27 58 PM" src="https://user-images.githubusercontent.com/2911/91087860-fd78d180-e605-11ea-9898-4048a95dd5b2.png">
<img width="1177" alt="Screen Shot 2020-08-24 at 12 27 19 PM" src="https://user-images.githubusercontent.com/2911/91087890-0669a300-e606-11ea-9176-6dc110274b61.png">
