### PR TITLE
Update sidekiq.service

### DIFF
--- a/examples/systemd/sidekiq.service
+++ b/examples/systemd/sidekiq.service
@@ -42,13 +42,19 @@ WatchdogSec=10
 
 WorkingDirectory=/opt/myapp/current
 # If you use rbenv:
-# ExecStart=/bin/bash -lc 'exec /home/deploy/.rbenv/shims/bundle exec sidekiq -e production'
+# ExecStart=/bin/bash -lc 'exec /home/deploy/.rbenv/shims/bundle exec sidekiq -e production' -C config/sidekiq.yml
 # If you use the system's ruby:
-# ExecStart=/usr/local/bin/bundle exec sidekiq -e production
+# ExecStart=/usr/local/bin/bundle exec sidekiq -e production -C config/sidekiq.yml
 # If you use rvm in production without gemset and your ruby version is 2.6.5
-# ExecStart=/home/deploy/.rvm/gems/ruby-2.6.5/wrappers/bundle exec sidekiq -e production
+# ExecStart=/home/deploy/.rvm/gems/ruby-2.6.5/wrappers/bundle exec sidekiq -e production -C config/sidekiq.yml
 # If you use rvm in production with gemset and your ruby version is 2.6.5
-ExecStart=/home/deploy/.rvm/gems/ruby-2.6.5@gemset-name/wrappers/bundle exec sidekiq -e production
+ExecStart=/home/deploy/.rvm/gems/ruby-2.6.5@gemset-name/wrappers/bundle exec sidekiq -e production -C config/sidekiq.yml
+
+# To work with the gem 'capistrano/sidekiq'
+# If you are not using this gem, just remove the two lines just below
+# although it will not have any effect on the service if you keep these two lines
+ExecReload=/bin/kill -TSTP $MAINPID
+ExecStop=/bin/kill -TERM $MAINPID
 
 # Use `systemctl kill -s TSTP sidekiq` to quiet the Sidekiq process
 

--- a/examples/systemd/sidekiq.service
+++ b/examples/systemd/sidekiq.service
@@ -42,19 +42,19 @@ WatchdogSec=10
 
 WorkingDirectory=/opt/myapp/current
 # If you use rbenv:
-# ExecStart=/bin/bash -lc 'exec /home/deploy/.rbenv/shims/bundle exec sidekiq -e production' -C config/sidekiq.yml
+# ExecStart=/bin/bash -lc 'exec /home/deploy/.rbenv/shims/bundle exec sidekiq -e production'
 # If you use the system's ruby:
-# ExecStart=/usr/local/bin/bundle exec sidekiq -e production -C config/sidekiq.yml
+# ExecStart=/usr/local/bin/bundle exec sidekiq -e production
 # If you use rvm in production without gemset and your ruby version is 2.6.5
-# ExecStart=/home/deploy/.rvm/gems/ruby-2.6.5/wrappers/bundle exec sidekiq -e production -C config/sidekiq.yml
+# ExecStart=/home/deploy/.rvm/gems/ruby-2.6.5/wrappers/bundle exec sidekiq -e production
 # If you use rvm in production with gemset and your ruby version is 2.6.5
 ExecStart=/home/deploy/.rvm/gems/ruby-2.6.5@gemset-name/wrappers/bundle exec sidekiq -e production -C config/sidekiq.yml
 
-# To work with the gem 'capistrano/sidekiq'
-# If you are not using this gem, just remove the two lines just below
-# although it will not have any effect on the service if you keep these two lines
+# To work with the gem 'capistrano/sidekiq' use the command "ExecReload" configured below
+# If you are not wearing this jewel, just remove the line
+# NOTE: Don't forget to set up the mailer queue in config/sidekiq.yml
+# if you want to use the "delivery_later" method of the ActionMailer class
 ExecReload=/bin/kill -TSTP $MAINPID
-ExecStop=/bin/kill -TERM $MAINPID
 
 # Use `systemctl kill -s TSTP sidekiq` to quiet the Sidekiq process
 


### PR DESCRIPTION
Adding configuration to work with the gem 'capistrano/sidekiq' to be able to deploy automatically and restart the sidekiq service.

Repository gem 'capistrano/sidekiq': https://github.com/seuros/capistrano-sidekiq