### PR TITLE
Sidekiq has two non-ASCII method names that break ObjectSpace.dump

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -49,8 +49,11 @@ module Sidekiq
     "used_memory_peak_human" => "9P"
   }
 
-  def self.❨╯°□°❩╯︵┻━┻
+  def self.table_flip
     puts "Calm down, yo."
+  end
+  class << self
+    alias_method :❨╯°□°❩╯︵┻━┻, :table_flip
   end
 
   # config.concurrency = 5

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -124,7 +124,7 @@ module Sidekiq
     end
     at_exit(&method(:flush_stats))
 
-    def ❤
+    def heart
       key = identity
       fails = procd = 0
 
@@ -191,6 +191,7 @@ module Sidekiq
         Processor::FAILURE.incr(fails)
       end
     end
+    alias ❤ heart
 
     # We run the heartbeat every five seconds.
     # Capture five samples of RTT, log a warning if each sample


### PR DESCRIPTION
Ruby heap dump has a bug in which it generates invalid JSON when a method name is non-ASCII: https://github.com/ruby/ruby/pull/6161 

It will be fixed in 3.2, and I'll mark it for backport, but it may not happen that soon.

It's certainly not Sidekiq's fault, but I think it may be worth working around it to avoid confusing people trying to debug memory issues.

I'd totally understand if you din't want to include such a workaround though.