### PR TITLE
Prevent stray polling interval from running and prevent duplicate event listeners

### DIFF
--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -28,15 +28,7 @@ function addListeners() {
   })
 
   document.querySelectorAll("[data-toggle]").forEach(node => {
-    node.addEventListener("click", event => {
-      var targName = node.getAttribute("data-toggle");
-      var full = document.getElementById(targName + "_full");
-      if (full.style.display == "block") {
-        full.style.display = 'none';
-      } else {
-        full.style.display = 'block';
-      }
-    })
+    node.addEventListener("click", addDataToggleListeners)
   })
 
   updateFuzzyTimes();
@@ -44,24 +36,37 @@ function addListeners() {
   var buttons = document.querySelectorAll(".live-poll");
   if (buttons.length > 0) {
     buttons.forEach(node => {
-      node.addEventListener("click", event => {
-        if (localStorage.sidekiqLivePoll == "enabled") {
-          localStorage.sidekiqLivePoll = "disabled";
-          clearTimeout(livePollTimer);
-          livePollTimer = null;
-        } else {
-          localStorage.sidekiqLivePoll = "enabled";
-          livePollCallback();
-        }
-
-        updateLivePollButton();
-      })
+      node.addEventListener("click", addPollingListeners)
     });
 
     updateLivePollButton();
-    if (localStorage.sidekiqLivePoll == "enabled") {
+    if (localStorage.sidekiqLivePoll == "enabled" && !livePollTimer) {
       scheduleLivePoll();
     }
+  }
+}
+
+function addPollingListeners(_event)  {
+  if (localStorage.sidekiqLivePoll == "enabled") {
+    localStorage.sidekiqLivePoll = "disabled";
+    clearTimeout(livePollTimer);
+    livePollTimer = null;
+  } else {
+    localStorage.sidekiqLivePoll = "enabled";
+    livePollCallback();
+  }
+
+  updateLivePollButton();
+}
+
+function addDataToggleListeners(event) {
+  var source = event.target || event.srcElement;
+  var targName = source.getAttribute("data-toggle");
+  var full = document.getElementById(targName + "_full");
+  if (full.style.display == "block") {
+    full.style.display = 'none';
+  } else {
+    full.style.display = 'block';
   }
 }
 


### PR DESCRIPTION
Related to: https://github.com/mperham/sidekiq/pull/5230

### Bug 1: Multiple event listeners are added to elements

When adding event listeners to elements, Javascript will generally prevent duplicating the listener if the callback function is named. Anonymous functions aren't tracked the same way. Javascript will continue to add an event listener every time the polling happens. This commit names those functions where the listeners are added to elements outside of the "page" `div`.

The duplicate event listeners caused some odd behavior:

1. Clicking in the "Stop Polling" caused a single GET call to the server for each event listener on the element. This will be problematic if someone leaves the polling on for an extended period of time.
2. It would some times cause the "Stop Polling" functionality to not stop polling.

#### How to duplicate:

1. Open the page inspector from the developer tools of your browser.
2. Click on the "event" button next to the "Live Poll" button in the inspector. You'll see that there's only one event listener.
3. After the page does a poll, click on it again and you'll now see two event listeners with the same function.
4. Click on the stop polling button
5. Look at your server logs and you'll see a single request per event listener

### Bug 2: Ghost interval continues polling after clicking "Stop Polling"

Every time the `addListeners` function was called, it would call the `scheduleLivePoll()` function and setup a new `setTimeout`. Thus, when you clicked on the "Stop Polling" button, it would continue to poll because of a stray `setTimeout`. The only way to stop the polling was to refresh. This commit prevents the function from running if a timeout already exists.

#### How to duplicate:

1. All the UI to poll for 30 seconds
2. Clear your server logs
3. Click on "Stop Polling"
4. Watch your server logs and you'll see the same polling request continue to come in every five or so seconds.

----

**Note:** Above bugs and fixes experienced and tested on Firefox 98.0.1, respectively.