### PR TITLE
Reconnect on "UNBLOCKED force unblock" errors

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -100,7 +100,8 @@ module Sidekiq
         # 2550 Failover can cause the server to become a replica, need
         # to disconnect and reopen the socket to get back to the primary.
         # 4495 Use the same logic if we have a "Not enough replicas" error from the primary
-        if retryable && ex.message =~ /READONLY|NOREPLICAS/
+        # 4985 Use the same logic when a blocking command is force-unblocked
+        if retryable && ex.message =~ /READONLY|NOREPLICAS|UNBLOCKED/
           conn.disconnect!
           retryable = false
           retry

--- a/test/test_sidekiq.rb
+++ b/test/test_sidekiq.rb
@@ -96,6 +96,16 @@ describe Sidekiq do
       assert_equal 2, counts.size
       assert_equal counts[0] + 1, counts[1]
     end
+
+    it 'reconnects if instance state changed' do
+      counts = []
+      Sidekiq.redis do |c|
+        counts << c.info['total_connections_received'].to_i
+        raise Redis::CommandError, "UNBLOCKED force unblock from blocking operation, instance state changed (master -> replica?)" if counts.size == 1
+      end
+      assert_equal 2, counts.size
+      assert_equal counts[0] + 1, counts[1]
+    end
   end
 
   describe 'redis info' do


### PR DESCRIPTION
Thanks a lot for Sidekiq!

In our setup with a Redis cluster, we are having regular failovers,
which is fine. We are currently improving the way our application
handles these situations and stumbled across a possible improvement
in Sidekiq itself.

By far the most frequent error in our error monitoring system is the
following:

    UNBLOCKED force unblock from blocking operation, instance state changed (master -> replica?)

These errors can occur during Sidekiq's long-running job fetching
command. This uses Redis' blocking BRPOP primitive. On failover in a
cluster setup, these commands are interrupted by the server.

This error causes the worker threads to be restarted, but as they are
bubbled up to the top, they cause a lot of spam in our error logging
systems. As related errors from other commands are being handled (see
#2550 and #4495) this way, it seems senbile to also handle this one.

#### Details

<details>
<summary>Stacktrace</summary>

```
Redis::CommandError: UNBLOCKED force unblock from blocking operation, instance state changed (master -> replica?)
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis/client.rb:132:in `call'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis/client.rb:226:in `block in call_with_timeout'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis/client.rb:300:in `with_socket_timeout'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis/client.rb:225:in `call_with_timeout'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis.rb:1224:in `block in _bpop'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis.rb:69:in `block in synchronize'
  from monitor.rb:202:in `synchronize'
  from monitor.rb:202:in `mon_synchronize'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis.rb:69:in `synchronize'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis.rb:1221:in `_bpop'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis.rb:1266:in `brpop'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/fetch.rb:47:in `block in retrieve_work'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq.rb:98:in `block in redis'
  from vendor/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:63:in `block (2 levels) in with'
  from vendor/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:62:in `handle_interrupt'
  from vendor/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:62:in `block in with'
  from vendor/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:59:in `handle_interrupt'
  from vendor/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:59:in `with'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq.rb:95:in `redis'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/fetch.rb:47:in `retrieve_work'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:83:in `get_one'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:95:in `fetch'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:77:in `process_one'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:68:in `run'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/util.rb:43:in `watchdog'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/util.rb:52:in `block in safe_thread'
  from vendor/ruby/2.7.0/gems/logging-2.3.0/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
```
</details>