### PR TITLE
Use no-store for web UI to prevent intermediate caching

### DIFF
--- a/lib/sidekiq/web/action.rb
+++ b/lib/sidekiq/web/action.rb
@@ -68,7 +68,7 @@ module Sidekiq
     end
 
     def json(payload)
-      [200, {"Content-Type" => "application/json", "Cache-Control" => "no-cache"}, [Sidekiq.dump_json(payload)]]
+      [200, {"Content-Type" => "application/json", "Cache-Control" => "no-store"}, [Sidekiq.dump_json(payload)]]
     end
 
     def initialize(env, block)

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -314,7 +314,7 @@ module Sidekiq
         # rendered content goes here
         headers = {
           "Content-Type" => "text/html",
-          "Cache-Control" => "no-cache",
+          "Cache-Control" => "no-store",
           "Content-Language" => action.locale,
           "Content-Security-Policy" => CSP_HEADER
         }


### PR DESCRIPTION
This PR replaces the default `Cache-Control` for the Web UI to be `no-store` instead of `no-cache`. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#cacheability).

## Why?

This seems like a saner default to use - tell servers that we don't want the page cached _anywhere_. Using `no-cache` says that the page can still be cached by intermediates as long as the page is revalidated. We ran into this issue with the Web UI behind Fastly - since the Web UI doesn't support Etags/If-Modified-Since, it seems like cache validation is just being performed by looking at the content length. This means that we were getting cached responses (such as stat data) that were clearly stale but matched the content length of the previous request.

Similarly, it's not uncommon to put the Web UI behind some authentication system (such as `sidekiq-ent` provides). It looks like `sidekiq-ent` doesn't modify the cache headers at all, but when authentication is done we should have `private` (or just `no-store`) to prevent authenticated pages from being cached and returned to another user.

Alternatively we can use `no-cache, private`, although I'm not sure it would give much benefit over just not storing anywhere 🤔 