### PR TITLE
Reconnect on known errors after failover when pushing jobs to Redis

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -103,6 +103,7 @@ module Sidekiq
         # to disconnect and reopen the socket to get back to the primary.
         # 4495 Use the same logic if we have a "Not enough replicas" error from the primary
         # 4985 Use the same logic when a blocking command is force-unblocked
+        # The same retry logic is also used in client.rb
         if retryable && ex.message =~ /READONLY|NOREPLICAS|UNBLOCKED/
           conn.disconnect!
           retryable = false


### PR DESCRIPTION
This PR targets the discussion in https://github.com/mperham/sidekiq/discussions/4990.

In a Redis cluster setup, failovers will happen. In these cases,
a `Redis::CommandError` can be raised for different reasons, 
for example, when the server becomes a replica, when there 
is a "Not enough replicas" error from the primary, or when a 
blocking command is force-unblocked.

<details>
  <summary>Sample stacktrace</summary>
  
```
  Redis::CommandError: READONLY You can't write against a read only replica.
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis/client.rb:216:in `call_pipelined'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis/client.rb:170:in `block in call_pipeline'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis/client.rb:313:in `with_reconnect'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis/client.rb:168:in `call_pipeline'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis.rb:2490:in `block in multi'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis.rb:69:in `block in synchronize'
  from monitor.rb:202:in `synchronize'
  from monitor.rb:202:in `mon_synchronize'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis.rb:69:in `synchronize'
  from vendor/ruby/2.7.0/gems/redis-4.2.5/lib/redis.rb:2483:in `multi'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/client.rb:189:in `block in raw_push'
  from vendor/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:63:in `block (2 levels) in with'
  from vendor/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:62:in `handle_interrupt'
  from vendor/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:62:in `block in with'
  from vendor/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:59:in `handle_interrupt'
  from vendor/ruby/2.7.0/gems/connection_pool-2.2.5/lib/connection_pool.rb:59:in `with'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/client.rb:188:in `raw_push'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/client.rb:74:in `push'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/worker.rb:240:in `client_push'
  from vendor/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/worker.rb:200:in `perform_async'
  from app/models/my_model.rb:49:in `schedule_sync!'
```
</details>

These errors can occur when pushing a job to Redis, so it needs
to reconnect to the current master node and retry.

Reconnecting to Redis is [handled for `Sidekiq.redis`](https://github.com/mperham/sidekiq/blame/main/lib/sidekiq.rb#L106) and has been 
extended in #4985, but the Client's `#raw_push` method directly 
accesses the Redis connection pool, i.e. scheduling circumvents 
`Sidekiq.redis`.

Therefore, proper retry logic (similar to `Sidekiq.redis`) is added.