### PR TITLE
Helper middleware to preserve implicit context?

### DIFF
--- a/lib/sidekiq/middleware/current_attributes.rb
+++ b/lib/sidekiq/middleware/current_attributes.rb
@@ -1,12 +1,17 @@
 require "active_support/current_attributes"
 
 module Sidekiq
+  ##
   # Automatically save and load any current attributes in the execution context
-  # so the context "flows" from a Rails controller into any associated job execution.
-  # See ActiveSupport::CurrentAttributes. Usage:
+  # so context attributes "flow" from Rails actions into any associated jobs.
+  # This can be useful for multi-tenancy, i18n locale, timezone, any implicit
+  # per-request attribute. See +ActiveSupport::CurrentAttributes+.
   #
-  # require "sidekiq/middleware/context"
-  # Sidekiq::CurrentAttributes.persist(Myapp::Current)
+  # @example
+  #
+  #   # in your initializer
+  #   require "sidekiq/middleware/current_attributes"
+  #   Sidekiq::CurrentAttributes.persist(Myapp::Current)
   #
   module CurrentAttributes
     class Save
@@ -25,7 +30,7 @@ module Sidekiq
         @klass = with
       end
 
-      def call(_, job, _, _, &block)
+      def call(_, job, _, &block)
         @klass.set(job["ctx"], &block)
       end
     end

--- a/lib/sidekiq/middleware/current_attributes.rb
+++ b/lib/sidekiq/middleware/current_attributes.rb
@@ -1,0 +1,43 @@
+require "active_support/current_attributes"
+
+module Sidekiq
+  # Automatically save and load any current attributes in the execution context
+  # so the context "flows" from a Rails controller into any associated job execution.
+  # See ActiveSupport::CurrentAttributes. Usage:
+  #
+  # require "sidekiq/middleware/context"
+  # Sidekiq::CurrentAttributes.persist(Myapp::Current)
+  #
+  module CurrentAttributes
+    class Save
+      def initialize(with:)
+        @klass = with
+      end
+
+      def call(_, job, _, _)
+        job["ctx"] = @klass.attributes
+        yield
+      end
+    end
+
+    class Load
+      def initialize(with:)
+        @klass = with
+      end
+
+      def call(_, job, _, _, &block)
+        @klass.set(job["ctx"], &block)
+      end
+    end
+
+    def self.persist(klass)
+      Sidekiq.configure_client do |config|
+        config.client_middleware.add Save, with: klass
+      end
+      Sidekiq.configure_server do |config|
+        config.client_middleware.add Save, with: klass
+        config.server_middleware.add Load, with: klass
+      end
+    end
+  end
+end

--- a/test/test_current_attributes.rb
+++ b/test/test_current_attributes.rb
@@ -1,0 +1,51 @@
+require_relative "./helper"
+require "sidekiq/middleware/current_attributes"
+
+module Myapp
+  class Current < ActiveSupport::CurrentAttributes
+    attribute :user_id
+  end
+end
+
+class TestCurrentAttributes < Minitest::Test
+  def test_save
+    cm = Sidekiq::CurrentAttributes::Save.new(with: Myapp::Current)
+    job = {}
+    with_context(:user_id, 123) do
+      cm.call(nil, job, nil, nil) do
+        assert_equal 123, job["ctx"][:user_id]
+      end
+    end
+  end
+
+  def test_load
+    cm = Sidekiq::CurrentAttributes::Load.new(with: Myapp::Current)
+
+    job = { "ctx" => { "user_id" => 123 } }
+    assert_nil Myapp::Current.user_id
+    cm.call(nil, job, nil) do
+      assert_equal 123, Myapp::Current.user_id
+    end
+    # the Rails reloader is responsible for reseting Current after every unit of work
+  end
+
+  def test_persist
+    begin
+      Sidekiq::CurrentAttributes.persist(Myapp::Current)
+    ensure
+      Sidekiq.client_middleware.clear
+      Sidekiq.server_middleware.clear
+    end
+  end
+
+  private
+
+  def with_context(attr, value)
+    begin
+      Myapp::Current.send("#{attr}=", value)
+      yield
+    ensure
+      Myapp::Current.reset_all
+    end
+  end
+end


### PR DESCRIPTION
Implicit context via thread-local variables can be a powerful tool for things like multi-tenancy, logging, i18n, etc. Rails has ActiveSupport::CurrentAttributes, there's also gems like RequestStore. It would be excellent if Sidekiq included helper middleware that knows how to de-hydrate and re-hydrate variables between client and server so jobs can preserve this implicit context for their execution.

For example, one possible API:

```ruby
Sidekiq.configure_client do |config|
  config.client_middleware do |chain|
    chain.add Sidekiq::Context::Save, with: Myapp::Current
  end
end

class Sidekiq::Context::Save
  def call(_, job, _, _)
    # enumerate all saved attributes and de-hydrate them into the job hash
  end
end
```