### PR TITLE
Sync & Improve greek translations

### DIFF
--- a/web/locales/el.yml
+++ b/web/locales/el.yml
@@ -6,11 +6,12 @@ el: # <---- change this to your locale code
   Namespace: Namespace
   Realtime: Τρέχουσα Κατάσταση
   History: Ιστορικό
-  Busy: Απασχολημένο
-  Processed: Επεξεργάστηκε
-  Failed: Απέτυχε
-  Scheduled: Προγραματίστηκε
-  Retries: Προσπάθειες
+  Busy: Υπό επεξεργασία
+  Utilization: Σε χρήση
+  Processed: Επεξεργάστηκαν
+  Failed: Απέτυχαν
+  Scheduled: Προγραμματισμένα
+  Retries: Επαναλήψεις
   Enqueued: Μπήκαν στην στοίβα
   Worker: Εργάτης
   LivePoll: Τρέχουσα Κατάσταση
@@ -20,40 +21,42 @@ el: # <---- change this to your locale code
   Job: Εργασία
   Arguments: Ορίσματα
   Extras: Extras
-  Started: Ξεκίνησαν
+  Started: Ξεκίνησε
   ShowAll: Εμφάνιση Όλων
   CurrentMessagesInQueue: Τρέχουσες εργασίες <span class='title'>%{queue}</span>
   Delete: Διαγραφή
   AddToQueue: Προσθήκη στην στοίβα
-  AreYouSureDeleteJob: Θέλετε να διαγράψετε την εργασία αυτη;
-  AreYouSureDeleteQueue: Θέλετε να διαγράψετε την %{queue} στοίβα?
+  AreYouSureDeleteJob: Θέλετε να διαγράψετε αυτή την εργασία;
+  AreYouSureDeleteQueue: Θέλετε να διαγράψετε την στοίβα %{queue}; Αυτό θα διαγράψει όλες τις εργασίες εντός της στοίβας, θα εμφανιστεί ξανά εάν προωθήσετε περισσότερες εργασίες σε αυτήν στο μέλλον.
   Queues: Στοίβες
   Size: Μέγεθος
   Actions: Ενέργειες
-  NextRetry: Επόμενη προσπάθεια
-  RetryCount: Αριθμός προσπαθειών
-  RetryNow: Προσπάθησε τώρα
-  LastRetry: Τελευταία προσπάθεια
+  NextRetry: Επόμενη Προσπάθεια
+  RetryCount: Αριθμός Προσπαθειών
+  RetryNow: Επανάληψη Τώρα
+  # Kill: Kill
+  LastRetry: Τελευταία Προσπάθεια
   OriginallyFailed: Αρχικές Αποτυχίες
-  AreYouSure: Είστε σίγουρος?
-  DeleteAll: Διαγραφή όλων
+  AreYouSure: Είστε σίγουρος;
+  DeleteAll: Διαγραφή Όλων
   RetryAll: Επανάληψη Όλων
-  NoRetriesFound: Δεν βρέθηκαν προσπάθειες
+  # KillAll: Kill All
+  NoRetriesFound: Δεν βρέθηκαν εργασίες προς επαναλήψη
   Error: Σφάλμα
   ErrorClass: Κλάση σφάλματος
   ErrorMessage: Μήνυμα Σφάλματος
-  ErrorBacktrace: Σφάλμα Backtrace
+  ErrorBacktrace: Backtrace Σφάλματος
   GoBack: ← Πίσω
   NoScheduledFound: Δεν βρέθηκαν προγραμματισμένες εργασίες
   When: Πότε
   ScheduledJobs: Προγραμματισμένες Εργασίες
-  idle: αδρανής
-  active: ενεργή
+  idle: αδρανές
+  active: ενεργό
   Version: Έκδοση
   Connections: Συνδέσεις
   MemoryUsage: Χρήση Μνήμης
   PeakMemoryUsage: Μέγιστη Χρήση Μνήμης
-  Uptime: Διάρκεια Λειτουργείας (ημέρες)
+  Uptime: Ημέρες Λειτουργίας
   OneWeek: 1 εβδομάδα
   OneMonth: 1 μήνας
   ThreeMonths: 3 μήνες
@@ -62,7 +65,28 @@ el: # <---- change this to your locale code
   DeadJobs: Αδρανείς Εργασίες
   NoDeadJobsFound: Δεν βρέθηκαν αδρανείς εργασίες
   Dead: Αδρανείς
+  Process: Διεργασία
   Processes: Διεργασίες
+  Name: Όνομα
   Thread: Νήμα
   Threads: Νήματα
   Jobs: Εργασίες
+  Paused: Σε παύση
+  Stop: Διακοπή
+  Quiet: Σίγαση
+  StopAll: Διακοπή Όλων
+  QuietAll: Σίγαση Όλων
+  PollingInterval: Συχνότητα Ανανέωσης
+  Plugins: Πρόσθετα
+  NotYetEnqueued: Δεν προστέθηκε στην στοίβα ακόμη
+  CreatedAt: Δημιουργήθηκε στις
+  BackToApp: Πίσω στην Εφαρμογή
+  Latency: Καθυστέρηση
+  Pause: Παύση
+  Unpause: Κατάργηση Παύσης
+  Metrics: Μετρήσεις
+  NoDataFound: Δεν βρέθηκαν δεδομένα
+  ExecutionTime: Συνολικός Χρόνος Εκτέλεσης
+  AvgExecutionTime: Μέσος Χρόνος Εκτέλεσης
+  # Context: Context
+


### PR DESCRIPTION
Hi @mperham, thank you for this amazing gem!

I noticed that some Greek translations were missing, so I added them and improved some of the existing ones.

Did not translate keys: Kill, KillAll & Context and it is better to stay as is. I added them as comments, to be  in sync with en.yml and easier to update the file in the future.