### PR TITLE
Support ActiveJob’s wait_until

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,8 +19,9 @@ end
 ```ruby
 # config/initializers/sidekiq.rb
 require "sidekiq/middleware/current_attributes"
-Sidekiq::CurrentAttributes.persist(Myapp::Current) # Your AS:CurrentAttributes singleton
+Sidekiq::CurrentAttributes.persist(Myapp::Current) # Your AS::CurrentAttributes singleton
 ```
+- Implement `queue_as` and `wait_until` for ActiveJob compatibility [#5003]
 - Retry Redis operation if we get an `UNBLOCKED` Redis error. [#4985]
 - Run existing signal traps, if any, before running Sidekiq's trap. [#4991]
 

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -33,11 +33,13 @@ module Sidekiq
   #     end
   #   end
   #
-  #   SomeWorker.set(wait_until: 1.hour).perform_later(123)
+  #   SomeWorker.set(wait_until: 1.hour).perform_async(123)
   #
   # Note that arguments passed to the job must still obey Sidekiq's
   # best practice for simple, JSON-native data types. Sidekiq will not
-  # implement ActiveJob's more complex argument serialization.
+  # implement ActiveJob's more complex argument serialization. For
+  # this reason, we don't implement `perform_later` as our call semantics
+  # are very different.
   #
   module Worker
     ##

--- a/test/test_worker.rb
+++ b/test/test_worker.rb
@@ -5,7 +5,8 @@ describe Sidekiq::Worker do
 
     class SetWorker
       include Sidekiq::Worker
-      sidekiq_options :queue => :foo, 'retry' => 12
+      queue_as :foo
+      sidekiq_options 'retry' => 12
     end
 
     def setup
@@ -18,6 +19,14 @@ describe Sidekiq::Worker do
       jid = SetWorker.set(wait_until: 1.hour).perform_later(123)
       assert jid
       assert_equal 1, q.size
+
+      q = Sidekiq::Queue.new("foo")
+      assert_equal 0, q.size
+      SetWorker.perform_later
+      assert_equal 1, q.size
+
+      SetWorker.set(queue: 'xyz').perform_later
+      assert_equal 1, Sidekiq::Queue.new("xyz").size
     end
 
     it 'can be memoized' do

--- a/test/test_worker.rb
+++ b/test/test_worker.rb
@@ -16,16 +16,16 @@ describe Sidekiq::Worker do
     it "provides basic ActiveJob compatibilility" do
       q = Sidekiq::ScheduledSet.new
       assert_equal 0, q.size
-      jid = SetWorker.set(wait_until: 1.hour).perform_later(123)
+      jid = SetWorker.set(wait_until: 1.hour).perform_async(123)
       assert jid
       assert_equal 1, q.size
 
       q = Sidekiq::Queue.new("foo")
       assert_equal 0, q.size
-      SetWorker.perform_later
+      SetWorker.perform_async
       assert_equal 1, q.size
 
-      SetWorker.set(queue: 'xyz').perform_later
+      SetWorker.set(queue: 'xyz').perform_async
       assert_equal 1, Sidekiq::Queue.new("xyz").size
     end
 

--- a/test/test_worker.rb
+++ b/test/test_worker.rb
@@ -12,6 +12,14 @@ describe Sidekiq::Worker do
       Sidekiq.redis {|c| c.flushdb }
     end
 
+    it "provides basic ActiveJob compatibilility" do
+      q = Sidekiq::ScheduledSet.new
+      assert_equal 0, q.size
+      jid = SetWorker.set(wait_until: 1.hour).perform_later(123)
+      assert jid
+      assert_equal 1, q.size
+    end
+
     it 'can be memoized' do
       q = Sidekiq::Queue.new('bar')
       assert_equal 0, q.size


### PR DESCRIPTION
`SomeJob.set(wait_until: 1.hour).perform_later`

Sidekiq::Worker supports `set` to make it easy for people to convert from one API to another but does not know about `wait_until`. Implement it.