### PR TITLE
allow pushes to the top of the queue

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -219,7 +219,7 @@ module Sidekiq
     end
 
     def atomic_push(conn, payloads)
-      push = if payloads.first['push_to_top']
+      push = if payloads.first.delete('push_to_top')
         conn.method(:rpush)
       else 
         conn.method(:lpush)


### PR DESCRIPTION
This PR makes it possible to push new jobs to the top of the queue, rather than to the bottom.

An example of the use case is processing the following theoretical multi-stage job, consisting of the following stages:
  - fetch data from an external API
  - making an expensive calculation
  - pushing results to an external API

If all of these stages are considered expensive, we would like to have the ability to reprocess only the failed job, eg. if the push of the results failed, we should only retry that operation, rather than the whole job.

This was implemented as separate jobs for the stages, one queueing the next one using the result. However this also means that if one job starts processing and queues the second job, sidekiq will process any intermittent jobs BEFORE continuing with the next phase of the job. This means that the queue delay will have to be waited as many times as the  number of stages which is inefficient. We'd like to start working on a multi-stage job from start to finish.

A good enough solution would be to push the job to the top / beginning of the queue instead of the end of it, so that whenever the worker finishes working on the current stage it will be able to pick up the next stage immediately (unless another worker picks it up before)

The PR allows this to be used like:
```
  NextStage.set(push_to_top: true).perform_async(resultsOfCurrentStage)
```

This will probably need to be documented somewhere, and probably tests written, please let me know.