### PR TITLE
Fix stack level too deep when Sidekiq.logger == Rails.logger

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -42,7 +42,7 @@ module Sidekiq
         # This is the integration code necessary so that if code uses `Rails.logger.info "Hello"`,
         # it will appear in the Sidekiq console with all of the job context. See #5021 and
         # https://github.com/rails/rails/blob/b5f2b550f69a99336482739000c58e4e04e033aa/railties/lib/rails/commands/server/server_command.rb#L82-L84
-        unless ::ActiveSupport::Logger.logger_outputs_to?(::Rails.logger, $stdout)
+        unless ::Rails.logger == ::Sidekiq.logger || ::ActiveSupport::Logger.logger_outputs_to?(::Rails.logger, $stdout)
           ::Rails.logger.extend(::ActiveSupport::Logger.broadcast(::Sidekiq.logger))
         end
       end


### PR DESCRIPTION
See https://github.com/mperham/sidekiq/discussions/5021#discussioncomment-1613079 for the full-context

When `::ActiveSupport::Logger.logger_outputs_to?(::Rails.logger, $stdout)` is false because `Rails.logger` is outputting to a file, and `Sidekiq.logger == Rails.logger`, a stack level too deep error was thrown, because `Rails.logger` was broadcasting to itself.