### PR TITLE
Fix a typo in lt locale file

### DIFF
--- a/web/locales/lt.yml
+++ b/web/locales/lt.yml
@@ -71,7 +71,7 @@ lt:
   Paused: Pristabdytas
   Stop: Sustabdyti
   Quiet: Nutildyti
-  StopAll: Sustbadyti Visus
+  StopAll: Sustabdyti Visus
   QuietAll: Nutildyti Visus
   PollingInterval: Užklausimų intervalas
   Plugins: Įskiepiai


### PR DESCRIPTION
As you can see from the translation of `Stop`, the correct spelling should be `Sustabdyti`. There is no such word as `Sustbadyti` (also `badyti` means `stabbing` :dagger: , which is kind of funny)