### PR TITLE
Make ProcessSet cleaning flag injectable.

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -876,9 +876,11 @@ module Sidekiq
   class ProcessSet
     include Enumerable
 
+    CLEAN_ON_INIT = true
+
     # :nodoc:
     # @api private
-    def initialize(clean_plz = true)
+    def initialize(clean_plz = CLEAN_ON_INIT)
       cleanup if clean_plz
     end
 


### PR DESCRIPTION
`clean_plz` doesn't seem to be used anywhere in the codebase. This provides a semi-private hook (similar to internal LINGER const) which can be injected if needed in special cases (described in support email).