### PR TITLE
Change systemd restart method to "always"

### DIFF
--- a/examples/systemd/sidekiq.service
+++ b/examples/systemd/sidekiq.service
@@ -76,7 +76,7 @@ Environment=MALLOC_ARENA_MAX=2
 
 # if we crash, restart
 RestartSec=1
-Restart=on-failure
+Restart=always
 
 # output goes to /var/log/syslog (Ubuntu) or /var/log/messages (CentOS)
 StandardOutput=syslog


### PR DESCRIPTION
I'm running Sidekiq 6.4.1 on an Ubuntu 20.04 system with Ruby 3.1.1 installed via Snap for a Rails 7 application.

Using this systemd template, I noticed something odd when deploying with Capistrano. When my cap script ran `sudo systemctl restart sidekiq`, the Sidekiq process would restart, briefly go active, then go inactive and stop running. I would need to SSH in and manually do a `systemctl restart sidekiq` in order to get the process back up and running.

With some experimentation, I found that changing the `Restart` configuration from `on-failure` to `always` seems to do the trick. Now, when the Sidekiq process goes inactive, it properly restarts and stays restarted.

I'm not 100% sure of the "why" behind what's going on, but this change seems to be effective and I have not noticed any side effects.

## Documentation of previous behavior

### Prior to deploy (process running)
```
root@stage-worker01:~# systemctl status sidekiq
● sidekiq.service - sidekiq
     Loaded: loaded (/lib/systemd/system/sidekiq.service; enabled; vendor prese>
     Active: active (running) since Thu 2022-03-24 16:34:32 UTC; 51s ago
   Main PID: 118856 (bundle)
      Tasks: 30 (limit: 1120)
     Memory: 291.2M
     CGroup: /system.slice/sidekiq.service
             └─118856 sidekiq 6.4.1 staging [0 of 20 busy]
```

### Immediately post deploy (process restarting)

```
root@stage-worker01:~# systemctl status sidekiq
● sidekiq.service - sidekiq
     Loaded: loaded (/lib/systemd/system/sidekiq.service; enabled; vendor prese>
     Active: activating (start) since Thu 2022-03-24 16:38:35 UTC; 9s ago
   Main PID: 119572 (bundle)
      Tasks: 0 (limit: 1120)
     Memory: 43.4M
     CGroup: /system.slice/sidekiq.service
             ‣ 119572 /var/www/sox/staging/shared/bundle/ruby/3.1.0/bin/sidekiq>
```

### After deploy (process started)

```
Mar 24 16:38:35 stage-worker01.suggestionox.com systemd[1]: Starting sidekiq...
root@stage-worker01:~# systemctl status sidekiq
● sidekiq.service - sidekiq
     Loaded: loaded (/lib/systemd/system/sidekiq.service; enabled; vendor prese>
     Active: active (running) since Thu 2022-03-24 16:38:45 UTC; 3s ago
   Main PID: 119572 (bundle)
      Tasks: 0 (limit: 1120)
     Memory: 43.4M
     CGroup: /system.slice/sidekiq.service
             ‣ 119572 sidekiq 6.4.1 staging [0 of 20 busy]

Mar 24 16:38:35 stage-worker01.suggestionox.com systemd[1]: Starting sidekiq...
Mar 24 16:38:45 stage-worker01.suggestionox.com systemd[1]: Started sidekiq.
```

### Failure (process inactive)

```
root@stage-worker01:~# systemctl status sidekiq
● sidekiq.service - sidekiq
     Loaded: loaded (/lib/systemd/system/sidekiq.service; enabled; vendor prese>
     Active: inactive (dead) since Thu 2022-03-24 16:38:56 UTC; 2s ago
    Process: 119572 ExecStart=/usr/bin/env bundle exec sidekiq -e staging (code>
   Main PID: 119572 (code=exited, status=0/SUCCESS)

Mar 24 16:38:35 stage-worker01.suggestionox.com systemd[1]: Starting sidekiq...
Mar 24 16:38:45 stage-worker01.suggestionox.com systemd[1]: Started sidekiq.
Mar 24 16:38:56 stage-worker01.suggestionox.com systemd[1]: sidekiq.service: Su>
```