### PR TITLE
Add timeout value to process info

### DIFF
--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -188,6 +188,7 @@ module Sidekiq
           "pid" => ::Process.pid,
           "tag" => @options[:tag] || "",
           "concurrency" => @options[:concurrency],
+          "timeout" => @options[:timeout],
           "queues" => @options[:queues].uniq,
           "labels" => @options[:labels],
           "identity" => identity


### PR DESCRIPTION
I'm trying to introspect `Sidekiq::ProcessSet.new`, it already has `concurrency` value, but I also need `timeout`.