### PR TITLE
Fix drain_all infinite loop after clearing worker with symbolized queue

### DIFF
--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -188,7 +188,7 @@ module Sidekiq
       end
 
       def clear_for(queue, klass)
-        jobs_by_queue[queue].clear
+        jobs_by_queue[queue.to_s].clear
         jobs_by_class[klass].clear
       end
 

--- a/test/test_testing_fake.rb
+++ b/test/test_testing_fake.rb
@@ -250,6 +250,18 @@ describe "Sidekiq::Testing.fake" do
     assert_equal 1, SecondWorker.count
   end
 
+  it 'clears the jobs of workers having their queue name defined as a symbol' do
+    assert_equal Symbol, AltQueueWorker.sidekiq_options["queue"].class
+
+    AltQueueWorker.perform_async
+    assert_equal 1, AltQueueWorker.jobs.size
+    assert_equal 1, Sidekiq::Queues[AltQueueWorker.sidekiq_options["queue"].to_s].size
+
+    AltQueueWorker.clear
+    assert_equal 0, AltQueueWorker.jobs.size
+    assert_equal 0, Sidekiq::Queues[AltQueueWorker.sidekiq_options["queue"].to_s].size
+  end
+
   it "drains jobs across all workers even when workers create new jobs" do
     Sidekiq::Worker.jobs.clear
     FirstWorker.count = 0


### PR DESCRIPTION
`jobs_by_queue` saves the queue name of enqueued jobs as strings. When
`clear` is called for a worker that has it's queue name defined as a
symbol `clear` calls `Queues.clear_for` using a symbol. As a result
`jobs_by_queue` is not cleared, while `jobs_by_class` is. Calling
`drain_all` then runs into an infinite loop because of the mismatch of
the two state hashes.