### PR TITLE
Preserve behaviour of fetch_stats! returning stats.

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -113,6 +113,7 @@ module Sidekiq
 
       @stats[:workers_size] = workers_size
       @stats[:enqueued] = enqueued
+      @stats
     end
 
     def fetch_stats!


### PR DESCRIPTION
Preserve behaviour of previous `fetch_stats!` call.

While `fetch_stats!` might be better private, I think the api as-is is a bit cleaner if we make this change and preserve the previous behaviour.

I completely understand if you want to close instead though given your previous comment. Just thought I'd throw out the solution here so it's an easy option.

Follow on from https://github.com/mperham/sidekiq/pull/4936#issuecomment-924378724