### PR TITLE
Fix a Sidekiq Pro tagging bug

### DIFF
--- a/web/views/morgue.erb
+++ b/web/views/morgue.erb
@@ -44,7 +44,7 @@
             </td>
             <td>
               <%= entry.display_class %>
-              <%= display_tags(entry, "morgue") %>
+              <%= display_tags(entry, "dead") %>
             </td>
             <td>
               <div class="args"><%= display_args(entry.display_args) %></div>


### PR DESCRIPTION
**Issue:** Tags on morgue classes do not properly apply filters when clicked. They redirect to a route that Sidekiq does not service.

**Steps to reproduce:**
1. Create an app running Sidekiq.
1. Kill a job with a tag.
1. Click on the tag in the web UI.
1. Observe that the tag does not redirect to a route serviced by Sidekiq Rack app. Depending on how host app is configured, route will 404, redirect, or do something else as it falls through.

**Root cause:**
- It looks like Sidekiq Pro mounts the routes `/filter/dead` but the `display_tags` method links to `/filter/morgue`.

**Notes:**
- There might be other ways of fixing this problem, like change the `/filter/dead` to `/filter/morgue`. 

Let me know if there's any other info needed or test cases we can provide!