### PR TITLE
Allow to kill job if the exception is raised

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,19 @@
 
 [Sidekiq Changes](https://github.com/mperham/sidekiq/blob/main/Changes.md) | [Sidekiq Pro Changes](https://github.com/mperham/sidekiq/blob/main/Pro-Changes.md) | [Sidekiq Enterprise Changes](https://github.com/mperham/sidekiq/blob/main/Ent-Changes.md)
 
+
+- Allow to kill job if the exception is raised. The job will be moved to the dead job queue and
+  death handlers will be run if any. This is useful when the subject of the job, like an Active Record,
+  is no longer available, and the job is thus no longer relevant. [#5423, fatkodima]
+```ruby
+sidekiq_retry_in do |count, ex|
+  case ex
+  when SpecialException
+    :kill
+  end
+end
+```
+
 6.5.1
 ----------
 


### PR DESCRIPTION
Fixes #5406.

`discard` is used in rails - it means the job will be just like finished/succeeded - https://github.com/rails/rails/blob/81d6012f4ff24d071eb6831c0e9a310e779e98b4/activejob/lib/active_job/exceptions.rb#L94-L101

`stop` - sounds like it will be just stopped and resumed(?) later
`kill` - sounds the most appropriate to me, because the job is moved to dead set (basically it needs to be killed to become dead 😄)

cc @netwire88