### PR TITLE
Sort processes in UI

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -153,6 +153,8 @@ module Sidekiq
     # '2.1.1.1' < '192.168.0.2' < '192.168.0.10'
     def sorted_processes
       @sorted_processes ||= begin
+        return processes unless processes.all? { |p| p['hostname'].present? }
+
         split_characters = /[\._-]/
 
         padding = processes.flat_map { |p| p['hostname'].split(split_characters) }.map(&:size).max

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -148,6 +148,17 @@ module Sidekiq
       @processes ||= Sidekiq::ProcessSet.new
     end
 
+    # Sorts processes by hostname following the natural sort order so that
+    # 'worker.1' < 'worker.2' < 'worker.10' < 'worker.20'
+    def sorted_processes
+      @sorted_processes ||= processes.to_a.sort_by do |process|
+        words = process['hostname'].split('.')
+        padding = words.map(&:size).max
+
+        words.map { |word| word.rjust(padding, '0') }
+      end
+    end
+
     def stats
       @stats ||= Sidekiq::Stats.new
     end

--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -153,7 +153,7 @@ module Sidekiq
     # '2.1.1.1' < '192.168.0.2' < '192.168.0.10'
     def sorted_processes
       @sorted_processes ||= begin
-        return processes unless processes.all? { |p| p['hostname'].present? }
+        return processes unless processes.all? { |p| p['hostname'] }
 
         split_characters = /[\._-]/
 

--- a/test/test_web_helpers.rb
+++ b/test/test_web_helpers.rb
@@ -100,14 +100,14 @@ describe "Web helpers" do
   end
 
   it "tests displaying of illegal args" do
-    o = Helpers.new
-    s = o.display_args([1, 2, 3])
+    obj = Helpers.new
+    s = obj.display_args([1, 2, 3])
     assert_equal "1, 2, 3", s
-    s = o.display_args(["<html>", 12])
+    s = obj.display_args(["<html>", 12])
     assert_equal "&quot;&lt;html&gt;&quot;, 12", s
-    s = o.display_args("<html>")
+    s = obj.display_args("<html>")
     assert_equal "Invalid job payload, args must be an Array, not String", s
-    s = o.display_args(nil)
+    s = obj.display_args(nil)
     assert_equal "Invalid job payload, args is nil", s
   end
 

--- a/test/test_web_helpers.rb
+++ b/test/test_web_helpers.rb
@@ -127,7 +127,7 @@ describe "Web helpers" do
   end
 
   it "sorts processes using the natural sort order" do
-    ['worker.10.2', 'worker.2', 'busybee', 'worker.23', 'worker.10.1', 'worker.1'].each do |hostname|
+    ['a.10.2', 'a.2', 'busybee-10_1', 'a.23', 'a.10.1', 'a.1', '192.168.0.10', '192.168.0.2', '2.1.1.1', 'busybee-2_34'].each do |hostname|
       pdata = { "hostname" => hostname, "pid" => '123', "started_at" => Time.now.to_i }
       key = "#{hostname}:123"
 
@@ -140,6 +140,6 @@ describe "Web helpers" do
     obj = Helpers.new
 
     assert obj.sorted_processes.all? { |process| assert_instance_of Sidekiq::Process, process }
-    assert_equal ['busybee', 'worker.1', 'worker.2', 'worker.10.1', 'worker.10.2', 'worker.23'], obj.sorted_processes.map { |process| process['hostname'] }
+    assert_equal ['2.1.1.1', '192.168.0.2', '192.168.0.10', 'a.1', 'a.2', 'a.10.1', 'a.10.2', 'a.23', 'busybee-2_34', 'busybee-10_1'], obj.sorted_processes.map { |process| process['hostname'] }
   end
 end

--- a/test/test_web_helpers.rb
+++ b/test/test_web_helpers.rb
@@ -4,6 +4,10 @@ require_relative "helper"
 require "sidekiq/web"
 
 describe "Web helpers" do
+  before do
+    Sidekiq.redis { |c| c.flushdb }
+  end
+
   class Helpers
     include Sidekiq::WebHelpers
 

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -54,7 +54,7 @@
       <th>&nbsp;</th>
     </thead>
     <% lead = processes.leader %>
-    <% processes.each do |process| %>
+    <% sorted_processes.each do |process| %>
       <tr>
         <td class="box">
           <%= "#{process['hostname']}:#{process['pid']}" %>


### PR DESCRIPTION
Hi @mperham and thanks for this essential tool!

I noticed that the UI sorts processes by comparing hostnames as strings and, because Heroku just adds a number after the process name (`worker.1`, `worker.2`…), it results in processes named like `worker.10` ranking above `worker.1`:

<img width="1033" alt="Screen Shot 2022-06-20 at 4 34 47 PM" src="https://user-images.githubusercontent.com/154600/174625204-6f1e675f-c2a7-4034-9f62-ce7b1ce2107b.png">

This PR tries to address it without adding dependencies or too much unmaintainable cruft, so I thought a helper would contain this logic toward the frontend code.

The new helper `sorted_processes` sorts processes by hostname following the **natural sort order** so that

```rb
'worker.1' < 'worker.2' < 'worker.10' < 'worker.20'
'2.1.1.1' < '192.168.0.2' < '192.168.0.10'
```

Another approach would be to add or modify a `<=>` method in the `ProcessSet` class, whichever is preferable.

What do you think?