### PR TITLE
Implement strict argument checking

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -252,6 +252,10 @@ module Sidekiq
     options[:lifecycle_events][event] << block
   end
 
+  def self.strict_mode!
+    options[:raise_on_complex_arguments] = true
+  end
+
   # We are shutting down Sidekiq but what about workers that
   # are working on some long job?  This error is
   # raised in workers that have not finished within the hard

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -252,8 +252,8 @@ module Sidekiq
     options[:lifecycle_events][event] << block
   end
 
-  def self.strict_mode!
-    options[:raise_on_complex_arguments] = true
+  def self.strict_mode!(val = true)
+    options[:raise_on_complex_arguments] = val
   end
 
   # We are shutting down Sidekiq but what about workers that

--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -20,7 +20,7 @@ module Sidekiq
           To disable this error, remove `Sidekiq.strict_mode!` from your initializer.
         EOM
         raise(ArgumentError, msg)
-      elsif Sidekiq.options[:environment] == "development" && !json_safe?(item)
+      elsif !Sidekiq.options[:disable_complex_argument_warning] && Sidekiq.options[:environment] == "development" && !json_safe?(item)
         Sidekiq.logger.warn <<~EOM
           Job arguments do not serialize to JSON safely. This will raise an error in Sidekiq 7.0.
 

--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -6,6 +6,8 @@ module Sidekiq
     # These functions encapsulate various job utilities.
     # They must be simple and free from side effects.
 
+    JSON_SERIALIZABLE_TYPES = [String, Numeric, TrueClass, FalseClass, NilClass].freeze
+
     def validate(item)
       raise(ArgumentError, "Job must be a Hash with 'class' and 'args' keys: `#{item}`") unless item.is_a?(Hash) && item.key?("class") && item.key?("args")
       raise(ArgumentError, "Job args must be an Array: `#{item}`") unless item["args"].is_a?(Array)
@@ -14,9 +16,8 @@ module Sidekiq
       raise(ArgumentError, "Job tags must be an Array: `#{item}`") if item["tags"] && !item["tags"].is_a?(Array)
 
       if Sidekiq.options[:raise_on_complex_arguments]
-        klasses = [String, Numeric, TrueClass, FalseClass, NilClass]
         item["args"].each do |arg|
-          if klasses.none? { |klass| arg.is_a?(klass)}
+          if JSON_SERIALIZABLE_TYPES.none? { |klass| arg.is_a?(klass)}
             raise ArgumentError, 'Out of luck!'
           end
         end

--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -13,8 +13,8 @@ module Sidekiq
       raise(ArgumentError, "Job 'at' must be a Numeric timestamp: `#{item}`") if item.key?("at") && !item["at"].is_a?(Numeric)
       raise(ArgumentError, "Job tags must be an Array: `#{item}`") if item["tags"] && !item["tags"].is_a?(Array)
 
-      if Sidekiq.options[:raise_on_complex_arguments]
-        raise(ArgumentError, "Arguments must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices") unless job_is_json_safe(item)
+      if Sidekiq.options[:raise_on_complex_arguments] && !job_is_json_safe(item)
+        raise(ArgumentError, "Arguments must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices. To disable this error, remove Sidekiq.strict_mode! from your initializer.")
       elsif Sidekiq.options[:environment] == "development" && !job_is_json_safe(item)
         Sidekiq.logger.warn <<~EOM
           Job arguments do not serialize to JSON safely. This will raise an error in Sidekiq 7.0.

--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -18,7 +18,7 @@ module Sidekiq
       if Sidekiq.options[:raise_on_complex_arguments]
         item["args"].each do |arg|
           if JSON_SERIALIZABLE_TYPES.none? { |klass| arg.is_a?(klass)}
-            raise ArgumentError, 'Out of luck!'
+            raise(ArgumentError, "Job argument must be a type safe to serialize to JSON, i.e. String, Numeric, TrueClass, FalseClass, NilClass")
           end
         end
       end

--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -24,7 +24,7 @@ module Sidekiq
         Sidekiq.logger.warn <<~EOM
           Job arguments do not serialize to JSON safely. This will raise an error in Sidekiq 7.0.
 
-          see https://github.com/mperham/sidekiq/wiki/Best-Practices or raise the error today
+          See https://github.com/mperham/sidekiq/wiki/Best-Practices or raise the error today
           by calling `Sidekiq.strict_mode!` during Sidekiq initialization.
         EOM
       end

--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -12,6 +12,15 @@ module Sidekiq
       raise(ArgumentError, "Job class must be either a Class or String representation of the class name: `#{item}`") unless item["class"].is_a?(Class) || item["class"].is_a?(String)
       raise(ArgumentError, "Job 'at' must be a Numeric timestamp: `#{item}`") if item.key?("at") && !item["at"].is_a?(Numeric)
       raise(ArgumentError, "Job tags must be an Array: `#{item}`") if item["tags"] && !item["tags"].is_a?(Array)
+
+      if Sidekiq.options[:raise_on_complex_arguments]
+        klasses = [String, Numeric, TrueClass, FalseClass, NilClass]
+        item["args"].each do |arg|
+          if klasses.none? { |klass| arg.is_a?(klass)}
+            raise ArgumentError, 'Out of luck!'
+          end
+        end
+      end
     end
 
     def normalize_item(item)

--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -14,7 +14,12 @@ module Sidekiq
       raise(ArgumentError, "Job tags must be an Array: `#{item}`") if item["tags"] && !item["tags"].is_a?(Array)
 
       if Sidekiq.options[:raise_on_complex_arguments] && !job_is_json_safe(item)
-        raise(ArgumentError, "Arguments must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices. To disable this error, remove Sidekiq.strict_mode! from your initializer.")
+        msg = <<~EOM
+          Arguments must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices.
+
+          To disable this error, remove `Sidekiq.strict_mode!` from your initializer.
+        EOM
+        raise(ArgumentError, msg)
       elsif Sidekiq.options[:environment] == "development" && !job_is_json_safe(item)
         Sidekiq.logger.warn <<~EOM
           Job arguments do not serialize to JSON safely. This will raise an error in Sidekiq 7.0.

--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -13,14 +13,14 @@ module Sidekiq
       raise(ArgumentError, "Job 'at' must be a Numeric timestamp: `#{item}`") if item.key?("at") && !item["at"].is_a?(Numeric)
       raise(ArgumentError, "Job tags must be an Array: `#{item}`") if item["tags"] && !item["tags"].is_a?(Array)
 
-      if Sidekiq.options[:raise_on_complex_arguments] && !job_is_json_safe(item)
+      if Sidekiq.options[:raise_on_complex_arguments] && !json_safe?(item)
         msg = <<~EOM
           Arguments must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices.
 
           To disable this error, remove `Sidekiq.strict_mode!` from your initializer.
         EOM
         raise(ArgumentError, msg)
-      elsif Sidekiq.options[:environment] == "development" && !job_is_json_safe(item)
+      elsif Sidekiq.options[:environment] == "development" && !json_safe?(item)
         Sidekiq.logger.warn <<~EOM
           Job arguments do not serialize to JSON safely. This will raise an error in Sidekiq 7.0.
 
@@ -60,7 +60,7 @@ module Sidekiq
 
     private
 
-    def job_is_json_safe(item)
+    def json_safe?(item)
       JSON.parse(JSON.dump(item['args'])) == item['args']
     end
   end

--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -14,7 +14,7 @@ module Sidekiq
       raise(ArgumentError, "Job tags must be an Array: `#{item}`") if item["tags"] && !item["tags"].is_a?(Array)
 
       if Sidekiq.options[:raise_on_complex_arguments]
-        raise(ArgumentError, "Arguments must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices") unless JSON.load(JSON.dump(item['args'])) == item['args']
+        raise(ArgumentError, "Arguments must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices") unless JSON.parse(JSON.dump(item['args'])) == item['args']
       end
     end
 

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -283,6 +283,14 @@ module Sidekiq
       end
 
       def perform_async(*args)
+        if Sidekiq.options[:raise_on_complex_arguments]
+          klasses = [String, Numeric, TrueClass, FalseClass, NilClass]
+          args.each do |arg|
+            if klasses.none? { |klass| arg.is_a?(klass)}
+              raise ArgumentError, 'Out of luck!'
+            end
+          end
+        end
         Setter.new(self, {}).perform_async(*args)
       end
 

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -283,14 +283,6 @@ module Sidekiq
       end
 
       def perform_async(*args)
-        if Sidekiq.options[:raise_on_complex_arguments]
-          klasses = [String, Numeric, TrueClass, FalseClass, NilClass]
-          args.each do |arg|
-            if klasses.none? { |klass| arg.is_a?(klass)}
-              raise ArgumentError, 'Out of luck!'
-            end
-          end
-        end
         Setter.new(self, {}).perform_async(*args)
       end
 

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -161,6 +161,10 @@ describe Sidekiq::Client do
           Sidekiq.strict_mode!
         end
 
+        after do
+          Sidekiq.strict_mode!(false)
+        end
+
         it 'raises an error' do
           assert_raises ArgumentError do
             InterestingWorker.perform_async(

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -127,12 +127,13 @@ describe Sidekiq::Client do
       class InterestingWorker
         include Sidekiq::Worker
 
-        def perform(a_date, a_hash, a_struct)
+        def perform(a_symbol, a_date, a_hash, a_struct)
         end
       end
 
       it 'enqueues jobs with interesting arguments' do
         MyWorker.perform_async(
+          :symbol,
           Date.new(2021, 1, 1),
           { some: 'hash', 'with' => 'different_keys' },
           Struct.new(:x, :y).new(0, 0)
@@ -140,9 +141,14 @@ describe Sidekiq::Client do
       end
 
       describe 'config flag is set to strict' do
+        before do
+          Sidekiq.options[:raise_on_complex_arguments] = true
+        end
+
         it 'raises an error' do
           assert_raises ArgumentError do
             MyWorker.perform_async(
+              :symbol,
               Date.new(2021, 1, 1),
               { some: 'hash', 'with' => 'different_keys' },
               Struct.new(:x, :y).new(0, 0)

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -127,28 +127,36 @@ describe Sidekiq::Client do
       class InterestingWorker
         include Sidekiq::Worker
 
-        def perform(a_symbol, a_date, a_hash, a_struct)
+        def perform(an_argument)
         end
       end
 
-      class InterestingDeepWorker
-        include Sidekiq::Worker
-
-        def perform(a_deep_structure)
-        end
-      end
-
-      it 'enqueues jobs with interesting arguments' do
+      it 'enqueues jobs with a symbol as an argument' do
         InterestingWorker.perform_async(
-          :symbol,
-          Date.new(2021, 1, 1),
-          { some: 'hash', 'with' => 'different_keys' },
+          :symbol
+        )
+      end
+
+      it 'enqueues jobs with a Date as an argument' do
+        InterestingWorker.perform_async(
+          Date.new(2021, 1, 1)
+        )
+      end
+
+      it 'enqueues jobs with a Hash with symbols and string as keys as an argument' do
+        InterestingWorker.perform_async(
+          { some: 'hash', 'with' => 'different_keys' }
+        )
+      end
+
+      it 'enqueues jobs with a Struct as an argument' do
+        InterestingWorker.perform_async(
           Struct.new(:x, :y).new(0, 0)
         )
       end
 
       it 'works with a JSON-friendly deep, nested structure' do
-        InterestingDeepWorker.perform_async(
+        InterestingWorker.perform_async(
           {
             'foo' => ['a', 'b', 'c'],
             'bar' => ['x', 'y', 'z']
@@ -177,7 +185,7 @@ describe Sidekiq::Client do
         end
 
         it 'works with a JSON-friendly deep, nested structure' do
-          InterestingDeepWorker.perform_async(
+          InterestingWorker.perform_async(
             {
               'foo' => ['a', 'b', 'c'],
               'bar' => ['x', 'y', 'z']
@@ -188,7 +196,7 @@ describe Sidekiq::Client do
         describe 'worker that takes deep, nested structures' do
           it 'raises an error on JSON-unfriendly structures' do
             assert_raises ArgumentError do
-              InterestingDeepWorker.perform_async(
+              InterestingWorker.perform_async(
                 {
                   'foo' => [:a, :b, :c],
                   bar: ['x', 'y', 'z']

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -182,7 +182,7 @@ describe Sidekiq::Client do
         end
 
         describe 'worker that takes deep, nested structures' do
-          it 'raises an error' do
+          it 'raises an error on JSON-unfriendly structures' do
             assert_raises ArgumentError do
               InterestingDeepWorker.perform_async(
                 {

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -156,9 +156,9 @@ describe Sidekiq::Client do
         )
       end
 
-      describe 'config flag is set to strict' do
+      describe 'strict mode is enabled' do
         before do
-          Sidekiq.options[:raise_on_complex_arguments] = true
+          Sidekiq.strict_mode!
         end
 
         it 'raises an error' do

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -132,20 +132,19 @@ describe Sidekiq::Client do
       end
 
       it 'enqueues jobs with a symbol as an argument' do
-        InterestingWorker.perform_async(
-          :symbol
-        )
+        InterestingWorker.perform_async(:symbol)
       end
 
       it 'enqueues jobs with a Date as an argument' do
-        InterestingWorker.perform_async(
-          Date.new(2021, 1, 1)
-        )
+        InterestingWorker.perform_async(Date.new(2021, 1, 1))
       end
 
       it 'enqueues jobs with a Hash with symbols and string as keys as an argument' do
         InterestingWorker.perform_async(
-          { some: 'hash', 'with' => 'different_keys' }
+          {
+            some: 'hash',
+            'with' => 'different_keys'
+          }
         )
       end
 
@@ -175,24 +174,23 @@ describe Sidekiq::Client do
 
         it 'raises an error when using a symbol as an argument' do
           assert_raises ArgumentError do
-            InterestingWorker.perform_async(
-              :symbol
-            )
+            InterestingWorker.perform_async(:symbol)
           end
         end
 
         it 'raises an error when using a Date as an argument' do
           assert_raises ArgumentError do
-            InterestingWorker.perform_async(
-              Date.new(2021, 1, 1)
-            )
+            InterestingWorker.perform_async(Date.new(2021, 1, 1))
           end
         end
 
         it 'raises an error when using a Hash with symbols and string as keys as an argument' do
           assert_raises ArgumentError do
             InterestingWorker.perform_async(
-              { some: 'hash', 'with' => 'different_keys' }
+              {
+                some: 'hash',
+                'with' => 'different_keys'
+              }
             )
           end
         end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -173,12 +173,33 @@ describe Sidekiq::Client do
           Sidekiq.strict_mode!(false)
         end
 
-        it 'raises an error' do
+        it 'raises an error when using a symbol as an argument' do
           assert_raises ArgumentError do
             InterestingWorker.perform_async(
-              :symbol,
-              Date.new(2021, 1, 1),
-              { some: 'hash', 'with' => 'different_keys' },
+              :symbol
+            )
+          end
+        end
+
+        it 'raises an error when using a Date as an argument' do
+          assert_raises ArgumentError do
+            InterestingWorker.perform_async(
+              Date.new(2021, 1, 1)
+            )
+          end
+        end
+
+        it 'raises an error when using a Hash with symbols and string as keys as an argument' do
+          assert_raises ArgumentError do
+            InterestingWorker.perform_async(
+              { some: 'hash', 'with' => 'different_keys' }
+            )
+          end
+        end
+
+        it 'raises an error when using a Struct as an argument' do
+          assert_raises ArgumentError do
+            InterestingWorker.perform_async(
               Struct.new(:x, :y).new(0, 0)
             )
           end


### PR DESCRIPTION
This PR implements a runtime type check for arguments as a follow-up from the discussion here: https://github.com/mperham/sidekiq/issues/5070. The idea is to provide some safeguards in non-production environments for folks about to do something dangerous (i.e. use arguments in a job that cannot (de)serialize reliably to/from JSON).

Open Questions:

- Is `#validate` or `#normalize_item` the right place for this logic?
- Are there other types we'd like to include in the allow list?
- This check is relatively strict as written (no symbols, no hashes). Do we want to instead take the approach explored in #2870?

Notes:

- It looks like this idea has been considered before and has been commented out for some time: https://github.com/mperham/sidekiq/issues/2870 and ...
- https://github.com/mperham/sidekiq/blame/848df46c67da926587cd76ab7d78939b4d79714b/lib/sidekiq/client.rb#L222