### PR TITLE
Allow sidekiq_retry_in to return a range

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 HEAD
 ---------
 
+- Sidekiq::Worker `sidekiq_retry_in` block can now return a range [#4957]
 - Minimize scheduler load on Redis at scale [#4882]
 - Improve logging of delay jobs [#4904, BuonOno]
 - Minor CSS improvements for buttons and tables, design PRs always welcome!

--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -215,7 +215,12 @@ module Sidekiq
 
     def delay_for(worker, count, exception)
       if worker&.sidekiq_retry_in_block
-        custom_retry_in = retry_in(worker, count, exception).to_i
+        range_or_interval = retry_in(worker, count, exception)
+        custom_retry_in = if range_or_interval.is_a?(Range)
+          rand(range_or_interval)
+        else
+          range_or_interval
+        end.to_i
         return custom_retry_in if custom_retry_in > 0
       end
       seconds_to_delay(count)

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -287,6 +287,8 @@ describe Sidekiq::JobRetry do
             Sidekiq::JobRetry::USE_DEFAULT_RETRY_FORMULA
           when ArgumentError
             count * 4
+          when ZeroDivisionError
+            (count..count * 2)
           else
             count * 2
           end
@@ -311,6 +313,10 @@ describe Sidekiq::JobRetry do
 
       it "retries with a custom delay and exception 2" do
         assert_equal 4, handler.__send__(:delay_for, CustomWorkerWithException, 2, StandardError.new)
+      end
+
+      it "retries with a custom delay and exception 3" do
+        assert_includes 2..4, handler.__send__(:delay_for, CustomWorkerWithException, 2, ZeroDivisionError.new)
       end
 
       it "retries with a default delay and exception in case of configured with nil" do


### PR DESCRIPTION
The idea is to make it easier to implement (and reason about) exponential (and not only!) [backoffs with jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/).