### PR TITLE
Create a timeout that happens before cleanup

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -879,7 +879,7 @@ module Sidekiq
     # :nodoc:
     # @api private
     def initialize(clean_plz = true, lock_seconds = 60)
-      cleanup(lock_seconds) if clean_plz && unlocked(lock_seconds)
+      cleanup if clean_plz && unlocked(lock_seconds)
     end
 
     # :nodoc:

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -890,8 +890,8 @@ module Sidekiq
         while(conn.call("get","delay_cleanup") != "Wait to cleanup") {
           sleep 1
         }
+        conn.call("del","delay_cleanup")
       end
-      conn.call("del","delay_cleanup")
       true
     end
 

--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -878,21 +878,8 @@ module Sidekiq
 
     # :nodoc:
     # @api private
-    def initialize(clean_plz = true, lock_seconds = 60)
-      cleanup if clean_plz && unlocked(lock_seconds)
-    end
-
-    # :nodoc:
-    # @api private
-    def unlocked(lock_seconds)
-      Sidekiq.redis do |conn|
-        conn.set("delay_cleanup", "Wait to cleanup", :NX => true, :EX => lock_seconds.seconds )
-        while(conn.call("get","delay_cleanup") != "Wait to cleanup") {
-          sleep 1
-        }
-        conn.call("del","delay_cleanup")
-      end
-      true
+    def initialize(clean_plz = true)
+      cleanup if clean_plz
     end
 
     # Cleans up dead processes recorded in Redis.
@@ -900,6 +887,7 @@ module Sidekiq
     # :nodoc:
     # @api private
     def cleanup
+      return 0 unless Sidekiq.redis { |conn| conn.set("process_cleanup", "1", nx: true, ex: 60) }
       count = 0
       Sidekiq.redis do |conn|
         procs = conn.sscan_each("processes").to_a.sort

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -664,6 +664,7 @@ describe "API" do
       Sidekiq.redis do |conn|
         conn.sadd("processes", "bar:987")
         conn.sadd("processes", "bar:986")
+        conn.del("process_cleanup")
       end
 
       ps = Sidekiq::ProcessSet.new


### PR DESCRIPTION
I know that I did this wrong, but the redis commands for setting, getting and deleting the flag are correct (I think). I just don't think I implemented the best solution or understood the problem well enough.

Closes #5435