### PR TITLE
Ignore Docker config in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ tmp/
 pkg/*.gem
 .byebug_history
 development.log
+/Dockerfile
+/Makefile
+/docker-compose.yml


### PR DESCRIPTION
I can't let go of #5183. It takes 10 minutes of my time to compile new Ruby version when I use rbenv and 10 seconds when it's done via Docker. Could we add these to `.gitignore` so that I can use it for my development without having dirty directory?