### PR TITLE
coexist with other signal handlers

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,8 @@ require "sidekiq/middleware/current_attributes"
 Sidekiq::CurrentAttributes.persist(Myapp::Current) # Your AS:CurrentAttributes singleton
 ```
 - Retry Redis operation if we get an `UNBLOCKED` Redis error. [#4985]
+- **BREAKING CHANGE** Run existing signal-handling code, if there is any, before running sidekiq's
+  signal-handling code. [#4991]
 
 6.2.2
 ---------

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -46,7 +46,10 @@ module Sidekiq
       # USR1 and USR2 don't work on the JVM
       sigs << "USR2" if Sidekiq.pro? && !jruby?
       sigs.each do |sig|
-        trap sig do
+        old_handler = Signal.trap(sig) do
+          if old_handler.respond_to?(:call)
+            old_handler.call
+          end
           self_write.puts(sig)
         end
       rescue ArgumentError

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -48,7 +48,11 @@ module Sidekiq
       sigs.each do |sig|
         old_handler = Signal.trap(sig) do
           if old_handler.respond_to?(:call)
-            old_handler.call
+            begin
+              old_handler.call
+            rescue Exception
+              puts $!.inspect
+            end
           end
           self_write.puts(sig)
         end


### PR DESCRIPTION
Using a technique I learned from the fantastic [Working With Unix Processes](https://www.amazon.co.uk/Working-Unix-Processes-Jesse-Storimer-ebook/dp/B0078VSRUE), this allows other signal handlers to coexist with sidkiq. Simple example:


### config/initializers/sidekiq.rb

```ruby
Sidekiq.configure_server do |config|
  trap('INT') do
    puts "TRAPPED!"
  end
end
```

Before this PR, this will never run. With the PR, this will run before the sidekiq behavior runs.

I tried writing a test in test_cli.rb and spent longer than I'd care to admit before I realized the tests there don't send signals, they just invoke the method.

Are there any other tests in the suite which do run processes and send signals? If so I'll try to put something in there.

Let me know what you think!