### PR TITLE
Add missing french locales

### DIFF
--- a/web/locales/fr.yml
+++ b/web/locales/fr.yml
@@ -7,6 +7,7 @@ fr:
   Realtime: Temps réel
   History: Historique
   Busy: En cours
+  Utilization: Utilisation
   Processed: Traitées
   Failed: Échouées
   Scheduled: Planifiées
@@ -39,6 +40,7 @@ fr:
   AreYouSure: Êtes-vous certain ?
   DeleteAll: Tout supprimer
   RetryAll: Tout réessayer
+  KillAll: Tout tuer
   NoRetriesFound: Aucune tâche à réessayer n’a été trouvée
   Error: Erreur
   ErrorClass: Classe d’erreur
@@ -63,6 +65,7 @@ fr:
   DeadJobs: Tâches mortes
   NoDeadJobsFound: Aucune tâche morte n'a été trouvée
   Dead: Mortes
+  Process: Processus
   Processes: Processus
   Thread: Thread
   Threads: Threads
@@ -76,3 +79,7 @@ fr:
   Plugins: Plugins
   NotYetEnqueued: Pas encore en file d'attente
   CreatedAt: Créée le
+  Back to App: Retour à l'application
+  Latency: Latence
+  Pause: Pause
+  Unpause: Unpause


### PR DESCRIPTION
Hello @mperham 

I saw some missing french locales today.

To help me identify missing I used https://github.com/glebm/i18n-tasks with this config

```yml
# config/i18n-tasks.yml
base_locale: en
locales: [fr]
data:
  read:
    - web/locales/%{locale}.yml
```
Then `i18n-tasks health`