### PR TITLE
Sidekiq 7: Replace `redis` by `redis-client`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ development.log
 /Dockerfile
 /Makefile
 /docker-compose.yml
+Gemfile.lock
+

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake"
-gem "redis-namespace"
+gem "redis-client", github: "redis-rb/redis-client"
 gem "rails", "~> 7.0"
 gem "sqlite3", platforms: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby

--- a/bin/sidekiqload
+++ b/bin/sidekiqload
@@ -55,7 +55,7 @@ rescue ArgumentError
   puts "Signal #{sig} not supported"
 end
 
-Sidekiq.redis { |c| c.flushdb }
+Sidekiq.redis { |c| c.call("FLUSHDB") }
 def handle_signal(launcher, sig)
   Sidekiq.logger.debug "Got #{sig} signal"
   case sig
@@ -100,7 +100,7 @@ Monitoring = Thread.new do
   while true
     sleep 0.2
     qsize = Sidekiq.redis do |conn|
-      conn.llen "queue:default"
+      conn.call("LLEN", "queue:default")
     end
     total = qsize
     # Sidekiq.logger.error("RSS: #{Process.rss} Pending: #{total}")

--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -176,7 +176,7 @@ module Sidekiq
         retry_at = Time.now.to_f + delay
         payload = Sidekiq.dump_json(msg)
         Sidekiq.redis do |conn|
-          conn.zadd("retry", retry_at.to_s, payload)
+          conn.call("ZADD", "retry", retry_at.to_s, payload)
         end
       else
         # Goodbye dear message, you (re)tried your best I'm sure.

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -44,7 +44,7 @@ module Sidekiq
     head "/" do
       # HEAD / is the cheapest heartbeat possible,
       # it hits Redis to ensure connectivity
-      Sidekiq.redis { |c| c.llen("queue:default") }
+      Sidekiq.redis { |c| c.call("LLEN", "queue:default") }
       ""
     end
 

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -154,7 +154,7 @@ module Sidekiq
 
     def redis_connection
       Sidekiq.redis do |conn|
-        conn.connection[:id]
+        conn.id
       end
     end
 

--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
     "source_code_uri" => "https://github.com/mperham/sidekiq"
   }
 
-  gem.add_dependency "redis", ">= 4.5.1"
+  gem.add_dependency "redis-client"
   gem.add_dependency "connection_pool", ">= 2.2.5"
   gem.add_dependency "rack", "~> 2.2"
 end

--- a/test/test_actors.rb
+++ b/test/test_actors.rb
@@ -17,7 +17,7 @@ describe "Actors" do
   end
 
   before do
-    Sidekiq.redis { |c| c.flushdb }
+    Sidekiq.redis { |c| c.call("FLUSHDB") }
   end
 
   describe "scheduler" do

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -117,7 +117,7 @@ describe Sidekiq::Client do
     end
 
     it "enqueues" do
-      Sidekiq.redis { |c| c.flushdb }
+      Sidekiq.redis { |c| c.call("FLUSHDB") }
       assert_equal Sidekiq.default_job_options, MyWorker.get_sidekiq_options
       assert MyWorker.perform_async(1, 2)
       assert Sidekiq::Client.enqueue(MyWorker, 1, 2)
@@ -448,7 +448,7 @@ describe Sidekiq::Client do
     it "allows Resque helpers to point to different Redi" do
       conn = MiniTest::Mock.new
       conn.expect(:pipelined, []) { |*args, &block| block.call(conn) }
-      conn.expect(:zadd, 1, [String, Array])
+      conn.expect(:call, 2, [String, String, Array])
       DWorker.sidekiq_options("pool" => ConnectionPool.new(size: 1) { conn })
       Sidekiq::Client.enqueue_in(10, DWorker, 3)
       conn.verify

--- a/test/test_fetch.rb
+++ b/test/test_fetch.rb
@@ -7,10 +7,9 @@ require "sidekiq/api"
 describe Sidekiq::BasicFetch do
   before do
     @prev_redis = Sidekiq.instance_variable_get(:@redis) || {}
-    Sidekiq.redis = {namespace: "fuzzy"}
     Sidekiq.redis do |conn|
-      conn.redis.flushdb
-      conn.rpush("queue:basic", "msg")
+      conn.call("FLUSHDB")
+      conn.call("RPUSH","queue:basic", "msg")
     end
   end
 
@@ -39,8 +38,8 @@ describe Sidekiq::BasicFetch do
 
   it "bulk requeues" do
     Sidekiq.redis do |conn|
-      conn.rpush("queue:foo", ["bob", "bar"])
-      conn.rpush("queue:bar", "widget")
+      conn.call("RPUSH", "queue:foo", ["bob", "bar"])
+      conn.call("RPUSH", "queue:bar", "widget")
     end
 
     q1 = Sidekiq::Queue.new("foo")

--- a/test/test_job.rb
+++ b/test/test_job.rb
@@ -11,7 +11,7 @@ describe Sidekiq::Job do
     end
 
     def setup
-      Sidekiq.redis { |c| c.flushdb }
+      Sidekiq.redis { |c| c.call("FLUSHDB") }
     end
 
     it "provides basic ActiveJob compatibilility" do

--- a/test/test_launcher.rb
+++ b/test/test_launcher.rb
@@ -6,7 +6,7 @@ require "sidekiq/launcher"
 describe Sidekiq::Launcher do
   subject { Sidekiq::Launcher.new(options) }
   before do
-    Sidekiq.redis { |c| c.flushdb }
+    Sidekiq.redis { |c| c.call("FLUSHDB") }
   end
 
   def new_manager(opts)
@@ -49,13 +49,13 @@ describe Sidekiq::Launcher do
         it "stores process info in redis" do
           subject.heartbeat
 
-          workers, rtt = Sidekiq.redis { |c| c.hmget(subject.identity, "busy", "rtt_us") }
+          workers, rtt = Sidekiq.redis { |c| c.call("HMGET", subject.identity, "busy", "rtt_us") }
 
           assert_equal "1", workers
           refute_nil rtt
           assert_in_delta 1000, rtt.to_i, 1000
 
-          expires = Sidekiq.redis { |c| c.pttl(subject.identity) }
+          expires = Sidekiq.redis { |c| c.call("PTTL", subject.identity) }
 
           assert_in_delta 60000, expires, 500
         end
@@ -93,11 +93,11 @@ describe Sidekiq::Launcher do
         it "stores process info in redis" do
           subject.heartbeat
 
-          info = Sidekiq.redis { |c| c.hmget(subject.identity, "busy") }
+          info = Sidekiq.redis { |c| c.call("HMGET", subject.identity, "busy") }
 
           assert_equal ["1"], info
 
-          expires = Sidekiq.redis { |c| c.pttl(subject.identity) }
+          expires = Sidekiq.redis { |c| c.call("PTTL", subject.identity) }
 
           assert_in_delta 60000, expires, 50
         end
@@ -127,9 +127,9 @@ describe Sidekiq::Launcher do
         end
 
         it "stores process info in redis" do
-          info = Sidekiq.redis { |c| c.hmget(@id, "busy") }
+          info = Sidekiq.redis { |c| c.call("HMGET", @id, "busy") }
           assert_equal ["1"], info
-          expires = Sidekiq.redis { |c| c.pttl(@id) }
+          expires = Sidekiq.redis { |c| c.call("PTTL", @id) }
           assert_in_delta 60000, expires, 500
         end
       end
@@ -150,9 +150,9 @@ describe Sidekiq::Launcher do
       end
 
       it "stores process info in redis" do
-        info = Sidekiq.redis { |c| c.hmget(@id, "busy") }
+        info = Sidekiq.redis { |c| c.call("HMGET", @id, "busy") }
         assert_equal ["1"], info
-        expires = Sidekiq.redis { |c| c.pttl(@id) }
+        expires = Sidekiq.redis { |c| c.call("PTTL", @id) }
         assert_in_delta 60000, expires, 50
       end
     end

--- a/test/test_manager.rb
+++ b/test/test_manager.rb
@@ -5,7 +5,7 @@ require "sidekiq/manager"
 
 describe Sidekiq::Manager do
   before do
-    Sidekiq.redis { |c| c.flushdb }
+    Sidekiq.redis { |c| c.call("FLUSHDB") }
   end
 
   def new_manager(opts)

--- a/test/test_processor.rb
+++ b/test/test_processor.rb
@@ -298,7 +298,7 @@ describe Sidekiq::Processor do
 
   describe "stats" do
     before do
-      Sidekiq.redis { |c| c.flushdb }
+      Sidekiq.redis { |c| c.call("FLUSHDB") }
     end
 
     describe "when successful" do
@@ -336,7 +336,7 @@ describe Sidekiq::Processor do
 
   describe "stats" do
     before do
-      Sidekiq.redis { |c| c.flushdb }
+      Sidekiq.redis { |c| c.call("FLUSHDB") }
     end
 
     def successful_job

--- a/test/test_rails.rb
+++ b/test/test_rails.rb
@@ -6,7 +6,7 @@ require "sidekiq/api"
 
 describe "ActiveJob" do
   before do
-    Sidekiq.redis { |c| c.flushdb }
+    Sidekiq.redis { |c| c.call("FLUSHDB") }
     # need to force this since we aren't booting a Rails app
     ActiveJob::Base.queue_adapter = :sidekiq
     ActiveJob::Base.logger = nil

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -18,7 +18,7 @@ describe Sidekiq::JobRetry do
     end
 
     before do
-      Sidekiq.redis { |c| c.flushdb }
+      Sidekiq.redis { |c| c.call("FLUSHDB") }
     end
 
     def worker

--- a/test/test_sidekiqmon.rb
+++ b/test/test_sidekiqmon.rb
@@ -19,7 +19,7 @@ end
 
 describe Sidekiq::Monitor do
   before do
-    Sidekiq.redis { |c| c.flushdb }
+    Sidekiq.redis { |c| c.call("FLUSHDB") }
   end
 
   describe "status" do


### PR DESCRIPTION
As discussed in https://github.com/redis/redis-rb/issues/1070#issuecomment-1074094773

Current shortcomings (https://github.com/redis-rb/redis-client/issues/6):

  - No `namespace` support. This one is debatable.
  - No connection `url` support (this will be added very soon)
  - No `reconnect_attempts` support. I'd like to add it, but in a smarter way.

There is 2 failing tests left, not too sure what's happening with them, but I'm sure they could be fixed. The objective here was to find missing features in `redis-client`.

cc @mperham 