### PR TITLE
Fix incorrect button rounding

### DIFF
--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -78,9 +78,10 @@
         <td><%= process['busy'] %></td>
         <td>
           <form method="POST">
+            <%= csrf_tag %>
+            <input type="hidden" name="identity" value="<%= process['identity'] %>"/>
+
             <div class="btn-group pull-right flip">
-              <%= csrf_tag %>
-              <input type="hidden" name="identity" value="<%= process['identity'] %>"/>
               <% unless process.stopping? %><button class="btn btn-warn" type="submit" name="quiet" value="1"><%= t('Quiet') %></button><% end %>
               <button class="btn btn-danger" type="submit" name="stop" value="1"><%= t('Stop') %></button>
             </div>


### PR DESCRIPTION
.btn-group uses :first-child and :last-child to determine which buttons should have rounded corners and which ones should have square corners. The "Quiet" button had a square left corner, because the first child was a CSRF hidden field tag.

Keeping only .btn elements inside the .btn-group means that the 1 or 2 buttons are rounded as expected. When there's no "Quiet" button, the "Stop" button has 4 round corners. When both buttons are present, the corners between the buttons are square.

Fixes #4858

I traced this problem to this diff. https://github.com/mperham/sidekiq/commit/f0ddebc7406fe4b78333fbc5f14488a38b9ccebc#diff-d68d7f0b05d0be529c7d2493225a3cd8e5358f0c6327b7dfc8ead5f2927a1ba1L50-L59

The buttons now look like this:

When both buttons are present
<img width="156" alt="Screen Shot 2021-04-06 at 10 49 55 PM" src="https://user-images.githubusercontent.com/5104186/113808495-bc17db00-972b-11eb-8c9f-332570e51738.png">

When only Stop is present
<img width="86" alt="Screen Shot 2021-04-06 at 10 55 46 PM" src="https://user-images.githubusercontent.com/5104186/113808505-bf12cb80-972b-11eb-8626-9a5bfe82f895.png">
