### PR TITLE
Surface exact job class name in complex argument error message

### DIFF
--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -13,9 +13,7 @@ module Sidekiq
       raise(ArgumentError, "Job 'at' must be a Numeric timestamp: `#{item}`") if item.key?("at") && !item["at"].is_a?(Numeric)
       raise(ArgumentError, "Job tags must be an Array: `#{item}`") if item["tags"] && !item["tags"].is_a?(Array)
 
-      # If we're using a wrapper class, like ActiveJob, use the "wrapped"
-      # attribute to expose the underlying class.
-      job_class = item["display_class"] || item["wrapped"] || item["class"]
+      job_class = item["wrapped"] || item["class"]
       if Sidekiq.options[:on_complex_arguments] == :raise
         msg = <<~EOM
           Job arguments to #{job_class} must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices.

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -246,7 +246,7 @@ describe Sidekiq::Client do
 
           it 'raises error with correct class name' do
             error = assert_raises ArgumentError do
-              TestActiveJob.perform_later({:x => 1})
+              TestActiveJob.perform_later(1.1212.to_d)
             end
             assert_match /Job arguments to TestActiveJob/, error.message
           end


### PR DESCRIPTION
Follow up to https://github.com/mperham/sidekiq/issues/5228

I couldn't get the ActiveJob test working, but here's a draft for fixing the message.