### PR TITLE
Do not fix the width of the navigation status bar

### DIFF
--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -202,7 +202,7 @@ table .table-checkbox label {
 
 .navbar .navbar-brand .status {
   color: #585454;
-  display: inline-block;
+  display: inline;
 }
 
 

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -203,7 +203,6 @@ table .table-checkbox label {
 .navbar .navbar-brand .status {
   color: #585454;
   display: inline-block;
-  width: 75px;
 }
 
 


### PR DESCRIPTION
## summary
When using Sidekiq web console in Japanese, the `アクティブ` characters in the navigation status bar are wrapped.
https://github.com/mperham/sidekiq/blob/dce4b747f7d86e38d8be3879e359b376786c9804/web/locales/ja.yml#L54
<img width="500" alt="wrap" src="https://user-images.githubusercontent.com/3206268/153113925-7630764a-cdef-4ff4-a516-a5eae45e7b95.png">

## Change point
Removed the fixed width of the navigation status bar and changed `display: inline-block;` to `display: inline;`.
This will prevent characters from being wrapped.

<img width="500" alt="inline" src="https://user-images.githubusercontent.com/3206268/153114798-4830f662-332e-4155-bbd4-925c599b780d.png">
<img width="500" alt="inline-en" src="https://user-images.githubusercontent.com/3206268/153115017-198c1a01-7806-4295-935c-861ce72da137.png">
