### PR TITLE
Minor text change to make the description correct.

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -910,7 +910,7 @@ module Sidekiq
   end
 
   ##
-  # The WorkSet is stores the work being done by this Sidekiq cluster.
+  # The WorkSet stores the work being done by this Sidekiq cluster.
   # It tracks the process and thread working on each job.
   #
   # WARNING WARNING WARNING


### PR DESCRIPTION
There was an `is` still left in the change here  https://github.com/mperham/sidekiq/commit/53999adc2c3d9a0109d12abeee4b601d11a780bf#diff-25f829140be25a886134933b537d356dddb12234ca85319e50b381f9edb6b74dR913