### PR TITLE
Recover web UI on 500 errors

### DIFF
--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -91,7 +91,19 @@ function updateLivePollButton() {
 function livePollCallback() {
   clearTimeout(livePollTimer);
 
-  fetch(window.location.href).then(resp => resp.text()).then(replacePage).finally(scheduleLivePoll)
+  fetch(window.location.href)
+  .then(checkResponse)
+  .then(resp => resp.text())
+  .then(replacePage)
+  .catch(showError)
+  .finally(scheduleLivePoll)
+}
+
+function checkResponse(resp) {
+  if (!resp.ok) {
+    throw response.error();
+  }
+  return resp
 }
 
 function scheduleLivePoll() {
@@ -110,4 +122,8 @@ function replacePage(text) {
   document.querySelector('.status').replaceWith(header_status)
 
   addListeners();
+}
+
+function showError(error) {
+  console.error(error)
 }


### PR DESCRIPTION
If the polling response is not `.ok`, raise the response error and allow the `.catch()` to then show the error.

I tested this locally by changing the 
```ruby
    get "/busy" do
      raise "foo" if [true, false].sample
      erb(:busy)
    end
```

Should it show an error if `/busy` returns a 500? Or just silently move on? Right now I'm just logging to `console.error`