### PR TITLE
Exit sidekiqmon with non-zero exit code if an error occurs

### DIFF
--- a/lib/sidekiq/monitor.rb
+++ b/lib/sidekiq/monitor.rb
@@ -17,8 +17,7 @@ class Sidekiq::Monitor
       end
       send(section)
     rescue => e
-      puts "Couldn't get status: #{e}"
-      exit 1
+      abort "Couldn't get status: #{e}"
     end
 
     def all

--- a/lib/sidekiq/monitor.rb
+++ b/lib/sidekiq/monitor.rb
@@ -18,6 +18,7 @@ class Sidekiq::Monitor
       send(section)
     rescue => e
       puts "Couldn't get status: #{e}"
+      exit 1
     end
 
     def all


### PR DESCRIPTION
Closes #5195. Exit monitor with status code 1 if an exception is raised and sidekiq status isn't able to be displayed.