### PR TITLE
ensure `wrapped` is of type string, representing the AJ class name

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -243,6 +243,9 @@ module Sidekiq
 
       raise(ArgumentError, "Job must include a valid queue name") if item["queue"].nil? || item["queue"] == ""
 
+      # ensure the wrapped class, if exists, is serialized as its name
+      item["wrapped"] = item["wrapped"].name if item["wrapped"].respond_to?("name")
+
       item["class"] = item["class"].to_s
       item["queue"] = item["queue"].to_s
       item["jid"] ||= SecureRandom.hex(12)


### PR DESCRIPTION
This addresses a change in Rails codebase related to the Sidekiq adapter: https://github.com/rails/rails/commit/eb4f36c13f63fcabcd211ca8c669420e46c19a34 as explained in [this commit comment](https://github.com/rails/rails/commit/eb4f36c13f63fcabcd211ca8c669420e46c19a34#commitcomment-44607834).

Sidekiq and related libs that are built around the ecosystem ([like scout_apm](https://github.com/scoutapp/scout_apm_ruby/issues/342)) expect the `wrapped` job argument to be consistent, of type string, as the `name` of the underlying ActiveJob class.