### PR TITLE
Add event listeners after reload

### DIFF
--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -9,7 +9,9 @@ var ready = (callback) => {
   else document.addEventListener("DOMContentLoaded", callback);
 }
 
-ready(() => {
+ready(addListeners)
+
+function addListeners() {
   document.querySelectorAll(".check_all").forEach(node => {
     node.addEventListener("click", event => {
       node.closest('table').querySelectorAll('input[type=checkbox]').forEach(inp => { inp.checked = !!node.checked; });
@@ -61,7 +63,7 @@ ready(() => {
       scheduleLivePoll();
     }
   }
-})
+}
 
 function updateFuzzyTimes() {
   var locale = document.body.getAttribute("data-locale");
@@ -108,4 +110,5 @@ function replacePage(text) {
   document.querySelector('.status').replaceWith(header_status)
 
   updateFuzzyTimes();
+  addListeners();
 }

--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -109,6 +109,5 @@ function replacePage(text) {
   var header_status = doc.querySelector('.status')
   document.querySelector('.status').replaceWith(header_status)
 
-  updateFuzzyTimes();
   addListeners();
 }


### PR DESCRIPTION
This re-initializes the event listeners after the DOM is updated from polling.

Fixes #5184