### PR TITLE
Use Redis.pipelined instead of Redis.multi when pushing jobs

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -186,7 +186,7 @@ module Sidekiq
 
     def raw_push(payloads)
       @redis_pool.with do |conn|
-        conn.multi do
+        conn.pipelined do
           atomic_push(conn, payloads)
         end
       end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -233,7 +233,7 @@ describe Sidekiq::Client do
 
     it 'allows sidekiq_options to point to different Redi' do
       conn = MiniTest::Mock.new
-      conn.expect(:multi, [0, 1])
+      conn.expect(:pipelined, [0, 1])
       DWorker.sidekiq_options('pool' => ConnectionPool.new(size: 1) { conn })
       DWorker.perform_async(1,2,3)
       conn.verify
@@ -241,7 +241,7 @@ describe Sidekiq::Client do
 
     it 'allows #via to point to same Redi' do
       conn = MiniTest::Mock.new
-      conn.expect(:multi, [0, 1])
+      conn.expect(:pipelined, [0, 1])
       sharded_pool = ConnectionPool.new(size: 1) { conn }
       Sidekiq::Client.via(sharded_pool) do
         Sidekiq::Client.via(sharded_pool) do
@@ -255,11 +255,11 @@ describe Sidekiq::Client do
       default = Sidekiq::Client.new.redis_pool
 
       moo = MiniTest::Mock.new
-      moo.expect(:multi, [0, 1])
+      moo.expect(:pipelined, [0, 1])
       beef = ConnectionPool.new(size: 1) { moo }
 
       oink = MiniTest::Mock.new
-      oink.expect(:multi, [0, 1])
+      oink.expect(:pipelined, [0, 1])
       pork = ConnectionPool.new(size: 1) { oink }
 
       Sidekiq::Client.via(beef) do
@@ -278,7 +278,7 @@ describe Sidekiq::Client do
 
     it 'allows Resque helpers to point to different Redi' do
       conn = MiniTest::Mock.new
-      conn.expect(:multi, []) { |*args, &block| block.call }
+      conn.expect(:pipelined, []) { |*args, &block| block.call }
       conn.expect(:zadd, 1, [String, Array])
       DWorker.sidekiq_options('pool' => ConnectionPool.new(size: 1) { conn })
       Sidekiq::Client.enqueue_in(10, DWorker, 3)


### PR DESCRIPTION
We don't need the commands here to be atomic so we use command pipelining instead
to save us some overhead from `MULTI`.

https://github.com/mperham/sidekiq/commit/ac69c7ee5e42357a0f87957d17d38e5512ed66bb references Sidekiq Pro so I don't know if this affects Sidekiq Pro's atomic batches. But maybe this could be overridden in Pro to use `multi`?

We have been running with this patch on GitLab.com for a week: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/72473

Effects on Redis CPU were inconclusive but I think it's a good change to make anyway?