### PR TITLE
Add alert-danger and alert-info support for dark mode

### DIFF
--- a/web/assets/stylesheets/application-dark.css
+++ b/web/assets/stylesheets/application-dark.css
@@ -64,6 +64,14 @@ table {
   background-color: #484;
 }
 
+.alert-danger {
+  background-color: #980035;
+}
+
+.alert-info {
+  background-color: #31708f;
+}
+
 a:link,
 a:active,
 a:hover,


### PR DESCRIPTION
In our usage of sidekiq, we've added some custom tabs to the UI and we're using `alert-danger` and `alert-info` on those pages. The css for these does not look great in dark mode, this PR offers a dark-mode friendly style for those tags.

Here's an example of an `alert-danger` with the proposed style:
![image](https://user-images.githubusercontent.com/14058109/119583730-0e649800-bd7c-11eb-8e96-8cc2fef1b626.png)

Here's an example of an `alert-info` with the proposed style:
![image](https://user-images.githubusercontent.com/14058109/119583770-23412b80-bd7c-11eb-9619-b400d1cbc020.png)
