### PR TITLE
Feature api for restricting stats calls performed

### DIFF
--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -196,6 +196,17 @@ describe 'API' do
         s = Sidekiq::Stats.new
         assert_equal 3, s.workers_size
       end
+
+      it 'returns null workers_size if the stats object is initialized with skip_workers' do
+        Sidekiq.redis do |c|
+          c.sadd("processes", "process_1")
+          c.sadd("processes", "process_2")
+          c.hset("process_1", "busy", 1)
+          c.hset("process_2", "busy", 2)
+        end
+        s = Sidekiq::Stats.new(skip_workers: true)
+        assert_nil s.workers_size
+      end
     end
   end
 

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -184,6 +184,19 @@ describe 'API' do
         end
       end
     end
+
+    describe "workers_size" do
+      it 'retrieves the number of busy workers' do
+        Sidekiq.redis do |c|
+          c.sadd("processes", "process_1")
+          c.sadd("processes", "process_2")
+          c.hset("process_1", "busy", 1)
+          c.hset("process_2", "busy", 2)
+        end
+        s = Sidekiq::Stats.new
+        assert_equal 3, s.workers_size
+      end
+    end
   end
 
   describe 'with an empty database' do


### PR DESCRIPTION
`Sidekiq::Stats` currently makes 7 + number_of_processes + number_of_queues redis calls. (NOTE: due to pipelining, it's only 4 network trips, so it's not too bad but if you're running hundreds of processes it'd still be nice to skip 100 redis calls if you don't need them).

This Pr proposes an API to allow you to optionally remove `number_of_processes` redis calls from stats initialization. We could additionally allow the user to `skip_enqueued` to reduce the number of redis calls to just 7 at the users discretion.

Let me know what you think, and I can make changes + add documentation as relevant, and could add the `skip_enqueued` as well if you think that would also be useful.

Open questions:
1. Do we want this (my company does, but we can obviously just maintain a fork).
2. Is `skip_workers: true` the right name for this variable?
3. Do we want to save this `skip_workers` argument as an instance variable, so subsequent calls to `fetch_stats!` don't need to explicitly provide this, or leave the api as-is.
4. Do we want to extend this to skip a roundtrip to redis for other things? if so, which things? queues seems like an obvious option, as if a user does each, they'll skip 

(it seemed faster to make a PR to just show what I meant rather than an issue suggesting the change, though obviously it's just a proposal)