### PR TITLE
Sidekiq::Client.push_bulk fails because Enumerable#all? doesn't understand ActiveSupport::Duration is Numeric

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -95,7 +95,7 @@ module Sidekiq
       return [] if args.empty? # no jobs to push
 
       at = items.delete("at")
-      raise ArgumentError, "Job 'at' must be a Numeric or an Array of Numeric timestamps" if at && (Array(at).empty? || !Array(at).all?(Numeric))
+      raise ArgumentError, "Job 'at' must be a Numeric or an Array of Numeric timestamps" if at && (Array(at).empty? || !Array(at).all?{|entry| entry.is_a?(Numeric) })
       raise ArgumentError, "Job 'at' Array must have same size as 'args' Array" if at.is_a?(Array) && at.size != args.size
 
       normed = normalize_item(items)

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -148,6 +148,11 @@ describe Sidekiq::Client do
       assert_equal second_at, Sidekiq::ScheduledSet.new.find_job(second_jid).at
     end
 
+    it 'can push jobs scheduled using ActiveSupport::Duration' do
+      jids = Sidekiq::Client.push_bulk('class' => QueuedWorker, 'args' => [[1], [2]], 'at' => [1.seconds, 111.seconds])
+      assert_equal 2, jids.size
+    end
+
     it 'returns the jids for the jobs' do
       Sidekiq::Client.push_bulk('class' => 'QueuedWorker', 'args' => (1..2).to_a.map { |x| Array(x) }).each do |jid|
         assert_match(/[0-9a-f]{12}/, jid)


### PR DESCRIPTION
Ruby version: 2.7.4
Rails version: 6.0.3.4
Sidekiq / Pro / Enterprise version(s): 6.2.1, 5.2.2, 2.2.2

### Enumerable#all? doesn't understand ActiveSupport::Duration

Sidekiq::Client.push_bulk uses the Ruby Enumerable#all? to ensure the 'at' is valid. The problem is all? incorrectly evaluates an array of ActiveSupport::Duration as not being all Numeric. 

Sidekiq::Client.push_bulk is using the following check for at validity

```ruby
raise ArgumentError, "Job 'at' must be a Numeric or an Array of Numeric timestamps" if at && (Array(at).empty? || !Array(at).all?(Numeric))
```

### Examples

These are all valid values for 'at' but some would fail the above check

```ruby
1.is_a?(Numeric)                                                      #=> true
1.seconds.is_a?(Numeric)                                              #=> true # Fails the all? check
(1.seconds).is_a?(Numeric)                                            #=> true # Fails the all? check
Array(1.seconds).map{ _1.is_a?(Numeric) }                             #=> [true] # Fails the all? check
Array(1).map{ _1.is_a?(Numeric) }                                     #=> [true]
[1.seconds].map{ _1.is_a?(Numeric) }                                  #=> [true] # Fails the all? check
[1].map{ _1.is_a?(Numeric) }                                          #=> [true]
[1, 2i, 3.14].all?(Numeric)                                           #=> true
[1.seconds, 2.seconds, 3.seconds, 4.seconds].map{ _1.is_a?(Numeric) } #=> [true, true, true, true] # Fails the all? check

```

These are all valid but fail the all? above check

```ruby
Array(1.seconds).all?(Numeric)         #=> false
[1.seconds].all?(Numeric)              #=> false
[1, 2i, 3.14, 1.seconds].all?(Numeric) #=> false
```

These are valid calls to push_bulk

```ruby
Sidekiq::Client.push_bulk('class' => MyJob, 'args' => [[1], [2]])
Sidekiq::Client.push_bulk('at' => 1, 'class' => MyJob, 'args' => [[1], [2]])
Sidekiq::Client.push_bulk('at' => [1, 1], 'class' => MyJob, 'args' => [[1], [2]])
```

These calls will fail but should be valid

```ruby
Sidekiq::Client.push_bulk('at' => 1.seconds, 'class' => MyJob, 'args' => [[1], [2]])
Sidekiq::Client.push_bulk('at' => [1.seconds, 1.seconds], 'class' => MyJob, 'args' => [[1], [2]])
```

### Resolution

For the moment we will pass in an integer of seconds instead of an ActiveSupport::Duration

Until Enumerable#all? can support ActiveSupport::Duration any usage of 
```ruby
all?(Numeric)
```
should be replaced with something else like
```ruby
all?{ _1.is_a?(Numeric) }
```

all? with a block is smart enough to quit on the first false but I don't know if it is as fast as passing Numeric directly