### PR TITLE
Ensure retry_count does not drop below zero on retry via api

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -555,7 +555,7 @@ module Sidekiq
     def retry
       remove_job do |message|
         msg = Sidekiq.load_json(message)
-        msg["retry_count"] -= 1 if msg["retry_count"]
+        msg["retry_count"] -= 1 if msg["retry_count"].to_i > 0
         Sidekiq::Client.push(msg)
       end
     end


### PR DESCRIPTION
I was building a port of sidekiq in rust and stumbled upon an edge case where (best I can tell) jobs were being enqueued with a retry_count of -1. I don't have a reproducible, but from the issue report I received, this happened around the time people were manually retrying jobs in sidekiq-web. I'm wondering if it's worth it to backstop the `-= 1` with a zero check. Technically sidekiq will schedule it just fine with a retry_count of -1, but I'm not sure if it's intentional or not.

Btw, I was using usize for retry_count and changing to isize fixed it for me, and frankly it's probably the _more correct_ type.

I'm happy to add a more coerced test case to cover this but admittedly, I was unable to get a retry_count lower than zero just by clicking aggressively in the web interface. So this report is largely circumstantial but the code is a bit suspicious. 

