### PR TITLE
Add `perform_sync` alias method of `perform_inline`

### DIFF
--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -294,6 +294,7 @@ module Sidekiq
       def perform_inline(*args)
         Setter.new(self, {}).perform_inline(*args)
       end
+      alias_method :perform_sync, :perform_inline
 
       ##
       # Push a large number of jobs to Redis, while limiting the batch of

--- a/test/test_worker.rb
+++ b/test/test_worker.rb
@@ -144,5 +144,9 @@ describe Sidekiq::Worker do
         end
       end
     end
+
+    it 'has the alias #perform_sync' do
+      assert_equal MyCustomWorker.method(:perform_inline), MyCustomWorker.method(:perform_sync)
+    end
   end
 end


### PR DESCRIPTION
Since v6.4.0, Sidekiq supports `perform_sync` class method in `Sidekiq::Job`.
https://github.com/mperham/sidekiq/blob/6a6fda35fa9d07c4fe8ed3b05609a0eba6781101/Changes.md?plain=1#L22-L27

However, when I called `perform_sync`, `NoMethodError` has occurred.
``` ruby
class SomeJob
  include Sidekiq::Job

  def perform
    puts "foo"
  end
end

SomeJob.perform_sync # => undefined method `perform_sync' for SomeJob:Class (NoMethodError)
```

I added `perform_sync` alias of `perform_inline` and fix it.