### PR TITLE
Re-introduce JobLogger#job_hash_context

### DIFF
--- a/lib/sidekiq/job_logger.rb
+++ b/lib/sidekiq/job_logger.rb
@@ -24,14 +24,7 @@ module Sidekiq
     def prepare(job_hash, &block)
       # If we're using a wrapper class, like ActiveJob, use the "wrapped"
       # attribute to expose the underlying thing.
-      h = {
-        class: job_hash["display_class"] || job_hash["wrapped"] || job_hash["class"],
-        jid: job_hash["jid"]
-      }
-      h[:bid] = job_hash["bid"] if job_hash.has_key?("bid")
-      h[:tags] = job_hash["tags"] if job_hash.has_key?("tags")
-
-      Thread.current[:sidekiq_context] = h
+      Thread.current[:sidekiq_context] = job_hash_context(job_hash)
       level = job_hash["log_level"]
       if level
         @logger.log_at(level, &block)
@@ -46,6 +39,17 @@ module Sidekiq
 
     def elapsed(start)
       (::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - start).round(3)
+    end
+
+    def job_hash_context(job_hash)
+      h = {
+        class: job_hash["display_class"] || job_hash["wrapped"] || job_hash["class"],
+        jid: job_hash["jid"]
+      }
+      h[:bid] = job_hash["bid"] if job_hash.has_key?("bid")
+      h[:tags] = job_hash["tags"] if job_hash.has_key?("tags")
+
+      h
     end
   end
 end


### PR DESCRIPTION
What
----

Re-introduce `JobLogger#job_hash_context` that was [added in `5.0.1`](https://github.com/mperham/sidekiq/blob/main/Changes.md#501), then silently removed in `6.4.1`: https://github.com/mperham/sidekiq/commit/01686c5e25dd83ab89c6d85b36feec26e203e81b.

Why
----

It's much easier to add extra context to logs by overwriting `job_hash_context` than [`prepare`](https://github.com/mperham/sidekiq/blob/0b3751bf29088cb703d40787bb52f0cb6aa6e74f/lib/sidekiq/job_logger.rb#L24).

Example:

```ruby
Sidekiq.configure_server do |config|
  config[:job_logger] = Sidekiq::AddedContextLogger
end

class Sidekiq::AddedContextLogger < Sidekiq::JobLogger
  def job_hash_context(job_hash)
    context = super
    
    context[:organization] = job_hash["tenant"]

    context
  end
end
```