### PR TITLE
constantize consolidation

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -3,6 +3,7 @@
 require "sidekiq/version"
 fail "Sidekiq #{Sidekiq::VERSION} does not support Ruby versions below 2.5.0." if RUBY_PLATFORM != "java" && Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5.0")
 
+require "sidekiq/constantize"
 require "sidekiq/logger"
 require "sidekiq/client"
 require "sidekiq/worker"

--- a/lib/sidekiq/constantize.rb
+++ b/lib/sidekiq/constantize.rb
@@ -1,0 +1,11 @@
+module Sidekiq
+  # mimic Rails String#constantize
+  def self.constantize(str)
+    names = str.split("::")
+    names.shift if names.empty? || names.first.empty?
+
+    names.inject(Object) do |constant, name|
+      constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
+    end
+  end
+end

--- a/lib/sidekiq/delay.rb
+++ b/lib/sidekiq/delay.rb
@@ -27,14 +27,9 @@ module Sidekiq
 
     module PsychAutoload
       def resolve_class(klass_name)
-        return nil if !klass_name || klass_name.empty?
-        # constantize
-        names = klass_name.split("::")
-        names.shift if names.empty? || names.first.empty?
+        return if !klass_name || klass_name.empty?
 
-        names.inject(Object) do |constant, name|
-          constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
-        end
+        Sidekiq.constantize(klass_name)
       rescue NameError
         super
       end

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -129,7 +129,7 @@ module Sidekiq
               # the Reloader.  It handles code loading, db connection management, etc.
               # Effectively this block denotes a "unit of work" to Rails.
               @reloader.call do
-                klass = constantize(job_hash["class"])
+                klass = Sidekiq.constantize(job_hash["class"])
                 inst = klass.new
                 inst.jid = job_hash["jid"]
                 @retrier.local(inst, jobstr, queue) do
@@ -261,19 +261,6 @@ module Sidekiq
       ensure
         WORK_STATE.delete(tid)
         PROCESSED.incr
-      end
-    end
-
-    def constantize(str)
-      return Object.const_get(str) unless str.include?("::")
-
-      names = str.split("::")
-      names.shift if names.empty? || names.first.empty?
-
-      names.inject(Object) do |constant, name|
-        # the false flag limits search for name to under the constant namespace
-        #   which mimics Rails' behaviour
-        constant.const_get(name, false)
       end
     end
   end

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -55,15 +55,6 @@ module Sidekiq
         yield @server_chain if block_given?
         @server_chain
       end
-
-      def constantize(str)
-        names = str.split("::")
-        names.shift if names.empty? || names.first.empty?
-
-        names.inject(Object) do |constant, name|
-          constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
-        end
-      end
     end
   end
 
@@ -83,7 +74,7 @@ module Sidekiq
         true
       elsif Sidekiq::Testing.inline?
         payloads.each do |job|
-          klass = Sidekiq::Testing.constantize(job["class"])
+          klass = Sidekiq.constantize(job["class"])
           job["id"] ||= SecureRandom.hex(12)
           job_hash = Sidekiq.load_json(Sidekiq.dump_json(job))
           klass.process_job(job_hash)
@@ -318,7 +309,7 @@ module Sidekiq
           job_classes = jobs.map { |job| job["class"] }.uniq
 
           job_classes.each do |job_class|
-            Sidekiq::Testing.constantize(job_class).drain
+            Sidekiq.constantize(job_class).drain
           end
         end
       end

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -218,7 +218,7 @@ module Sidekiq
         msg = Sidekiq.load_json(Sidekiq.dump_json(item))
 
         # prepare the job instance
-        klass = msg["class"].constantize
+        klass = Sidekiq.constantize(msg["class"])
         job = klass.new
         job.jid = msg["jid"]
         job.bid = msg["bid"] if job.respond_to?(:bid)

--- a/test/test_constantize.rb
+++ b/test/test_constantize.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "helper"
+
+class TestConstantize < Minitest::Test
+  def test_constantize
+    assert_equal Sidekiq, Sidekiq.constantize("Sidekiq")
+    assert_equal Sidekiq, Sidekiq.constantize("::Sidekiq")
+    assert_equal Sidekiq::Worker, Sidekiq.constantize("Sidekiq::Worker")
+    assert_equal Sidekiq::Middleware::Chain, Sidekiq.constantize("::Sidekiq::Middleware::Chain")
+
+    assert_raises NameError do
+      Sidekiq.constantize("Sidekiq::Foo")
+    end
+  end
+end


### PR DESCRIPTION
Thought it might be useful to consolidate the three different versions of constantize implemented within Sidekiq, and to avoid using the Rails one implicitly since it causes a bug if rails is not loaded.


```ruby
> class MockWorker
  include Sidekiq::Worker

  def perform; end
end
=> :perform
> MockWorker.perform_inline
Traceback (most recent call last):
        5: from /Users/dpepper/.rvm/rubies/ruby-2.7.6/bin/irb:23:in `load'
        4: from /Users/dpepper/.rvm/rubies/ruby-2.7.6/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        3: from (irb):6
        2: from /Users/dpepper/.rvm/gems/ruby-2.7.6/gems/sidekiq-6.4.2/lib/sidekiq/worker.rb:294:in `perform_inline'
        1: from /Users/dpepper/.rvm/gems/ruby-2.7.6/gems/sidekiq-6.4.2/lib/sidekiq/worker.rb:221:in `perform_inline'
NoMethodError (undefined method `constantize' for "MockWorker":String)
> require 'rails'
=> true
> MockWorker.perform_inline
=> true
```