### PR TITLE
Load aliases for Psych 4 (included in Ruby 3.1)

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -382,7 +382,7 @@ module Sidekiq
     def parse_config(path)
       erb = ERB.new(File.read(path))
       erb.filename = File.expand_path(path)
-      opts = YAML.load(erb.result) || {}
+      opts = load_yaml(erb.result) || {}
 
       if opts.respond_to? :deep_symbolize_keys!
         opts.deep_symbolize_keys!
@@ -396,6 +396,14 @@ module Sidekiq
       parse_queues(opts, opts.delete(:queues) || [])
 
       opts
+    end
+
+    def load_yaml(src)
+      if Psych::VERSION > "4.0"
+        YAML.safe_load(src, permitted_classes: [Symbol], aliases: true)
+      else
+        YAML.load(src)
+      end
     end
 
     def parse_queues(opts, queues_and_weights)

--- a/test/config_with_alias.yml
+++ b/test/config_with_alias.yml
@@ -1,0 +1,12 @@
+---
+:production: &production
+  :verbose:      true
+  :require:      ./test/fake_env.rb
+  :concurrency:  50
+  :queues:
+    - [<%="very_"%>often, 2]
+    - [seldom, 1]
+
+:staging:
+  <<: *production
+  :verbose: false

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -198,6 +198,26 @@ describe Sidekiq::CLI do
             assert_equal 1, Sidekiq.options[:queues].count { |q| q == 'seldom' }
           end
 
+          it 'accepts environment specific config with alias' do
+            subject.parse(%w[sidekiq -e staging -C ./test/config_with_alias.yml])
+            assert_equal './test/config_with_alias.yml', Sidekiq.options[:config_file]
+            refute Sidekiq.options[:verbose]
+            assert_equal './test/fake_env.rb', Sidekiq.options[:require]
+            assert_equal 'staging', Sidekiq.options[:environment]
+            assert_equal 50, Sidekiq.options[:concurrency]
+            assert_equal 2, Sidekiq.options[:queues].count { |q| q == 'very_often' }
+            assert_equal 1, Sidekiq.options[:queues].count { |q| q == 'seldom' }
+
+            subject.parse(%w[sidekiq -e production -C ./test/config_with_alias.yml])
+            assert_equal './test/config_with_alias.yml', Sidekiq.options[:config_file]
+            assert Sidekiq.options[:verbose]
+            assert_equal './test/fake_env.rb', Sidekiq.options[:require]
+            assert_equal 'production', Sidekiq.options[:environment]
+            assert_equal 50, Sidekiq.options[:concurrency]
+            assert_equal 2, Sidekiq.options[:queues].count { |q| q == 'very_often' }
+            assert_equal 1, Sidekiq.options[:queues].count { |q| q == 'seldom' }
+          end
+
           it 'exposes ERB expected __FILE__ and __dir__' do
             given_path = './test/config__FILE__and__dir__.yml'
             expected_file = File.expand_path(given_path)


### PR DESCRIPTION
This PR allows config files to contain aliases in Ruby 3.1 and beyond by explicitly allowing aliases.
Pre-Psych 4 behavior is unchanged