### PR TITLE
CI: Avoid double bundle install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,7 @@ jobs:
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
-        bundler-cache: true
+        bundler-cache: true # 'bundle install' and cache gems
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle install
     - name: Run tests
       run: bundle exec rake


### PR DESCRIPTION
We use bundler-cache: true which does bundle install.