### PR TITLE
Fix lingering command pipelining to Redis instance

### DIFF
--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -149,9 +149,9 @@ module Sidekiq
 
             transaction.unlink(workers_key)
             curstate.each_pair do |tid, hash|
-              conn.hset(workers_key, tid, Sidekiq.dump_json(hash))
+              transaction.hset(workers_key, tid, Sidekiq.dump_json(hash))
             end
-            conn.expire(workers_key, 60)
+            transaction.expire(workers_key, 60)
           end
         end
 


### PR DESCRIPTION
Related to #5139 . Redis was still throwing deprecation warnings for the
`conn.expire` call. I also changed the `conn.hset` call since my assumption is any commands called directly on the Redis instance are undesirable.