### PR TITLE
Require TransactionAwareClient

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -5,6 +5,7 @@ fail "Sidekiq #{Sidekiq::VERSION} does not support Ruby versions below 2.5.0." i
 
 require "sidekiq/logger"
 require "sidekiq/client"
+require "sidekiq/transaction_aware_client"
 require "sidekiq/worker"
 require "sidekiq/job"
 require "sidekiq/redis_connection"


### PR DESCRIPTION
As I mentioned in https://github.com/mperham/sidekiq/commit/fdfb7a5211fbe2c29cfcca84aabd868004a4eb57#r73562100. I wanted to test `TransactionAwareClient` in https://github.com/adamniedzielski/sidekiq-staged_push-demo/pull/6. That's what I needed to change.