### PR TITLE
Fix deprecation warning when using redis-namespace

### DIFF
--- a/lib/sidekiq/scheduled.rb
+++ b/lib/sidekiq/scheduled.rb
@@ -47,7 +47,10 @@ module Sidekiq
       private
 
       def zpopbyscore(conn, keys: nil, argv: nil)
-        @lua_zpopbyscore_sha = conn.script(:load, LUA_ZPOPBYSCORE) if @lua_zpopbyscore_sha.nil?
+        if @lua_zpopbyscore_sha.nil?
+          raw_conn = conn.respond_to?(:redis) ? conn.redis : conn
+          @lua_zpopbyscore_sha = raw_conn.script(:load, LUA_ZPOPBYSCORE)
+        end
 
         conn.evalsha(@lua_zpopbyscore_sha, keys: keys, argv: argv)
       rescue Redis::CommandError => e


### PR DESCRIPTION
We need to call the `script` command on the raw redis connection because
passthrough for administrative commands has been deprecated and will be
removed in redis-namespace 2.0

Sample deprecation message:

```
Passing 'script' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /data/cache/bundle-2.7.4/ruby/2.7.0/gems/sidekiq-6.3.1/lib/sidekiq/scheduled.rb:45:i
n `zpopbyscore')
```