### PR TITLE
Use TIMEOUT constant instead of hardcoded 2 second sleep

### DIFF
--- a/lib/sidekiq/fetch.rb
+++ b/lib/sidekiq/fetch.rb
@@ -40,7 +40,7 @@ module Sidekiq
       # 4825 Sidekiq Pro with all queues paused will return an
       # empty set of queues with a trailing TIMEOUT value.
       if qs.size <= 1
-        sleep(2)
+        sleep(TIMEOUT)
         return nil
       end
 

--- a/test/test_fetch.rb
+++ b/test/test_fetch.rb
@@ -57,4 +57,11 @@ describe Sidekiq::BasicFetch do
     assert_equal 1, q2.size
   end
 
+  it 'sleeps when no queues are active' do
+    fetch = Sidekiq::BasicFetch.new(:queues => [])
+    mock = Minitest::Mock.new
+    mock.expect(:call, nil, [Sidekiq::BasicFetch::TIMEOUT])
+    fetch.stub(:sleep, mock) { assert_nil fetch.retrieve_work }
+    mock.verify
+  end
 end


### PR DESCRIPTION
At a quick glance, figured the `sleep(2)` call here should be using the same `TIMEOUT` value being passed to the `brpop` call. Also added a test for the "no active queues" code path.