### PR TITLE
Allow hiding web actions

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -81,6 +81,7 @@ module Sidekiq
 
     get "/queues" do
       @queues = Sidekiq::Queue.all
+      @should_hide_delete_queue_action = Sidekiq.options[:should_hide_web_action]?.include?("delete_queue")
 
       erb(:queues)
     end

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -21,7 +21,9 @@
         <td class="delete-confirm">
           <form action="<%=root_path %>queues/<%= CGI.escape(queue.name) %>" method="post">
             <%= csrf_tag %>
-            <input class="btn btn-danger" type="submit" name="delete" title="This will delete all jobs within the queue, it will reappear if you push more jobs to it in the future." value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteQueue', :queue => h(queue.name)) %>" />
+            <% unless @should_hide_delete_queue_action %>
+              <input class="btn btn-danger" type="submit" name="delete" title="This will delete all jobs within the queue, it will reappear if you push more jobs to it in the future." value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteQueue', :queue => h(queue.name)) %>" />
+            <% end %>
 
             <% if Sidekiq.pro? %>
               <% if queue.paused? %>


### PR DESCRIPTION
Default
![image](https://user-images.githubusercontent.com/67226689/177028818-1a8ae022-f99e-45f6-9ce4-767c73be0cc4.png)

Adding 
`Sidekiq.options[:should_hide_web_action]=["delete_queue"]` to the user's application level, will prevent the Delete action where needed.
This is most useful where we need local env with the Delete queue ability, but we want to prevent this from happening in production level.
![image](https://user-images.githubusercontent.com/67226689/177031728-3f7daf29-906b-4adc-8947-829f6e2716e4.png)
