### PR TITLE
Enable `sidekiq_retry_in` to signal :kill or :discard dynamically

### DIFF
--- a/test/test_processor.rb
+++ b/test/test_processor.rb
@@ -278,7 +278,7 @@ describe Sidekiq::Processor do
           assert_equal "boom", msg["args"].first
         }
 
-        @processor.instance_variable_get(:@retrier).stub(:attempt_retry, retry_stub) do
+        @processor.instance_variable_get(:@retrier).stub(:process_retry, retry_stub) do
           msg = Sidekiq.dump_json(job_data)
           begin
             @processor.process(work(msg))

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -269,6 +269,10 @@ describe Sidekiq::JobRetry do
 
         sidekiq_retry_in do |count, exception|
           case exception
+          when RuntimeError
+            :kill
+          when Interrupt
+            :discard
           when SpecialError
             nil
           when ArgumentError
@@ -288,32 +292,67 @@ describe Sidekiq::JobRetry do
       end
 
       it "retries with a default delay" do
-        refute_equal 4, handler.__send__(:delay_for, worker, 2, StandardError.new)
+        strat, count = handler.__send__(:delay_for, worker, 2, StandardError.new)
+        assert_equal :default, strat
+        refute_equal 4, count 
       end
 
       it "retries with a custom delay and exception 1" do
-        assert_includes 4..35, handler.__send__(:delay_for, CustomWorkerWithException, 2, ArgumentError.new)
+        strat, count = handler.__send__(:delay_for, CustomWorkerWithException, 2, ArgumentError.new)
+        assert_equal :default, strat
+        assert_includes 4..35, count
+      end
+
+      it "supports discard" do
+        strat, count = handler.__send__(:delay_for, CustomWorkerWithException, 2, Interrupt.new)
+        assert_equal :discard, strat
+        assert_nil count
+      end
+
+      it "supports kill" do
+        strat, count = handler.__send__(:delay_for, CustomWorkerWithException, 2, RuntimeError.new)
+        assert_equal :kill, strat
+        assert_nil count
       end
 
       it "retries with a custom delay and exception 2" do
-        assert_includes 4..35, handler.__send__(:delay_for, CustomWorkerWithException, 2, StandardError.new)
+        strat, count = handler.__send__(:delay_for, CustomWorkerWithException, 2, StandardError.new)
+        assert_equal :default, strat
+        assert_includes 4..35, count
       end
 
       it "retries with a default delay and exception in case of configured with nil" do
-        refute_equal 8, handler.__send__(:delay_for, CustomWorkerWithException, 2, SpecialError.new)
-        refute_equal 4, handler.__send__(:delay_for, CustomWorkerWithException, 2, SpecialError.new)
+        strat, count = handler.__send__(:delay_for, CustomWorkerWithException, 2, SpecialError.new)
+        assert_equal :default, strat
+        refute_equal 8, count
+        refute_equal 4, count
       end
 
       it "retries with a custom delay without exception" do
-        assert_includes 4..35, handler.__send__(:delay_for, CustomWorkerWithoutException, 2, StandardError.new)
+        strat, count = handler.__send__(:delay_for, CustomWorkerWithoutException, 2, StandardError.new)
+        assert_equal :default, strat
+        assert_includes 4..35, count
       end
 
       it "falls back to the default retry on exception" do
         output = capture_logging do
-          refute_equal 4, handler.__send__(:delay_for, ErrorWorker, 2, StandardError.new)
+          strat, count = handler.__send__(:delay_for, ErrorWorker, 2, StandardError.new)
+          assert_equal :default, strat
+          refute_equal 4, count
         end
         assert_match(/Failure scheduling retry using the defined `sidekiq_retry_in`/,
           output, "Log entry missing for sidekiq_retry_in")
+      end
+
+      it "kills when configured on special exceptions" do
+        ds = Sidekiq::DeadSet.new
+        assert_equal 0, ds.size
+        assert_raises Sidekiq::JobRetry::Skip do
+          handler.local(CustomWorkerWithException, jobstr({"class" => "CustomWorkerWithException"}), "default") do
+            raise "oops"
+          end
+        end
+        assert_equal 1, ds.size
       end
     end
 


### PR DESCRIPTION
Allow `sidekiq_retry_in` to return either an Integer of seconds OR :kill OR :discard. The latter two symbols tell Sidekiq to send it directly to the morgue or throw the job away. Any other returned value will result in the default retry processing.

Fixes #5406