### PR TITLE
Add keyword arguments support in extensions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ bin/rails generate sidekiq:job ProcessOrderJob
 ```
 - Fix job retries losing CurrentAttributes [#5090]
 - Tweak shutdown to give long-running threads time to cleanup [#5095]
+- Add keyword arguments support in extensions
 
 6.3.1
 ---------

--- a/lib/sidekiq/extensions/action_mailer.rb
+++ b/lib/sidekiq/extensions/action_mailer.rb
@@ -16,8 +16,8 @@ module Sidekiq
       include Sidekiq::Worker
 
       def perform(yml)
-        (target, method_name, args) = YAML.load(yml)
-        msg = target.public_send(method_name, *args)
+        (target, method_name, args, kwargs) = YAML.load(yml)
+        msg = target.public_send(method_name, *args, **kwargs)
         # The email method can return nil, which causes ActionMailer to return
         # an undeliverable empty message.
         if msg

--- a/lib/sidekiq/extensions/action_mailer.rb
+++ b/lib/sidekiq/extensions/action_mailer.rb
@@ -17,7 +17,7 @@ module Sidekiq
 
       def perform(yml)
         (target, method_name, args, kwargs) = YAML.load(yml)
-        msg = target.public_send(method_name, *args, **kwargs)
+        msg = kwargs.empty? ? target.public_send(method_name, *args) : target.public_send(method_name, *args, **kwargs)
         # The email method can return nil, which causes ActionMailer to return
         # an undeliverable empty message.
         if msg

--- a/lib/sidekiq/extensions/active_record.rb
+++ b/lib/sidekiq/extensions/active_record.rb
@@ -18,8 +18,8 @@ module Sidekiq
       include Sidekiq::Worker
 
       def perform(yml)
-        (target, method_name, args) = YAML.load(yml)
-        target.__send__(method_name, *args)
+        (target, method_name, args, kwargs) = YAML.load(yml)
+        target.__send__(method_name, *args, **kwargs)
       end
     end
 

--- a/lib/sidekiq/extensions/active_record.rb
+++ b/lib/sidekiq/extensions/active_record.rb
@@ -19,7 +19,7 @@ module Sidekiq
 
       def perform(yml)
         (target, method_name, args, kwargs) = YAML.load(yml)
-        target.__send__(method_name, *args, **kwargs)
+        kwargs.empty? ? target.__send__(method_name, *args) : target.__send__(method_name, *args, **kwargs)
       end
     end
 

--- a/lib/sidekiq/extensions/class_methods.rb
+++ b/lib/sidekiq/extensions/class_methods.rb
@@ -16,8 +16,8 @@ module Sidekiq
       include Sidekiq::Worker
 
       def perform(yml)
-        (target, method_name, args) = YAML.load(yml)
-        target.__send__(method_name, *args)
+        (target, method_name, args, kwargs) = YAML.load(yml)
+        target.__send__(method_name, *args, **kwargs)
       end
     end
 

--- a/lib/sidekiq/extensions/class_methods.rb
+++ b/lib/sidekiq/extensions/class_methods.rb
@@ -17,7 +17,7 @@ module Sidekiq
 
       def perform(yml)
         (target, method_name, args, kwargs) = YAML.load(yml)
-        target.__send__(method_name, *args, **kwargs)
+        kwargs.empty? ? target.__send__(method_name, *args) : target.__send__(method_name, *args, **kwargs)
       end
     end
 

--- a/lib/sidekiq/extensions/generic_proxy.rb
+++ b/lib/sidekiq/extensions/generic_proxy.rb
@@ -13,13 +13,13 @@ module Sidekiq
         @opts = options
       end
 
-      def method_missing(name, *args)
+      def method_missing(name, *args, **kwargs)
         # Sidekiq has a limitation in that its message must be JSON.
         # JSON can't round trip real Ruby objects so we use YAML to
         # serialize the objects to a String.  The YAML will be converted
         # to JSON and then deserialized on the other side back into a
         # Ruby object.
-        obj = [@target, name, args]
+        obj = [@target, name, args, kwargs]
         marshalled = ::YAML.dump(obj)
         if marshalled.size > SIZE_LIMIT
           ::Sidekiq.logger.warn { "#{@target}.#{name} job argument is #{marshalled.bytesize} bytes, you should refactor it to reduce the size" }

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -36,6 +36,8 @@ describe Sidekiq::Extensions do
     MyModel.delay.long_class_method_with_optional_args(with: :keywords)
     assert_equal ['default'], Sidekiq::Queue.all.map(&:name)
     assert_equal 1, q.size
+    obj = YAML.load q.first['args'].first
+    assert_equal({ with: :keywords }, obj.last)
   end
 
   it 'uses and stringifies specified options' do
@@ -88,6 +90,8 @@ describe Sidekiq::Extensions do
     UserMailer.delay.greetings_with_optional_args(with: :keywords)
     assert_equal ['default'], Sidekiq::Queue.all.map(&:name)
     assert_equal 1, q.size
+    obj = YAML.load q.first['args'].first
+    assert_equal({ with: :keywords }, obj.last)
   end
 
   it 'allows delayed scheduling of AM mails' do
@@ -124,6 +128,8 @@ describe Sidekiq::Extensions do
     assert_equal 0, q.size
     SomeClass.delay.doit_with_optional_args(with: :keywords)
     assert_equal 1, q.size
+    obj = YAML.load q.first['args'].first
+    assert_equal({ with: :keywords }, obj.last)
   end
 
   module SomeModule
@@ -153,5 +159,7 @@ describe Sidekiq::Extensions do
     assert_equal 0, q.size
     SomeModule.delay.doit_with_optional_args(with: :keywords)
     assert_equal 1, q.size
+    obj = YAML.load q.first['args'].first
+    assert_equal({ with: :keywords }, obj.last)
   end
 end

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -16,7 +16,7 @@ describe Sidekiq::Extensions do
     end
 
     def self.long_class_method_with_optional_args(*arg, **kwargs)
-      raise "Should not be called!"
+      kwargs
     end
   end
 
@@ -38,6 +38,12 @@ describe Sidekiq::Extensions do
     assert_equal 1, q.size
     obj = YAML.load q.first['args'].first
     assert_equal({ with: :keywords }, obj.last)
+  end
+
+  it 'forwards the keyword arguments to perform' do
+    yml = "---\n- !ruby/class 'MyModel'\n- :long_class_method_with_optional_args\n- []\n- :with: :keywords\n"
+    result = Sidekiq::Extensions::DelayedClass.new.perform(yml)
+    assert_equal({ with: :keywords }, result)
   end
 
   it 'uses and stringifies specified options' do
@@ -70,7 +76,6 @@ describe Sidekiq::Extensions do
     end
 
     def greetings_with_optional_args(*arg, **kwargs)
-      raise "Should not be called!"
     end
   end
 
@@ -113,6 +118,7 @@ describe Sidekiq::Extensions do
     end
 
     def self.doit_with_optional_args(*arg, **kwargs)
+      kwargs
     end
   end
 
@@ -132,11 +138,18 @@ describe Sidekiq::Extensions do
     assert_equal({ with: :keywords }, obj.last)
   end
 
+  it 'forwards the keyword arguments to perform' do
+    yml = "---\n- !ruby/class 'SomeClass'\n- :doit_with_optional_args\n- []\n- :with: :keywords\n"
+    result = Sidekiq::Extensions::DelayedClass.new.perform(yml)
+    assert_equal({ with: :keywords }, result)
+  end
+
   module SomeModule
     def self.doit(arg)
     end
 
     def self.doit_with_optional_args(*arg, **kwargs)
+      kwargs
     end
   end
 
@@ -161,5 +174,11 @@ describe Sidekiq::Extensions do
     assert_equal 1, q.size
     obj = YAML.load q.first['args'].first
     assert_equal({ with: :keywords }, obj.last)
+  end
+
+  it 'forwards the keyword arguments to perform' do
+    yml = "---\n- !ruby/class 'SomeModule'\n- :doit_with_optional_args\n- []\n- :with: :keywords\n"
+    result = Sidekiq::Extensions::DelayedClass.new.perform(yml)
+    assert_equal({ with: :keywords }, result)
   end
 end

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -14,6 +14,10 @@ describe Sidekiq::Extensions do
     def self.long_class_method
       raise "Should not be called!"
     end
+
+    def self.long_class_method_with_optional_args(*arg, **kwargs)
+      raise "Should not be called!"
+    end
   end
 
   it 'allows delayed execution of ActiveRecord class methods' do
@@ -21,6 +25,15 @@ describe Sidekiq::Extensions do
     q = Sidekiq::Queue.new
     assert_equal 0, q.size
     MyModel.delay.long_class_method
+    assert_equal ['default'], Sidekiq::Queue.all.map(&:name)
+    assert_equal 1, q.size
+  end
+
+  it 'allows delayed execution of ActiveRecord class methods with optional arguments' do
+    assert_equal [], Sidekiq::Queue.all.map(&:name)
+    q = Sidekiq::Queue.new
+    assert_equal 0, q.size
+    MyModel.delay.long_class_method_with_optional_args(with: :keywords)
     assert_equal ['default'], Sidekiq::Queue.all.map(&:name)
     assert_equal 1, q.size
   end
@@ -53,6 +66,10 @@ describe Sidekiq::Extensions do
     def greetings(a, b)
       raise "Should not be called!"
     end
+
+    def greetings_with_optional_args(*arg, **kwargs)
+      raise "Should not be called!"
+    end
   end
 
   it 'allows delayed delivery of ActionMailer mails' do
@@ -60,6 +77,15 @@ describe Sidekiq::Extensions do
     q = Sidekiq::Queue.new
     assert_equal 0, q.size
     UserMailer.delay.greetings(1, 2)
+    assert_equal ['default'], Sidekiq::Queue.all.map(&:name)
+    assert_equal 1, q.size
+  end
+
+  it 'allows delayed delivery of ActionMailer mails with optional arguments' do
+    assert_equal [], Sidekiq::Queue.all.map(&:name)
+    q = Sidekiq::Queue.new
+    assert_equal 0, q.size
+    UserMailer.delay.greetings_with_optional_args(with: :keywords)
     assert_equal ['default'], Sidekiq::Queue.all.map(&:name)
     assert_equal 1, q.size
   end
@@ -81,6 +107,9 @@ describe Sidekiq::Extensions do
   class SomeClass
     def self.doit(arg)
     end
+
+    def self.doit_with_optional_args(*arg, **kwargs)
+    end
   end
 
   it 'allows delay of any ole class method' do
@@ -90,8 +119,18 @@ describe Sidekiq::Extensions do
     assert_equal 1, q.size
   end
 
+  it 'allows delay of any ole class method with optional arguments' do
+    q = Sidekiq::Queue.new
+    assert_equal 0, q.size
+    SomeClass.delay.doit_with_optional_args(with: :keywords)
+    assert_equal 1, q.size
+  end
+
   module SomeModule
     def self.doit(arg)
+    end
+
+    def self.doit_with_optional_args(*arg, **kwargs)
     end
   end
 
@@ -109,4 +148,10 @@ describe Sidekiq::Extensions do
     assert_equal 1, q.size
   end
 
+  it 'allows delay of any module class method with optional arguments' do
+    q = Sidekiq::Queue.new
+    assert_equal 0, q.size
+    SomeModule.delay.doit_with_optional_args(with: :keywords)
+    assert_equal 1, q.size
+  end
 end


### PR DESCRIPTION
This PR allows the delay extension to support keyword arguments.
I know the extensions will be deleted in 7.0 but it would be a nice addition in the meantime.