### PR TITLE
Update Gemfile.lock and CI to ensure compatibility with Rubies from 2.6-3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0"]
+        ruby: [2.6, 2.7, "3.0", 3.1]
     services:
       redis:
         image: redis

--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,7 @@ group :load_test do
   gem "hiredis"
   gem "toxiproxy"
 end
+
+gem "net-smtp", require: false
+gem "net-imap", require: false
+gem "net-pop", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,16 +81,18 @@ GEM
     codecov (0.2.8)
       json
       simplecov
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
     crass (1.0.6)
+    digest (3.1.0)
     docile (1.3.2)
     erubi (1.10.0)
-    globalid (0.4.2)
-      activesupport (>= 4.2.0)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
     hiredis (0.6.3)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
+    io-wait (0.2.1)
     json (2.3.1)
     loofah (2.9.0)
       crass (~> 1.0.2)
@@ -101,7 +103,22 @@ GEM
     method_source (1.0.0)
     mini_mime (1.0.3)
     mini_portile2 (2.5.0)
-    minitest (5.14.4)
+    minitest (5.15.0)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
+    net-protocol (0.1.2)
+      io-wait
+      timeout
+    net-smtp (0.3.1)
+      digest
+      net-protocol
+      timeout
     nio4r (2.5.7)
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
@@ -174,7 +191,9 @@ GEM
     standard (1.6.0)
       rubocop (= 1.24.1)
       rubocop-performance (= 1.13.1)
+    strscan (3.0.1)
     thor (1.1.0)
+    timeout (0.2.0)
     toxiproxy (1.0.3)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -182,7 +201,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.3)
 
 PLATFORMS
   ruby
@@ -192,6 +211,9 @@ DEPENDENCIES
   codecov
   hiredis
   minitest
+  net-imap
+  net-pop
+  net-smtp
   rails (>= 6.0.2)
   rake
   redis-namespace!
@@ -200,3 +222,6 @@ DEPENDENCIES
   sqlite3
   standard
   toxiproxy
+
+BUNDLED WITH
+   2.3.4


### PR DESCRIPTION
This isn't green because the DelayedExtension changes are problematic for Psych's new safe defaults.  Given those are going to be removed shortly, we may just want to wait to merge this until Sidekiq 7.0