### PR TITLE
define DEFAULT_ERROR_HANDLER

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -84,6 +84,11 @@ module Sidekiq
     logger.warn(ex.backtrace.join("\n")) unless ex.backtrace.nil?
   end
 
+  # DEFAULT_ERROR_HANDLER is a constant that allows the default error handler to
+  # be referenced. It must be defined here, after the default_error_handler
+  # method is defined.
+  DEFAULT_ERROR_HANDLER = method(:default_error_handler)
+
   @config = DEFAULTS.dup
   def self.options
     logger.warn "`config.options[:key] = value` is deprecated, use `config[:key] = value`: #{caller(1..2)}"


### PR DESCRIPTION
This will allow the default error handler to be easily removed if needed via `error_handlers.delete(DEFAULT_ERROR_HANDLER)` without having to depend on an internal implementation detail

I'm not sure where you might want this constant to be defined as it has to be after the method `self.default_error_handler` is defined.  So I thought right after the method might be okay or maybe at the end of the module?

Closes: https://github.com/mperham/sidekiq/issues/5391