### PR TITLE
Quick stats api.

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -32,7 +32,6 @@ module Sidekiq
     end
 
     def enqueued
-      maybe_fetch_stats_slow!
       stat :enqueued
     end
 
@@ -41,7 +40,6 @@ module Sidekiq
     end
 
     def workers_size
-      maybe_fetch_stats_slow!
       stat :workers_size
     end
 
@@ -139,13 +137,11 @@ module Sidekiq
 
     private
 
-    def maybe_fetch_stats_slow!
-      return unless stat(:enqueued).nil? || stat(:workers_size).nil?
-
-      fetch_stats_slow!
-    end
-
     def stat(s)
+      if (s == :enqueued || s == :workers_size) &&
+         @stats.present? && @stats[s].nil?
+        fetch_stats_slow!
+      end
       @stats[s]
     end
 

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -16,6 +16,7 @@ describe 'API' do
       assert_equal 0, s.failed
       assert_equal 0, s.enqueued
       assert_equal 0, s.default_queue_latency
+      assert_equal 0, s.workers_size
     end
 
     describe "processed" do
@@ -68,6 +69,19 @@ describe 'API' do
         s = Sidekiq::Stats.new
         assert_equal 0, s.failed
         assert_equal 5, s.processed
+      end
+    end
+
+    describe "workers_size" do
+      it 'retrieves the number of busy workers' do
+        Sidekiq.redis do |c|
+          c.sadd("processes", "process_1")
+          c.sadd("processes", "process_2")
+          c.hset("process_1", "busy", 1)
+          c.hset("process_2", "busy", 2)
+        end
+        s = Sidekiq::Stats.new
+        assert_equal 3, s.workers_size
       end
     end
 


### PR DESCRIPTION
follow on from https://github.com/mperham/sidekiq/pull/4935

This api seems simpler (I can just call `Sidekiq::Stats::QuickStats.new.fetch_stats!` for my usecase, and we reduce duplication with the main `Stats` api, since there's an overlap).

What do you think?