### PR TITLE
Disable new minitest parallelism

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,6 +8,7 @@ require 'minitest/autorun'
 
 $TESTING = true
 # disable minitest/parallel threads
+ENV["MT_CPU"] = 0
 ENV["N"] = "0"
 # Disable any stupid backtrace cleansers
 ENV["BACKTRACE"] = "1"


### PR DESCRIPTION
This PR disables the new minitest parallelism environment variable
`MT_CPU` that is meant to take over from `N`.

https://github.com/seattlerb/minitest/blob/f4f57afaeb3a11bd0b86ab0757704cb78db96cf4/lib/minitest.rb#L25-L27