### PR TITLE
Fix logger with from deleting existing context

### DIFF
--- a/lib/sidekiq/logger.rb
+++ b/lib/sidekiq/logger.rb
@@ -6,10 +6,11 @@ require "time"
 module Sidekiq
   module Context
     def self.with(hash)
+      orig_context = current.dup
       current.merge!(hash)
       yield
     ensure
-      hash.each_key { |key| current.delete(key) }
+      Thread.current[:sidekiq_context] = orig_context
     end
 
     def self.current

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -49,6 +49,18 @@ class TestLogger < Minitest::Test
     assert_equal({}, subject.current)
   end
 
+  def test_with_overlapping_context
+    subject = Sidekiq::Context
+    subject.current.merge!({ foo: 'bar' })
+    assert_equal({ foo: 'bar' }, subject.current)
+
+    subject.with(foo: 'bingo') do
+      assert_equal({ foo: 'bingo' }, subject.current)
+    end
+
+    assert_equal({ foo: 'bar' }, subject.current)
+  end
+
   def test_nested_contexts
     subject = Sidekiq::Context
     assert_equal({}, subject.current)


### PR DESCRIPTION
If using `with` to add logging context, any context that has the same
keys as existing context will disappear after the with block completes,
instead of reverting back to the original context.

This fixes that by restoring the original context directly instead of
just deleting the keys from the `with` context.