### PR TITLE
Add failing test for scheduling in bulk and enqueued_at

### DIFF
--- a/test/test_scheduling.rb
+++ b/test/test_scheduling.rb
@@ -54,6 +54,16 @@ describe 'job scheduling' do
       assert job['created_at']
       refute job['enqueued_at']
     end
+
+    it 'removes the enqueued_at field when scheduling in bulk' do
+      ss = Sidekiq::ScheduledSet.new
+      ss.clear
+
+      assert Sidekiq::Client.push_bulk('class' => SomeScheduledWorker, 'args' => [['mike'], ['mike']], 'at' => 600)
+      job = ss.first
+      assert job['created_at']
+      refute job['enqueued_at']
+    end
   end
 
 end


### PR DESCRIPTION
While working on https://github.com/mperham/sidekiq/issues/5158 I noticed an inconsistency with how `enqueued_at` is being handled with `push_bulk`.

I'm submitting this PR with a new failing test to demonstrate this inconsistency. The reason for it is [here](https://github.com/mperham/sidekiq/blob/cd553fa14cefe789684f3cf35b0f61e4e22b6305/lib/sidekiq/client.rb#L106). `push_bulk` always adds `enqueued_at`. `push` only adds it [conditionally](https://github.com/mperham/sidekiq/blob/cd553fa14cefe789684f3cf35b0f61e4e22b6305/lib/sidekiq/client.rb#L209).

I'm not 100% sure what's expected here, but it prevents me from unifying `push` and `push_bulk` 😅 