### PR TITLE
Migrate 5.x version to Redis 4.2.0

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -904,7 +904,7 @@ module Sidekiq
         procs = sscan(conn, 'processes')
         procs.sort.each do |key|
           valid, workers = conn.pipelined do
-            conn.exists(key)
+            conn.exists?(key)
             conn.hgetall("#{key}:workers")
           end
           next unless valid

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -102,7 +102,7 @@ module Sidekiq
         _, exists, _, _, msg = Sidekiq.redis do |conn|
           conn.multi do
             conn.sadd('processes', key)
-            conn.exists(key)
+            conn.exists?(key)
             conn.hmset(key, 'info', to_json, 'busy', curstate.size, 'beat', Time.now.to_f, 'quiet', @done)
             conn.expire(key, 60)
             conn.rpop("#{key}-signals")

--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.version       = Sidekiq::VERSION
   gem.required_ruby_version = ">= 2.2.2"
 
-  gem.add_dependency 'redis', '>= 3.3.5', '< 4.2'
+  gem.add_dependency "redis", ">= 4.2.0"
   gem.add_dependency 'connection_pool', '~> 2.2', '>= 2.2.2'
   gem.add_dependency 'rack', '~> 2.0'
   gem.add_dependency 'rack-protection', '>= 1.5.0'

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -376,7 +376,7 @@ describe 'API' do
 
       Sidekiq.redis do |conn|
         refute conn.smembers('queues').include?('foo')
-        refute conn.exists('queue:foo')
+        refute conn.exists?('queue:foo')
       end
     end
 

--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -148,7 +148,7 @@ describe Sidekiq::Web do
 
     Sidekiq.redis do |conn|
       refute conn.smembers('queues').include?('foo')
-      refute conn.exists('queue:foo')
+      refute conn.exists?('queue:foo')
     end
   end
 


### PR DESCRIPTION
Incorporating changes from https://github.com/mperham/sidekiq/commit/6a334042ee567acb24a1b6ab31a4cca759795282 into the 5.x version