### PR TITLE
Warn on boot if maxmemory policy is not 'noeviction'

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -62,6 +62,11 @@ module Sidekiq
       ver = Sidekiq.redis_info["redis_version"]
       raise "You are connecting to Redis v#{ver}, Sidekiq requires Redis v4.0.0 or greater" if ver < "4"
 
+      maxmemory_policy = Sidekiq.redis_info["maxmemory_policy"]
+      if maxmemory_policy != "noeviction"
+        logger.warn "'noeviction' maxmemory policy is recommended (current policy: '#{maxmemory_policy}'). See: https://github.com/mperham/sidekiq/wiki/Using-Redis#memory"
+      end
+
       # Since the user can pass us a connection pool explicitly in the initializer, we
       # need to verify the size is large enough or else Sidekiq's performance is dramatically slowed.
       cursize = Sidekiq.redis_pool.size

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -481,6 +481,32 @@ describe Sidekiq::CLI do
           assert_includes @logdev.string, "Booted Rails #{::Rails.version} application in production environment"
         end
       end
+
+      describe 'checking maxmemory policy' do
+        it 'warns if the policy is not noeviction' do
+          redis_info = { "maxmemory_policy" => "allkeys-lru", "redis_version" => "6" }
+
+          Sidekiq.stub(:redis_info, redis_info) do
+            subject.stub(:launch, nil) do
+              subject.run
+            end
+          end
+
+          assert_includes @logdev.string, "'noeviction' maxmemory policy is recommended (current policy: 'allkeys-lru')"
+        end
+
+        it 'silent if the policy is noeviction' do
+          redis_info = { "maxmemory_policy" => "noeviction", "redis_version" => "6" }
+
+          Sidekiq.stub(:redis_info, redis_info) do
+            subject.stub(:launch, nil) do
+              subject.run
+            end
+          end
+
+          refute_includes @logdev.string, "'noeviction' maxmemory policy is recommended"
+        end
+      end
     end
 
     describe 'signal handling' do


### PR DESCRIPTION
This PR proposes logging a warning when the CLI boots if the maxmemory policy is not 'noeviction'.

Inspired by [Nate Berkopec's tweet the other day](https://twitter.com/nateberkopec/status/1333863949238931464) (I've also had clients who had this misconfiguration):

> Running Sidekiq from a Redis datastore with a volatile eviction policy is probably the most common Sidekiq error I see in the wild w/clients. Switch to noeviction, you want Sidekiq to fail very loudly when you run out of memory, not silently drop jobs.