### PR TITLE
Use Kernel.warn for deprecation of delay extension.

### DIFF
--- a/lib/sidekiq/delay.rb
+++ b/lib/sidekiq/delay.rb
@@ -3,7 +3,7 @@
 module Sidekiq
   module Extensions
     def self.enable_delay!
-      Sidekiq.logger.error "Sidekiq's Delayed Extensions will be removed in Sidekiq 7.0. #{caller(1..1).first}"
+      warn "Sidekiq's Delayed Extensions will be removed in Sidekiq 7.0", uplevel: 1
 
       if defined?(::ActiveSupport)
         require "sidekiq/extensions/active_record"


### PR DESCRIPTION
## Why?
For consideration: 

This allows disabling the console output via RUBYOPT, etc. in certain contexts where it's desirable to keep console output clean without having to change log level. (e.g. large projects with parallel builds in CI).

Thanks for Sidekiq!