### PR TITLE
Improve metrics chart colors for dark mode

### DIFF
--- a/web/assets/javascripts/metrics.js
+++ b/web/assets/javascripts/metrics.js
@@ -1,3 +1,8 @@
+if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  Chart.defaults.borderColor = "#333"
+  Chart.defaults.color = "#aaa"
+}
+
 class MetricsChart {
   constructor(id, options) {
     this.ctx = document.getElementById(id);


### PR DESCRIPTION
Just a couple small color tweaks for the metrics charts in dark mode.

Here's light mode:

<img width="1125" alt="CleanShot 2022-08-13 at 12 28 36@2x" src="https://user-images.githubusercontent.com/372/184502779-e1d0d729-1076-4341-94d8-14ea6fcd1996.png">


Dark mode before this change:

<img width="1149" alt="CleanShot 2022-08-13 at 12 27 59@2x" src="https://user-images.githubusercontent.com/372/184502785-7fcea0ae-e68b-47e7-8fc9-1bba0f9ef797.png">


Dark mode with this change:

<img width="1130" alt="CleanShot 2022-08-13 at 12 29 18@2x" src="https://user-images.githubusercontent.com/372/184502788-4f8580de-0c94-4dc5-bfeb-7ecaa824e5fd.png">

