### PR TITLE
Add updated translations for spanish language

### DIFF
--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -7,6 +7,7 @@ en: # <---- change this to your locale code
   Realtime: Real-time
   History: History
   Busy: Busy
+  Utilization: Utilization
   Processed: Processed
   Failed: Failed
   Scheduled: Scheduled
@@ -64,6 +65,7 @@ en: # <---- change this to your locale code
   DeadJobs: Dead Jobs
   NoDeadJobsFound: No dead jobs were found
   Dead: Dead
+  Process: Process
   Processes: Processes
   Thread: Thread
   Threads: Threads

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -67,6 +67,7 @@ en: # <---- change this to your locale code
   Dead: Dead
   Process: Process
   Processes: Processes
+  Name: Name
   Thread: Thread
   Threads: Threads
   Jobs: Jobs

--- a/web/locales/es.yml
+++ b/web/locales/es.yml
@@ -39,6 +39,7 @@ es:
   AreYouSure: ¿Estás seguro?
   DeleteAll: Borrar Todo
   RetryAll: Reintentar Todo
+  KillAll: Matar Todo
   NoRetriesFound: No se encontraron reintentos
   Error: Error
   ErrorClass: Clase del Error
@@ -67,4 +68,16 @@ es:
   Thread: Hilo
   Threads: Hilos
   Jobs: Trabajos
+  Paused: Pausado
+  Stop: Detener
+  Quiet: Silenciar
+  StopAll: Detener Todo
+  QuietAll: Silenciar Todo
+  PollingInterval: Intervalo de Sondeo
+  Plugins: Plugins
+  NotYetEnqueued: Aún no en cola
+  CreatedAt: Creado en
+  BackToApp: Volver a la Aplicación
   Latency: Latencia
+  Pause: Pausar
+  Unpause: Reanudar

--- a/web/locales/es.yml
+++ b/web/locales/es.yml
@@ -7,6 +7,7 @@ es:
   Realtime: Tiempo Real
   History: Historial
   Busy: Ocupado
+  Utilization: Utilización
   Processed: Procesadas
   Failed: Fallidas
   Scheduled: Programadas
@@ -24,9 +25,9 @@ es:
   ShowAll: Mostrar Todo
   CurrentMessagesInQueue: Mensajes actualmente en <span class='title'>%{queue}</span>
   Delete: Eliminar
-  AddToQueue: Añadir a fila
+  AddToQueue: Añadir a la cola
   AreYouSureDeleteJob: ¿Estás seguro de eliminar este trabajo?
-  AreYouSureDeleteQueue: ¿Estás seguro de eliminar la fila  %{queue}?
+  AreYouSureDeleteQueue: ¿Estás seguro de eliminar la cola %{queue}?
   Queues: Colas
   Size: Tamaño
   Actions: Acciones
@@ -64,6 +65,7 @@ es:
   DeadJobs: Trabajos muertos
   NoDeadJobsFound: No hay trabajos muertos
   Dead: Muerto
+  Process: Proceso
   Processes: Procesos
   Thread: Hilo
   Threads: Hilos

--- a/web/locales/es.yml
+++ b/web/locales/es.yml
@@ -67,6 +67,7 @@ es:
   Dead: Muerto
   Process: Proceso
   Processes: Procesos
+  Name: Nombre
   Thread: Hilo
   Threads: Hilos
   Jobs: Trabajos


### PR DESCRIPTION
This PR adds some missing translations for Spanish language:

<img width="1975" alt="Captura de Pantalla 2021-04-23 a la(s) 10 55 28" src="https://user-images.githubusercontent.com/7851011/115890064-8a3c8f00-a422-11eb-9573-0a652b4b9772.png">

Also adds three words (Utilization, Process and Name) that were missing from locale files.