### PR TITLE
Make `__FILE__` and `__dir__` behave as expected in ERB configs

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -380,7 +380,8 @@ module Sidekiq
     end
 
     def parse_config(path)
-      opts = YAML.load(ERB.new(File.read(path)).result) || {}
+      erb = ERB.new(File.read(path))
+      opts = YAML.load(erb.result) || {}
 
       if opts.respond_to? :deep_symbolize_keys!
         opts.deep_symbolize_keys!

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -381,6 +381,7 @@ module Sidekiq
 
     def parse_config(path)
       erb = ERB.new(File.read(path))
+      erb.filename = File.expand_path(path)
       opts = YAML.load(erb.result) || {}
 
       if opts.respond_to? :deep_symbolize_keys!

--- a/test/config__FILE__and__dir__.yml
+++ b/test/config__FILE__and__dir__.yml
@@ -1,0 +1,5 @@
+---
+:require:  ./test/fake_env.rb
+
+:__FILE__: <%= __FILE__ %>
+:__dir__:  <%= __dir__ %>

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -197,6 +197,17 @@ describe Sidekiq::CLI do
             assert_equal 2, Sidekiq.options[:queues].count { |q| q == 'very_often' }
             assert_equal 1, Sidekiq.options[:queues].count { |q| q == 'seldom' }
           end
+
+          it 'exposes ERB default __FILE__ and __dir__' do
+            given_path = './test/config__FILE__and__dir__.yml'
+            expected_file = '(erb)'
+            expected_dir = '.'
+
+            subject.parse(%W[sidekiq -C #{given_path}])
+
+            assert_equal(expected_file, Sidekiq.options.fetch(:__FILE__))
+            assert_equal(expected_dir, Sidekiq.options.fetch(:__dir__))
+          end
         end
 
         describe 'default config file' do

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -198,10 +198,11 @@ describe Sidekiq::CLI do
             assert_equal 1, Sidekiq.options[:queues].count { |q| q == 'seldom' }
           end
 
-          it 'exposes ERB default __FILE__ and __dir__' do
+          it 'exposes ERB expected __FILE__ and __dir__' do
             given_path = './test/config__FILE__and__dir__.yml'
-            expected_file = '(erb)'
-            expected_dir = '.'
+            expected_file = File.expand_path(given_path)
+            # As per Ruby's Kernel module docs, __dir__ is equivalent to File.dirname(File.realpath(__FILE__))
+            expected_dir = File.dirname(File.realpath(expected_file))
 
             subject.parse(%W[sidekiq -C #{given_path}])
 


### PR DESCRIPTION
This enables the use of `__FILE__` and `__dir__` in ERB config files by setting [`ERB#filename`](https://ruby-doc.org/stdlib-3.0.2/libdoc/erb/rdoc/ERB.html#filename) before computing its `results`. This allows `__FILE__` to provide a useful value, and `__dir__` works automatically if `__FILE__` is set correctly.

### Use Case

While in production it may be useful to have granular workers, in development it may be convenient (and less expensive) to have a worker capable of processing all queues, so as not to require starting up all workers individually.

Furthermore, it may be desirable to dynamically read in queue names from the other configs, so as not to have to worry about "drift" in the development config file (e.g. if a new queue is added).

Having access to `__FILE__` and `__dir__` allows such code to be written without worrying about  exact filenames or locations:

```yml
---
:queues: <%=
  (Dir.glob(File.join(__dir__, 'sidekiq*.yml')) - [__FILE__]).flat_map do |config_path|
    YAML.load_file(config_path).fetch(:queues, 'default')
  end.uniq.to_json
%>
```