### PR TITLE
Fix rbenv usage example in systemd service

### DIFF
--- a/examples/systemd/sidekiq.service
+++ b/examples/systemd/sidekiq.service
@@ -50,7 +50,7 @@ WatchdogSec=10
 
 WorkingDirectory=/opt/myapp/current
 # If you use rbenv:
-# ExecStart=/bin/bash -lc 'exec /home/deploy/.rbenv/shims/bundle exec sidekiq -e production'
+# ExecStart=/bin/bash -lc '/home/deploy/.rbenv/shims/bundle exec sidekiq -e production'
 # If you use the system's ruby:
 # ExecStart=/usr/local/bin/bundle exec sidekiq -e production
 # If you use rvm in production without gemset and your ruby version is 2.6.5


### PR DESCRIPTION
Fixed rbenv usage example in the systemd service. There was an additional `exec` (probably copy/paste from "bundle exec")