### PR TITLE
code doc for "dead" sidekiq_option

### DIFF
--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -65,6 +65,7 @@ module Sidekiq
         #      *true* to use the default or *Integer* count
         #   backtrace - whether to save any error backtrace in the retry payload to display in web UI,
         #      can be true, false or an integer number of lines to save, default *false*
+        #   dead - if *false*, sidekiq will not add failed jobs to the dead jobs list
         #
         # In practice, any option is allowed.  This is the main mechanism to configure the
         # options for a specific job.


### PR DESCRIPTION
I was testing our workers to ensure that only valid options were present, and found that 'dead' was a valid option, yet I could not find documentation about it.

Another unsurprising finding was that many authors thought the "retry" option was actually "retries", probably because it is commonly accompanied by an integer.