### PR TITLE
Fixing width of status span to be large enough for 'active' 

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -202,6 +202,8 @@ table .table-checkbox label {
 
 .navbar .navbar-brand .status {
   color: #585454;
+  display: inline-block;
+  width: 75px;
 }
 
 


### PR DESCRIPTION
Addresses #5054 

The nav bar jumps because the status span did not have a width, and therefore grew to the width of the enclosed string. 

Changed display to `inline-block` and set the width to `75px`