### PR TITLE
Remove Sidekiq Logger#add patch

### DIFF
--- a/lib/sidekiq/logger.rb
+++ b/lib/sidekiq/logger.rb
@@ -70,26 +70,6 @@ module Sidekiq
     ensure
       self.local_level = old_local_level
     end
-
-    # Redefined to check severity against #level, and thus the thread-local level, rather than +@level+.
-    # FIXME: Remove when the minimum Ruby version supports overriding Logger#level.
-    def add(severity, message = nil, progname = nil, &block)
-      severity ||= ::Logger::UNKNOWN
-      progname ||= @progname
-
-      return true if @logdev.nil? || severity < level
-
-      if message.nil?
-        if block
-          message = yield
-        else
-          message = progname
-          progname = @progname
-        end
-      end
-
-      @logdev.write format_message(format_severity(severity), Time.now, progname, message)
-    end
   end
 
   class Logger < ::Logger


### PR DESCRIPTION
ruby 2.7.0 now honors Logger#level overrides, and since sidekiq 7 will require ruby version >= 2.7, we can remove the patch.

Ref:
https://github.com/ruby/ruby/commit/eb18cb3e476db3bc44d489e090e1535237c4c6c9
https://github.com/rails/rails/pull/44247