### PR TITLE
Fix faulty environment variable value

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,7 @@ require 'minitest/autorun'
 
 $TESTING = true
 # disable minitest/parallel threads
-ENV["MT_CPU"] = 0
+ENV["MT_CPU"] = "0"
 ENV["N"] = "0"
 # Disable any stupid backtrace cleansers
 ENV["BACKTRACE"] = "1"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,6 +8,7 @@ require 'minitest/autorun'
 
 $TESTING = true
 # disable minitest/parallel threads
+ENV["MT_CPU"] = 0
 ENV["N"] = "0"
 # Disable any stupid backtrace cleansers
 ENV["BACKTRACE"] = "1"


### PR DESCRIPTION
This PR fixes the faulty environment value that was introduced in #4980,
where you cannot set an environment variable as an integer but it must
instead be a string.
