### PR TITLE
Add Sidekiq::Process#queues method

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -882,6 +882,10 @@ module Sidekiq
       self["identity"]
     end
 
+    def queues
+      self["queues"]
+    end
+
     def quiet!
       signal("TSTP")
     end

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -540,6 +540,7 @@ describe 'API' do
         'key' => identity_string,
         'identity' => identity_string,
         'started_at' => Time.now.to_f - 15,
+        'queues' => ['foo', 'bar']
       }
 
       time = Time.now.to_f
@@ -557,6 +558,7 @@ describe 'API' do
       assert_equal 10, data['busy']
       assert_equal time, data['beat']
       assert_equal 123, data['pid']
+      assert_equal ['foo', 'bar'], data.queues
       data.quiet!
       data.stop!
       signals_string = "#{odata['key']}-signals"

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -70,7 +70,7 @@
           <% end %>
           <br>
           <b><%= "#{t('Queues')}: " %></b>
-          <%= process['queues'] * ", " %>
+          <%= process.queues.join(", ") %>
         </td>
         <td><%= relative_time(Time.at(process['started_at'])) %></td>
         <td><%= format_memory(process['rss'].to_i) %></td>


### PR DESCRIPTION
I wanted to customize the way the queues are displayed in the web UI, but there was no way I could see to do so. This PR adds a `Process#queues` method, replacing the array access and matching similar methods `Process#identity` and `Process#tag`. I can redefine this method when the gem is required, which isn't great, but better than nothing.