### PR TITLE
Fix `Uncaught exception: can't dump IO`

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -94,12 +94,10 @@ module Sidekiq
       def log_info(options)
         redacted = "REDACTED"
 
-        # deep clone so we can muck with these options all we want
-        #
-        # exclude SSL params from dump-and-load because some information isn't
-        # safely dumpable in current Rubies
-        keys = options.keys
-        keys.delete(:ssl_params)
+        # Deep clone so we can muck with these options all we want and exclude
+        # params from dump-and-load that may contain objects that Marshal is
+        # unable to safely dump.
+        keys = options.keys - [:logger, :ssl_params]
         scrubbed_options = Marshal.load(Marshal.dump(options.slice(*keys)))
         if scrubbed_options[:url] && (uri = URI.parse(scrubbed_options[:url])) && uri.password
           uri.password = redacted


### PR DESCRIPTION
An error occurs when the underlying Redis client is configured with a logger, due to the limitations of `Marshal` when dealing with `IO` objects. This change excludes the `:logger` option in a similar fashion to the way `:ssl_params` is currently excluded.

This error can be reproduced with the following:

```ruby
Sidekiq.configure_client do |config|
  config.redis = { logger: Logger.new(STDOUT) }
end
```

The complete exception message and stacktrace is as follows:

    Uncaught exception: can't dump IO
    	/usr/local/bundle/gems/sidekiq-6.2.2/lib/sidekiq/redis_connection.rb:103:in `dump'
    	/usr/local/bundle/gems/sidekiq-6.2.2/lib/sidekiq/redis_connection.rb:103:in `log_info'
    	/usr/local/bundle/gems/sidekiq-6.2.2/lib/sidekiq/redis_connection.rb:32:in `create'
    	/usr/local/bundle/gems/sidekiq-6.2.2/lib/sidekiq.rb:137:in `redis='

**Note:** I recognize this isn't a common need but it's useful for enabling some additional debug logging from the Redis driver.