### PR TITLE
Fix typo in 5.0 upgrade manual, method name is `delay_for`

### DIFF
--- a/5.0-Upgrade.md
+++ b/5.0-Upgrade.md
@@ -14,7 +14,7 @@ versions of Ruby and Rails and adds support for RTL languages in the Web UI.
   integrated as Sidekiq middleware; the logging/retry logic had to be pulled out
   too.  Sidekiq 4.2 had a hack to make it work but this redesign provides
   a cleaner integration. [#3235]
-* The Delayed Extensions `delay`, `delay_in` and `delay_until` APIs are
+* The Delayed Extensions `delay`, `delay_for` and `delay_until` APIs are
   no longer available by default.  The extensions allow you to marshal
   job arguments as YAML, leading to cases where job payloads could be many
   100s of KB or larger if not careful, leading to Redis networking


### PR DESCRIPTION
Method name is `delay_for`, not `delay_in`.
This is somewhat confusing for those who upgrade and grep their code for these calls.