### PR TITLE
Make `.perform_bulk` immediately evaluate lazy enumerators.

### DIFF
--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -192,10 +192,11 @@ module Sidekiq
       end
 
       def perform_bulk(args, batch_size: 1_000)
-        args = args.force if args.is_a?(Enumerator::Lazy)
-        args.each_slice(batch_size).flat_map do |slice|
+        result = args.each_slice(batch_size).flat_map do |slice|
           Sidekiq::Client.push_bulk(@opts.merge("class" => @klass, "args" => slice))
         end
+
+        result.is_a?(Enumerator::Lazy) ? result.force : result
       end
 
       # +interval+ must be a timestamp, numeric or something that acts
@@ -263,10 +264,11 @@ module Sidekiq
       #     SomeWorker.perform_bulk([[1], [2], [3]])
       #
       def perform_bulk(items, batch_size: 1_000)
-        items = items.force if items.is_a?(Enumerator::Lazy)
-        items.each_slice(batch_size).flat_map do |slice|
+        result = items.each_slice(batch_size).flat_map do |slice|
           Sidekiq::Client.push_bulk("class" => self, "args" => slice)
         end
+
+        result.is_a?(Enumerator::Lazy) ? result.force : result
       end
 
       # +interval+ must be a timestamp, numeric or something that acts

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -192,6 +192,7 @@ module Sidekiq
       end
 
       def perform_bulk(args, batch_size: 1_000)
+        args = args.force if args.is_a?(Enumerator::Lazy)
         args.each_slice(batch_size).flat_map do |slice|
           Sidekiq::Client.push_bulk(@opts.merge("class" => @klass, "args" => slice))
         end
@@ -262,6 +263,7 @@ module Sidekiq
       #     SomeWorker.perform_bulk([[1], [2], [3]])
       #
       def perform_bulk(items, batch_size: 1_000)
+        items = items.force if items.is_a?(Enumerator::Lazy)
         items.each_slice(batch_size).flat_map do |slice|
           Sidekiq::Client.push_bulk("class" => self, "args" => slice)
         end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -207,6 +207,14 @@ describe Sidekiq::Client do
           end
         end
       end
+
+      describe 'lazy enumerator' do
+        it 'enqueues the jobs by evaluating the enumerator' do
+          lazy_array = (1..1_001).to_a.map { |x| Array(x) }.lazy
+          jids = MyWorker.perform_bulk(lazy_array)
+          assert_equal 1_001, jids.size
+        end
+      end
     end
   end
 

--- a/test/test_worker.rb
+++ b/test/test_worker.rb
@@ -91,5 +91,19 @@ describe Sidekiq::Worker do
       assert_equal 1_001, q.size
       assert_equal 1_001, jids.size
     end
+
+    describe '.perform_bulk and lazy enumerators' do
+      it 'evaluates lazy enumerators' do
+        q = Sidekiq::Queue.new('bar')
+        assert_equal 0, q.size
+
+        set = SetWorker.set('queue' => 'bar')
+        lazy_args = (1..1_001).to_a.map { |x| Array(x) }.lazy
+        jids = set.perform_bulk(lazy_args)
+
+        assert_equal 1_001, q.size
+        assert_equal 1_001, jids.size
+      end
+    end
   end
 end


### PR DESCRIPTION
Because `.perform_bulk`'s job is to enqueue Sidekiq jobs, it can bit a little surprising to not have jobs enqueued when it is called with a lazy enumerator until the returned JID enumerable has `.to_a` or `.force` called on it.

This PR changes the behavior of `.perform_bulk` to evaluate a lazy enumerable to ensure jobs are enqueued as soon as `.perform_bulk` is called and not some indeterminate time in the future (or never).

More background here: https://github.com/mperham/sidekiq/issues/5058