### PR TITLE
Hide tagline on md viewports

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,7 @@
         <button data-toggle="collapse" data-target="#navbar-top-collapse-1" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span
             class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
         <a href="/" class="skq navbar-brand">Sidekiq</a><span
-          class="default skq-tagline navbar-brand col-sm-5 hidden-xs">Simple, efficient background jobs for Ruby.</span>
+          class="default skq-tagline navbar-brand col-sm-5 hidden-md">Simple, efficient background jobs for Ruby.</span>
       </div>
       <div id="navbar-top-collapse-1" class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-right">

--- a/_site/404.html
+++ b/_site/404.html
@@ -30,7 +30,7 @@
         <button data-toggle="collapse" data-target="#navbar-top-collapse-1" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span
             class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
         <a href="/" class="skq navbar-brand">Sidekiq</a><span
-          class="default skq-tagline navbar-brand col-sm-5 hidden-xs">Simple, efficient background jobs for Ruby.</span>
+          class="default skq-tagline navbar-brand col-sm-5 hidden-md">Simple, efficient background jobs for Ruby.</span>
       </div>
       <div id="navbar-top-collapse-1" class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-right">

--- a/_site/about.html
+++ b/_site/about.html
@@ -30,7 +30,7 @@
         <button data-toggle="collapse" data-target="#navbar-top-collapse-1" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span
             class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
         <a href="/" class="skq navbar-brand">Sidekiq</a><span
-          class="default skq-tagline navbar-brand col-sm-5 hidden-xs">Simple, efficient background jobs for Ruby.</span>
+          class="default skq-tagline navbar-brand col-sm-5 hidden-md">Simple, efficient background jobs for Ruby.</span>
       </div>
       <div id="navbar-top-collapse-1" class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-right">

--- a/_site/index.html
+++ b/_site/index.html
@@ -30,7 +30,7 @@
         <button data-toggle="collapse" data-target="#navbar-top-collapse-1" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span
             class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
         <a href="/" class="skq navbar-brand">Sidekiq</a><span
-          class="default skq-tagline navbar-brand col-sm-5 hidden-xs">Simple, efficient background jobs for Ruby.</span>
+          class="default skq-tagline navbar-brand col-sm-5 hidden-md">Simple, efficient background jobs for Ruby.</span>
       </div>
       <div id="navbar-top-collapse-1" class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-right">

--- a/_site/products/enterprise.html
+++ b/_site/products/enterprise.html
@@ -30,7 +30,7 @@
         <button data-toggle="collapse" data-target="#navbar-top-collapse-1" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span
             class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
         <a href="/" class="skq navbar-brand">Sidekiq</a><span
-          class="default skq-tagline navbar-brand col-sm-5 hidden-xs">Simple, efficient background jobs for Ruby.</span>
+          class="default skq-tagline navbar-brand col-sm-5 hidden-md">Simple, efficient background jobs for Ruby.</span>
       </div>
       <div id="navbar-top-collapse-1" class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-right">

--- a/_site/products/pro.html
+++ b/_site/products/pro.html
@@ -30,7 +30,7 @@
         <button data-toggle="collapse" data-target="#navbar-top-collapse-1" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span
             class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
         <a href="/" class="skq navbar-brand">Sidekiq</a><span
-          class="default skq-tagline navbar-brand col-sm-5 hidden-xs">Simple, efficient background jobs for Ruby.</span>
+          class="default skq-tagline navbar-brand col-sm-5 hidden-md">Simple, efficient background jobs for Ruby.</span>
       </div>
       <div id="navbar-top-collapse-1" class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-right">

--- a/_site/support.html
+++ b/_site/support.html
@@ -30,7 +30,7 @@
         <button data-toggle="collapse" data-target="#navbar-top-collapse-1" class="navbar-toggle"><span class="sr-only">Toggle navigation</span><span
             class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
         <a href="/" class="skq navbar-brand">Sidekiq</a><span
-          class="default skq-tagline navbar-brand col-sm-5 hidden-xs">Simple, efficient background jobs for Ruby.</span>
+          class="default skq-tagline navbar-brand col-sm-5 hidden-md">Simple, efficient background jobs for Ruby.</span>
       </div>
       <div id="navbar-top-collapse-1" class="collapse navbar-collapse">
         <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Hiding the tagline on `md` yields the following result:

https://user-images.githubusercontent.com/178448/171727899-03bec94b-8c5c-4f9a-945d-5c7f0ca1f5d7.mp4

Fixes #5351