### PR TITLE
Update Sidekiq.service to reflect the more common use case of a user service

### DIFF
--- a/examples/systemd/sidekiq.service
+++ b/examples/systemd/sidekiq.service
@@ -2,6 +2,14 @@
 # This file tells systemd how to run Sidekiq as a 24/7 long-running daemon.
 #
 # Customize this file based on your bundler location, app directory, etc.
+#
+# If you are going to run this as a user service (or you are going to use capistrano-sidekiq)
+# Customize and copy this to ~/.config/systemd/user
+# Then run:
+#   - systemctl --user enable sidekiq
+#   - systemctl --user {start,stop,restart} sidekiq
+#
+# If you are going to run this as a system service
 # Customize and copy this into /usr/lib/systemd/system (CentOS) or /lib/systemd/system (Ubuntu).
 # Then run:
 #   - systemctl enable sidekiq
@@ -55,10 +63,12 @@ ExecStart=/home/deploy/.rvm/bin/rvm in /opt/myapp/current do bundle exec sidekiq
 
 # Use `systemctl kill -s TSTP sidekiq` to quiet the Sidekiq process
 
-# !!! Change this to your deploy user account !!!
-User=deploy
-Group=deploy
-UMask=0002
+# Uncomment this if you are going to use this as a system service
+# if using as a user service then leave commented out, or you will get an error trying to start the service
+# !!! Change this to your deploy user account if you are using this as a system service !!!
+# User=deploy
+# Group=deploy
+# UMask=0002
 
 # Greatly reduce Ruby memory fragmentation and heap usage
 # https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/


### PR DESCRIPTION
You recommend the use of capistrano-sidekiq. This uses a user service (which is likely a good idea for most users from a security perspective). In order to get it to work, changes need to be made to the Sidekiq.service file (and location).

I describe the challenges I had in [this gist](https://gist.github.com/narath/060f01f3866a1b83d1db6f8cff4c054b) which can give you more context if needed.