### PR TITLE
redis-client: Fix `ZADD` compatibility

### DIFF
--- a/lib/sidekiq/client.rb
+++ b/lib/sidekiq/client.rb
@@ -220,7 +220,7 @@ module Sidekiq
 
     def atomic_push(conn, payloads)
       if payloads.first.key?("at")
-        conn.zadd("schedule", *payloads.map { |hash|
+        conn.zadd("schedule", payloads.flat_map { |hash|
           at = hash.delete("at").to_s
           [at, Sidekiq.dump_json(hash)]
         })


### PR DESCRIPTION
Fix: https://github.com/mperham/sidekiq/issues/5381

`redis-rb`'s `zadd` argument parsing is particularly strict and doesn't make it easy to have transparent compatibility.

The bug only happens if there is more than two elements being added, hence why we missed it.

I'll be improving the `zadd` signature in `redis-rb` as well to make the transition easier.

cc @mperham @christos 