### PR TITLE
Use bundle add instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Sidekiq 6.0 supports Rails 5.0+ but does not require it.
 Installation
 -----------------
 
-    gem install sidekiq
+    bundle add sidekiq
 
 
 Getting Started


### PR DESCRIPTION
As per https://github.com/rubygems/rubygems/pull/5337, we can simplify the steps of adding a gem.