### PR TITLE
Fix handling of no csrf session token

### DIFF
--- a/lib/sidekiq/web/csrf_protection.rb
+++ b/lib/sidekiq/web/csrf_protection.rb
@@ -90,12 +90,10 @@ module Sidekiq
         end
 
         sess = session(env)
-
-        # Checks that Rack::Session::Cookie did not return empty session
-        # object in case the digest verification failed
-        return false if sess.empty?
-
         localtoken = sess[:csrf]
+
+        # Checks that Rack::Session::Cookie actualy contains the csrf toekn
+        return false if localtoken.nil?
 
         # Rotate the session token after every use
         sess[:csrf] = SecureRandom.base64(TOKEN_LENGTH)

--- a/test/test_csrf.rb
+++ b/test/test_csrf.rb
@@ -97,4 +97,19 @@ class TestCsrf < Minitest::Test
     assert_equal 403, result[0]
     assert_equal ["Forbidden"], result[2]
   end
+
+  def test_empty_csrf_session_post
+    goodtoken = call(env) do |envy|
+      envy[:csrf_token]
+    end
+    assert goodtoken
+
+    # Make a POST without csrf session data and good token
+    result = call(env(:post, { "authenticity_token" => goodtoken }, { 'session_id' => 'foo' })) do
+      raise "shouldnt be called"
+    end
+    refute_nil result
+    assert_equal 403, result[0]
+    assert_equal ["Forbidden"], result[2]
+  end
 end


### PR DESCRIPTION
The previous fix for #4671 added a guard for a completely empty session. However, it seems that even if you delete the `rack.session` cookie, the session will still contain `session_id`, thus its not actually `empty?`. This changes the guard to actually check for the csrf token.
