### PR TITLE
Implement `Sidekiq::Worker.perform_bulk`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,16 @@ end
 require "sidekiq/middleware/current_attributes"
 Sidekiq::CurrentAttributes.persist(Myapp::Current) # Your AS::CurrentAttributes singleton
 ```
+- **FEATURE**: Introduce new method, `.perform_bulk` on `Sidekiq::Worker` that makes enqueuing
+  jobs in bulk adhere to Redis best practices by enqueuing 1,000 jobs per round trip. This
+  shares a similar args syntax to `Sidekiq::Client.push_bulk`. Batch sizes can be configured
+  with the optional `batch_size:` keyword argument.
+```ruby
+MyJob.perform_bulk([[1], [2], [3]])
+
+# With a batch size provided:
+MyJob.perform_bulk([[1], [2], [3]], batch_size: 100)
+```
 - Implement `queue_as`, `wait` and `wait_until` for ActiveJob compatibility [#5003]
 - Retry Redis operation if we get an `UNBLOCKED` Redis error. [#4985]
 - Run existing signal traps, if any, before running Sidekiq's trap. [#4991]

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -235,8 +235,8 @@ module Sidekiq
         client_push("class" => self, "args" => args)
       end
 
-      def perform_bulk(items)
-        items.each_slice(1_000).flat_map do |slice|
+      def perform_bulk(items, batch_size: 1_000)
+        items.each_slice(batch_size).flat_map do |slice|
           Sidekiq::Client.push_bulk("class" => self, "args" => slice)
         end
       end

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -235,6 +235,12 @@ module Sidekiq
         client_push("class" => self, "args" => args)
       end
 
+      def perform_bulk(items)
+        items.each_slice(1_000).flat_map do |slice|
+          Sidekiq::Client.push_bulk("class" => self, "args" => slice)
+        end
+      end
+
       # +interval+ must be a timestamp, numeric or something that acts
       #   numeric (like an activesupport time interval).
       def perform_in(interval, *args)

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -241,6 +241,26 @@ module Sidekiq
         client_push("class" => self, "args" => args)
       end
 
+      ##
+      # Push a large number of jobs to Redis, while limiting the batch of
+      # each job payload to 1,000. This method helps cut down on the number
+      # of round trips to Redis, which can increase the performance of enqueueing
+      # large numbers of jobs.
+      #
+      # +items+ must be an Array of Arrays.
+      #
+      # For finer-grained control, use `Sidekiq::Client.push_bulk` directly.
+      #
+      # Example (3 Redis round trips):
+      #
+      #     SomeWorker.perform_async(1)
+      #     SomeWorker.perform_async(2)
+      #     SomeWorker.perform_async(3)
+      #
+      # Would instead become (1 Redis round trip):
+      #
+      #     SomeWorker.perform_bulk([[1], [2], [3]])
+      #
       def perform_bulk(items, batch_size: 1_000)
         items.each_slice(batch_size).flat_map do |slice|
           Sidekiq::Client.push_bulk("class" => self, "args" => slice)

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -191,6 +191,12 @@ module Sidekiq
         @klass.client_push(@opts.merge("args" => args, "class" => @klass))
       end
 
+      def perform_bulk(args, batch_size: 1_000)
+        args.each_slice(batch_size).flat_map do |slice|
+          Sidekiq::Client.push_bulk(@opts.merge("class" => @klass, "args" => slice))
+        end
+      end
+
       # +interval+ must be a timestamp, numeric or something that acts
       #   numeric (like an activesupport time interval).
       def perform_in(interval, *args)

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -190,6 +190,11 @@ describe Sidekiq::Client do
         assert_equal 1_001, jids.size
       end
 
+      it 'pushes a large set of jobs with a different batch size' do
+        jids = MyWorker.perform_bulk((1..1_001).to_a.map { |x| Array(x) }, batch_size: 100)
+        assert_equal 1_001, jids.size
+      end
+
       it 'handles no jobs' do
         jids = MyWorker.perform_bulk([])
         assert_equal 0, jids.size

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -183,6 +183,26 @@ describe Sidekiq::Client do
         end
       end
     end
+
+    describe '.perform_bulk' do
+      it 'pushes a large set of jobs' do
+        jids = MyWorker.perform_bulk((1..1_001).to_a.map { |x| Array(x) })
+        assert_equal 1_001, jids.size
+      end
+
+      it 'handles no jobs' do
+        jids = MyWorker.perform_bulk([])
+        assert_equal 0, jids.size
+      end
+
+      describe 'errors' do
+        it 'raises ArgumentError with invalid params' do
+          assert_raises ArgumentError do
+            Sidekiq::Client.push_bulk('class' => 'MyWorker', 'args' => [[1], 2])
+          end
+        end
+      end
+    end
   end
 
   class BaseWorker

--- a/test/test_worker.rb
+++ b/test/test_worker.rb
@@ -80,5 +80,16 @@ describe Sidekiq::Worker do
       assert_equal 'foo', job['queue']
       assert_equal 'xyz', job['bar']
     end
+
+    it 'works with .perform_bulk' do
+      q = Sidekiq::Queue.new('bar')
+      assert_equal 0, q.size
+
+      set = SetWorker.set('queue' => 'bar')
+      jids = set.perform_bulk((1..1_001).to_a.map { |x| Array(x) })
+
+      assert_equal 1_001, q.size
+      assert_equal 1_001, jids.size
+    end
   end
 end


### PR DESCRIPTION
This is the code implements #5041.

We've got a monkey-patch into `Sidekiq::Worker::ClassMethods` and `Sidekiq::Worker::Setter` that we have been getting a lot of mileage out of that might be worth upstreaming. 

Background: We do a lot of batch processing, needing to enqueue 1000's or 100's of K's of jobs at once. We were using [`Sidekiq::Client.push_bulk`](https://www.rubydoc.info/github/mperham/sidekiq/Sidekiq%2FClient:push_bulk) with an `each_slice` to create chunks of 1000. 

Enter what we call `.perform_bulk`. It's an implementation of `Sidekiq::Client.push_bulk` that encodes the best practice of 1000 jobs at a time. This allows clients to enqueue many jobs without the sharp edge of forgetting to slice their batch up into smaller chunks.

Downside here is that the `.push_bulk`-based approach _does_ communicate to the client, "Hey, you're interacting with the network N times (once per loop)."

This PR has the implementation and tests for the `.perform_bulk` method. Please let me know if anything looks amiss, but I tried to keep things as idiomatic as possible. 

**Notes:**

- [x] Should I update the CHANGELOG or is that for the repo maintainers to update?
- [ ] I took a stab at a comment, but wasn't sure if it was too verbose. Feel free to slim down.