### PR TITLE
Add private to Web UI Cache-Control to prevent request collapsing

### DIFF
--- a/lib/sidekiq/web/action.rb
+++ b/lib/sidekiq/web/action.rb
@@ -68,7 +68,7 @@ module Sidekiq
     end
 
     def json(payload)
-      [200, {"Content-Type" => "application/json", "Cache-Control" => "no-store"}, [Sidekiq.dump_json(payload)]]
+      [200, {"Content-Type" => "application/json", "Cache-Control" => "private, no-store"}, [Sidekiq.dump_json(payload)]]
     end
 
     def initialize(env, block)

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -314,7 +314,7 @@ module Sidekiq
         # rendered content goes here
         headers = {
           "Content-Type" => "text/html",
-          "Cache-Control" => "no-store",
+          "Cache-Control" => "private, no-store",
           "Content-Language" => action.locale,
           "Content-Security-Policy" => CSP_HEADER
         }


### PR DESCRIPTION
As a follow up to #4966, I realized it's also important to add `private` to the Cache-Control header as well to prevent [request collapsing](https://developer.fastly.com/learning/concepts/request-collapsing/). Even with `no-store`, Fastly (and I assume other places) can still collapse requests.

Note that this is only important if the Web UI is behind some form of authentication, since it provides the possibility of sending authenticated data to non-authenticated users under very specific circumstances.

This matches the example [here](https://developer.fastly.com/solutions/examples/prohibit-browser-caching) that fastly shows to prevent downstream caching + request collapsing.