### PR TITLE
Change the background colour for the RSS info badge to be less eye-catching

### DIFF
--- a/web/assets/stylesheets/application-dark.css
+++ b/web/assets/stylesheets/application-dark.css
@@ -147,3 +147,14 @@ input {
   fill: #ddd;
   color: #ddd;
 }
+
+.info-circle {
+  color: #282828;
+  background-color: #555555;
+  border-radius: 50%;
+  text-align: center;
+  vertical-align: middle;
+  padding: 3px 7px;
+  font-size: 0.7em;
+  margin-left: 5px;
+}

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -1153,10 +1153,9 @@ div.interval-slider input {
   width: 20%;
 }
 
-.circled {
-  border-color: #333;
-  color: #eee;
-  background-color: #b1003e;
+.info-circle {
+  color: #f3f3f3;
+  background-color: #dddddd;
   border-radius: 50%;
   text-align: center;
   vertical-align: middle;

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -18,7 +18,7 @@
     <thead>
       <th><%= t('Name') %></th>
       <th><%= t('Started') %></th>
-      <th><%= t('RSS') %><a href="https://github.com/mperham/sidekiq/wiki/Memory#rss"><span class="circled" title="Click to learn more about RSS">?</span></a></th>
+      <th><%= t('RSS') %><a href="https://github.com/mperham/sidekiq/wiki/Memory#rss"><span class="info-circle" title="Click to learn more about RSS">?</span></a></th>
       <th><%= t('Threads') %></th>
       <th><%= t('Busy') %></th>
       <th>&nbsp;</th>


### PR DESCRIPTION
3b5ae30c4e5e9e760268243ab5c14664a2f8d236 added a process RSS column to the table on the busy page. The red badge beside column header is useful for linking users to more information, but it's quite eye-catching. Since the badge doesn't indicate a notification or status change, it would be nice if it stood out a little less from the background.

This PR changes the background colour to light grey in normal mode and dark grey in dark mode. I also changed the class name from "circled" to "info-circle" since, with the more discreet colouring, I feel like it's less generally useful.

Before:
![image](https://user-images.githubusercontent.com/59188756/108397628-26a9a180-71e6-11eb-9b97-250c94f1e033.png)
![image](https://user-images.githubusercontent.com/59188756/108397451-f95cf380-71e5-11eb-9ec4-4f69b69e0397.png)

After:
![image](https://user-images.githubusercontent.com/59188756/108397479-01b52e80-71e6-11eb-9e7e-dbfe656d9258.png)
![image](https://user-images.githubusercontent.com/59188756/108397489-0548b580-71e6-11eb-9b8b-9c4d689d5ee1.png)
