### PR TITLE
Allow extensions to properly process empty hashes

### DIFF
--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -29,6 +29,18 @@ describe Sidekiq::Extensions do
     assert_equal 1, q.size
   end
 
+  it 'allows delayed execution of ActiveRecord class methods with empty hash argument' do
+    assert_equal [], Sidekiq::Queue.all.map(&:name)
+    q = Sidekiq::Queue.new
+    assert_equal 0, q.size
+    MyModel.delay.long_class_method_with_optional_args({})
+    assert_equal ['default'], Sidekiq::Queue.all.map(&:name)
+    assert_equal 1, q.size
+    obj = YAML.load q.first['args'].first
+    assert_equal([{}], obj[2])
+    assert_equal({}, obj.last)
+  end
+
   it 'allows delayed execution of ActiveRecord class methods with optional arguments' do
     assert_equal [], Sidekiq::Queue.all.map(&:name)
     q = Sidekiq::Queue.new
@@ -89,6 +101,18 @@ describe Sidekiq::Extensions do
     assert_equal 1, q.size
   end
 
+  it 'allows delayed delivery of ActionMailer mails with empty hash argument' do
+    assert_equal [], Sidekiq::Queue.all.map(&:name)
+    q = Sidekiq::Queue.new
+    assert_equal 0, q.size
+    UserMailer.delay.greetings_with_optional_args({})
+    assert_equal ['default'], Sidekiq::Queue.all.map(&:name)
+    assert_equal 1, q.size
+    obj = YAML.load q.first['args'].first
+    assert_equal([{}], obj[2])
+    assert_equal({}, obj.last)
+  end
+
   it 'allows delayed delivery of ActionMailer mails with optional arguments' do
     assert_equal [], Sidekiq::Queue.all.map(&:name)
     q = Sidekiq::Queue.new
@@ -129,6 +153,16 @@ describe Sidekiq::Extensions do
     assert_equal 0, q.size
     SomeClass.delay.doit(Date.today)
     assert_equal 1, q.size
+  end
+
+  it 'allows delay of any ole class method with empty hash argument' do
+    q = Sidekiq::Queue.new
+    assert_equal 0, q.size
+    SomeClass.delay.doit_with_optional_args({})
+    assert_equal 1, q.size
+    obj = YAML.load q.first['args'].first
+    assert_equal([{}], obj[2])
+    assert_equal({}, obj.last)
   end
 
   it 'allows delay of any ole class method with optional arguments' do


### PR DESCRIPTION
In 0a4de94d76a07d9a61f0f55d87de79ff8bfe2f41 some existing
functionality was broken in the case of the sole argument being passed
to the exetension being an empty hash.

The **kwargs parameter interprets the hash as belonging to it, rather
than to args. The result of this is that when the `perform` method is
called, the args is now `[]` whereas before that commit, it was `[{}]`.

This commit restores the functionality by removing **kwargs and adding
code that replicates the functionality of **kwargs complete with a
special case for an empty hash being passed.

## A backtrace of this error in action

Ruby 2.7.5, Rails 6.0.4.1.

Given:
```ruby
class TopSecretMailer < ActionMailer::Base
  def secret_method(data)
    ...
```

and:

```ruby
class TopSecretController < ActionController::Base
  def top_secret_method_name(data)
    TopSecretMailer.delay.secret_method(data)
```

I get the following stack trace when `data = {}`. By testing on different versions of sidekiq, I narrowed it down to the commit in question. (note: also fails in sidekiq 6.4.1).

```
ArgumentError:
       wrong number of arguments (given 0, expected 1)
     # ./app/mailers/top_secret_mailer.rb:2:in `secret_method'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionpack-6.0.4.1/lib/abstract_controller/base.rb:195:in `process_action'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionpack-6.0.4.1/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/activesupport-6.0.4.1/lib/active_support/callbacks.rb:101:in `run_callbacks'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionpack-6.0.4.1/lib/abstract_controller/callbacks.rb:41:in `process_action'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionpack-6.0.4.1/lib/abstract_controller/base.rb:136:in `process'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionmailer-6.0.4.1/lib/action_mailer/rescuable.rb:25:in `block in process'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionmailer-6.0.4.1/lib/action_mailer/rescuable.rb:17:in `handle_exceptions'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionmailer-6.0.4.1/lib/action_mailer/rescuable.rb:24:in `process'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionview-6.0.4.1/lib/action_view/rendering.rb:39:in `process'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionmailer-6.0.4.1/lib/action_mailer/base.rb:637:in `block in process'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/activesupport-6.0.4.1/lib/active_support/notifications.rb:180:in `block in instrument'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/activesupport-6.0.4.1/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/activesupport-6.0.4.1/lib/active_support/notifications.rb:180:in `instrument'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionmailer-6.0.4.1/lib/action_mailer/base.rb:636:in `process'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionmailer-6.0.4.1/lib/action_mailer/message_delivery.rb:124:in `block in processed_mailer'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionmailer-6.0.4.1/lib/action_mailer/message_delivery.rb:123:in `tap'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionmailer-6.0.4.1/lib/action_mailer/message_delivery.rb:123:in `processed_mailer'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/actionmailer-6.0.4.1/lib/action_mailer/message_delivery.rb:114:in `deliver_now'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/sidekiq-6.4.0/lib/sidekiq/extensions/action_mailer.rb:27:in `perform'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/sidekiq-6.4.0/lib/sidekiq/testing.rb:300:in `execute_job'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/sidekiq-6.4.0/lib/sidekiq/testing.rb:295:in `block in process_job'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/sidekiq-6.4.0/lib/sidekiq/middleware/chain.rb:133:in `invoke'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/sidekiq-6.4.0/lib/sidekiq/testing.rb:294:in `process_job'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/sidekiq-6.4.0/lib/sidekiq/testing.rb:89:in `block in raw_push'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/sidekiq-6.4.0/lib/sidekiq/testing.rb:85:in `each'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/sidekiq-6.4.0/lib/sidekiq/testing.rb:85:in `raw_push'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/sidekiq-6.4.0/lib/sidekiq/client.rb:77:in `push'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/sidekiq-6.4.0/lib/sidekiq/worker.rb:360:in `client_push'
     # /Users/reedstonefood/.gem/ruby/2.7.5/gems/sidekiq-6.4.0/lib/sidekiq/extensions/generic_proxy.rb:27:in `method_missing'
     # ./app/controllers/top_secret_controller.rb:3:in `top_secret_method_name'
```