### PR TITLE
Toggle which metric is shown in the job metrics overview

### DIFF
--- a/web/assets/javascripts/metrics.js
+++ b/web/assets/javascripts/metrics.js
@@ -56,13 +56,29 @@ class BaseChart {
 
   update() {
     this.chart.options = this.chartOptions;
-    this.options.marks && this.addMarksToChart();
     this.chart.update();
   }
 
-  addMarksToChart() {
+  get chartOptions() {
+    return {
+      interaction: {
+        mode: "x",
+      },
+    };
+  }
+
+  get plugins() {
+    const plugins = {
+      legend: {
+        display: false,
+      },
+      annotation: {
+        annotations: {},
+      },
+    };
+
     this.options.marks.forEach(([bucket, label], i) => {
-      this.chart.options.plugins.annotation.annotations[`deploy-${i}`] = {
+      plugins.annotation.annotations[`deploy-${i}`] = {
         type: "line",
         xMin: bucket,
         xMax: bucket,
@@ -70,6 +86,8 @@ class BaseChart {
         borderWidth: 2,
       };
     });
+
+    return plugins;
   }
 }
 
@@ -183,6 +201,7 @@ class JobMetricsOverviewChart extends BaseChart {
 
   get chartOptions() {
     return {
+      ...super.chartOptions,
       aspectRatio: 4,
       scales: {
         y: {
@@ -193,13 +212,8 @@ class JobMetricsOverviewChart extends BaseChart {
           },
         },
       },
-      interaction: {
-        mode: "x",
-      },
       plugins: {
-        legend: {
-          display: false,
-        },
+        ...this.plugins,
         tooltip: {
           callbacks: {
             title: (items) => `${items[0].label} UTC`,
@@ -236,6 +250,7 @@ class HistTotalsChart extends BaseChart {
 
   get chartOptions() {
     return {
+      ...super.chartOptions,
       aspectRatio: 6,
       scales: {
         y: {
@@ -246,13 +261,8 @@ class HistTotalsChart extends BaseChart {
           },
         },
       },
-      interaction: {
-        mode: "x",
-      },
       plugins: {
-        legend: {
-          display: false,
-        },
+        ...this.plugins,
         tooltip: {
           callbacks: {
             label: (item) => `${item.parsed.y} jobs`,
@@ -312,6 +322,7 @@ class HistBubbleChart extends BaseChart {
 
   get chartOptions() {
     return {
+      ...super.chartOptions,
       aspectRatio: 3,
       scales: {
         x: {
@@ -325,13 +336,8 @@ class HistBubbleChart extends BaseChart {
           },
         },
       },
-      interaction: {
-        mode: "x",
-      },
       plugins: {
-        legend: {
-          display: false,
-        },
+        ...this.plugins,
         tooltip: {
           callbacks: {
             title: (items) => `${items[0].raw.x} UTC`,

--- a/web/assets/javascripts/metrics.js
+++ b/web/assets/javascripts/metrics.js
@@ -24,7 +24,7 @@ class Colors {
   }
 
   reserve(assignee) {
-    const color = this.available.shift() || this.fallback;
+    const color = this.assigments[assignee] || this.available.shift() || this.fallback;
     this.assigments[assignee] = color;
     return color;
   }
@@ -35,12 +35,6 @@ class Colors {
 
     if (color && color != this.fallback) {
       this.available.unshift(color);
-    }
-  }
-
-  returnAll() {
-    for (const assignee of Object.keys(this.assigments)) {
-      this.return(assignee);
     }
   }
 }
@@ -97,7 +91,6 @@ class JobMetricsOverviewChart extends BaseChart {
     for (const el of document.querySelectorAll("a[data-show-metric]")) {
       this.updateMetricSelector(el);
     }
-    this.colors.returnAll();
     this.chart.data.datasets = this.datasets;
     this.chart.update();
   }

--- a/web/assets/javascripts/metrics.js
+++ b/web/assets/javascripts/metrics.js
@@ -20,7 +20,7 @@ class Colors {
       "#8549ba",
       "#991b1b",
     ];
-    this.primary = this.available[0]
+    this.primary = this.available[0];
   }
 
   reserve(assignee) {
@@ -48,7 +48,6 @@ class Colors {
 class BaseChart {
   constructor(id, options) {
     this.ctx = document.getElementById(id);
-    this.metric = "s";
     this.visibleKls = options.visible;
     this.options = options;
     this.colors = new Colors();
@@ -76,6 +75,7 @@ class BaseChart {
 class JobMetricsOverviewChart extends BaseChart {
   constructor(id, options) {
     super(id, { ...options, chartType: "line" });
+    this.metric = this.options.initialMetric;
     this.swatches = [];
 
     this.addMarksToChart();
@@ -83,7 +83,7 @@ class JobMetricsOverviewChart extends BaseChart {
   }
 
   get currentSeries() {
-    return this.options.series[this.metric];
+    return this.options.series[this.metric || this.options.initialMetric];
   }
 
   get datasets() {
@@ -92,9 +92,11 @@ class JobMetricsOverviewChart extends BaseChart {
       .map(([kls, _]) => this.buildDataset(kls));
   }
 
-  selectMetric(e) {
-    e.preventDefault();
-    this.metric = e.target.getAttribute("data-show-metric");
+  selectMetric(metric) {
+    this.metric = metric;
+    for (const el of document.querySelectorAll("a[data-show-metric]")) {
+      this.updateMetricSelector(el);
+    }
     this.colors.returnAll();
     this.chart.data.datasets = this.datasets;
     this.chart.update();
@@ -102,8 +104,17 @@ class JobMetricsOverviewChart extends BaseChart {
     // TODO: sort the table by the new metric
   }
 
+  updateMetricSelector(el) {
+    const isCurrent = el.getAttribute("data-show-metric") == this.metric;
+    el.classList.toggle("current-chart", isCurrent);
+  }
+
   registerMetricSelector(el) {
-    el.addEventListener("click", this.selectMetric.bind(this));
+    this.updateMetricSelector(el);
+    el.addEventListener("click", (e) => {
+      e.preventDefault();
+      this.selectMetric(e.target.getAttribute("data-show-metric"));
+    });
   }
 
   registerSwatch(id) {

--- a/web/assets/javascripts/metrics.js
+++ b/web/assets/javascripts/metrics.js
@@ -23,14 +23,14 @@ class Colors {
     this.primary = this.available[0];
   }
 
-  reserve(assignee) {
+  checkOutFor(assignee) {
     const color =
       this.assigments[assignee] || this.available.shift() || this.fallback;
     this.assigments[assignee] = color;
     return color;
   }
 
-  return(assignee) {
+  checkInFor(assignee) {
     const color = this.assigments[assignee];
     delete this.assigments[assignee];
 
@@ -164,7 +164,7 @@ class JobMetricsOverviewChart extends BaseChart {
       this.chart.data.datasets.push(this.buildDataset(kls));
     } else {
       const i = this.chart.data.datasets.findIndex((ds) => ds.label == kls);
-      this.colors.return(kls);
+      this.colors.checkInFor(kls);
       this.chart.data.datasets.splice(i, 1);
     }
 
@@ -189,7 +189,7 @@ class JobMetricsOverviewChart extends BaseChart {
   }
 
   buildDataset(kls) {
-    const color = this.colors.reserve(kls);
+    const color = this.colors.checkOutFor(kls);
 
     return {
       label: kls,

--- a/web/assets/javascripts/metrics.js
+++ b/web/assets/javascripts/metrics.js
@@ -77,15 +77,17 @@ class BaseChart {
       },
     };
 
-    this.options.marks.forEach(([bucket, label], i) => {
-      plugins.annotation.annotations[`deploy-${i}`] = {
-        type: "line",
-        xMin: bucket,
-        xMax: bucket,
-        borderColor: "rgba(220, 38, 38, 0.4)",
-        borderWidth: 2,
-      };
-    });
+    if (this.options.marks) {
+      this.options.marks.forEach(([bucket, label], i) => {
+        plugins.annotation.annotations[`deploy-${i}`] = {
+          type: "line",
+          xMin: bucket,
+          xMax: bucket,
+          borderColor: "rgba(220, 38, 38, 0.4)",
+          borderWidth: 2,
+        };
+      });
+    }
 
     return plugins;
   }

--- a/web/assets/javascripts/metrics.js
+++ b/web/assets/javascripts/metrics.js
@@ -100,8 +100,6 @@ class JobMetricsOverviewChart extends BaseChart {
     this.colors.returnAll();
     this.chart.data.datasets = this.datasets;
     this.chart.update();
-
-    // TODO: sort the table by the new metric
   }
 
   updateMetricSelector(el) {
@@ -114,6 +112,10 @@ class JobMetricsOverviewChart extends BaseChart {
     el.addEventListener("click", (e) => {
       e.preventDefault();
       this.selectMetric(e.target.getAttribute("data-show-metric"));
+      this.sortTableBody(
+        e.target.closest("table").querySelector("tbody"),
+        [...e.target.closest("tr").children].indexOf(e.target.closest("th"))
+      );
     });
   }
 
@@ -142,6 +144,22 @@ class JobMetricsOverviewChart extends BaseChart {
 
     this.updateSwatch(kls);
     this.chart.update();
+  }
+
+  sortTableBody(tbody, colNo) {
+    const [...rows] = tbody.querySelectorAll("tr");
+
+    rows.sort((r1, r2) => {
+      const val1 = parseFloat(r1.children[colNo].innerText);
+      const val2 = parseFloat(r2.children[colNo].innerText);
+
+      // Sorting highest to lowest
+      return val2 - val1;
+    });
+
+    for (const row of rows) {
+      tbody.append(row);
+    }
   }
 
   buildDataset(kls) {

--- a/web/assets/javascripts/metrics.js
+++ b/web/assets/javascripts/metrics.js
@@ -20,6 +20,7 @@ class Colors {
       "#8549ba",
       "#991b1b",
     ];
+    this.primary = this.available[0]
   }
 
   reserve(assignee) {
@@ -53,7 +54,7 @@ class BaseChart {
     this.colors = new Colors();
 
     this.chart = new Chart(this.ctx, {
-      type: "line",
+      type: this.options.chartType,
       data: { labels: this.options.labels, datasets: this.datasets },
       options: this.chartOptions,
     });
@@ -190,7 +191,7 @@ class HistTotalsChart extends BaseChart {
     return [
       {
         data: this.options.series,
-        backgroundColor: this.colors[0],
+        backgroundColor: this.colors.primary,
         borderWidth: 0,
       },
     ];
@@ -267,8 +268,8 @@ class HistBubbleChart extends BaseChart {
     return [
       {
         data: data,
-        backgroundColor: "#537bc4",
-        borderColor: "#537bc4",
+        backgroundColor: this.colors.primary,
+        borderColor: this.colors.primary,
       },
     ];
   }

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -997,3 +997,11 @@ div.interval-slider input {
 canvas {
   margin: 20px 0 30px;
 }
+
+a.current-chart {
+  text-decoration: underline;
+}
+
+a.current-chart:after {
+  content: ' 📈';
+}

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -37,7 +37,7 @@
 
 <div class="table_container">
   <table class="table table-bordered table-striped table-hover">
-    <tbody>
+    <thead>
       <tr>
         <th><%= t('Name') %></th>
         <th>
@@ -58,6 +58,8 @@
           }
         </script>
       </tr>
+    </thead>
+    <tbody>
       <% if job_results.any? %>
         <% job_results.each_with_index do |(kls, jr), i| %>
           <tr>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -23,6 +23,18 @@
         f: job_results.map { |(kls, jr)| [kls, jr.dig("series", "f")] }.to_h,
         avg: job_results.map { |(kls, jr)| [kls, jr.series_avg("s") ] }.to_h,
       },
+      metricLabels: {
+        s: "Total execution time (sec)",
+        p: "Processed jobs",
+        f: "Failed jobs",
+        avg: "Avg execution time (sec)",
+      },
+      metricUnits: {
+        s: "seconds",
+        p: "jobs",
+        f: "jobs",
+        avg: "seconds",
+      },
       marks: @query_result.marks.map { |m| [m.bucket, m.label] },
       visible: visible_kls,
       labels: @query_result.buckets,

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -53,7 +53,7 @@
         </th>
         <script>
           for (const el of document.querySelectorAll("a[data-show-metric]")) {
-            metricsChart.registerMetricSelector(el)
+            jobMetricsChart.registerMetricSelector(el)
           }
         </script>
       </tr>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -28,6 +28,7 @@
       marks: @query_result.marks.map { |m| [m.bucket, m.label] },
       visible: visible_kls,
       labels: @query_result.buckets,
+      initialMetric: "s",
     }) %>
   )
 </script>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -21,9 +21,7 @@
         s: job_results.map { |(kls, jr)| [kls, jr.dig("series", "s")] }.to_h,
         p: job_results.map { |(kls, jr)| [kls, jr.dig("series", "p")] }.to_h,
         f: job_results.map { |(kls, jr)| [kls, jr.dig("series", "f")] }.to_h,
-        avg: job_results.map { |(kls, jr)|
-          [kls, jr.dig("series", "s").map.with_index { |(b, s), i| [b, s / jr.dig("series", "p", b)] }.to_h]
-        }.to_h,
+        avg: job_results.map { |(kls, jr)| [kls, jr.series_avg("s") ] }.to_h,
       },
       marks: @query_result.marks.map { |m| [m.bucket, m.label] },
       visible: visible_kls,

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -17,7 +17,14 @@
   window.metricsChart = new MetricsChart(
     "metrics-chart",
     <%= Sidekiq.dump_json({
-      series: job_results.map { |(kls, jr)| [kls, jr.dig("series", "s")] }.to_h,
+      series: {
+        s: job_results.map { |(kls, jr)| [kls, jr.dig("series", "s")] }.to_h,
+        p: job_results.map { |(kls, jr)| [kls, jr.dig("series", "p")] }.to_h,
+        f: job_results.map { |(kls, jr)| [kls, jr.dig("series", "f")] }.to_h,
+        avg: job_results.map { |(kls, jr)|
+          [kls, jr.dig("series", "s").map.with_index { |(b, s), i| [b, s / jr.dig("series", "p", b)] }.to_h]
+        }.to_h,
+      },
       marks: @query_result.marks.map { |m| [m.bucket, m.label] },
       visible: visible_kls,
       labels: @query_result.buckets,
@@ -32,10 +39,23 @@
     <tbody>
       <tr>
         <th><%= t('Name') %></th>
-        <th><%= t('Processed') %></th>
-        <th><%= t('Failed') %></th>
-        <th><%= t('ExecutionTime') %></th>
-        <th><%= t('AvgExecutionTime') %></th>
+        <th>
+          <a href="#" data-show-metric="p"><%= t('Processed') %></a>
+        </th>
+        <th>
+          <a href="#" data-show-metric="f"><%= t('Failed') %></a>
+        </th>
+        <th>
+          <a href="#" data-show-metric="s"><%= t('ExecutionTime') %></a>
+        </th>
+        <th>
+          <a href="#" data-show-metric="avg"><%= t('AvgExecutionTime') %></a>
+        </th>
+        <script>
+          for (const el of document.querySelectorAll("a[data-show-metric]")) {
+            metricsChart.registerMetricSelector(el)
+          }
+        </script>
       </tr>
       <% if job_results.any? %>
         <% job_results.each_with_index do |(kls, jr), i| %>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -2,7 +2,7 @@
 <script type="text/javascript" src="<%= root_path %>javascripts/chartjs-plugin-annotation.min.js"></script>
 <script type="text/javascript" src="<%= root_path %>javascripts/metrics.js"></script>
 
-<h2>Total execution time</h2>
+<h2>Metrics</h2>
 
 <%
   table_limit = 20


### PR DESCRIPTION
This PR wires up the column headers so users can choose which metric to view in the charts. Clicking a column header will also sort the table (descending) based on the selected metric.

https://user-images.githubusercontent.com/372/185694543-7a82ffe3-5945-4134-8a16-fabfbc723203.mp4

Dark mode:

<img width="962" alt="CleanShot 2022-08-19 at 15 37 31@2x" src="https://user-images.githubusercontent.com/372/185694625-2825d0b4-1ca8-46b9-88c5-28cf3598c03e.png">

