### PR TITLE
Redis 5.0.0.beta4 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.5", "2.6", "2.7", "3.0", "3.1"]
+        redis-rb: ["< 5", "edge"]
     services:
       redis:
         image: redis
@@ -28,7 +29,8 @@ jobs:
           --health-retries 5
         ports:
           - 6379:6379
-
+    env:
+      REDIS_GEM: "${{ matrix.redis-rb }}"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,11 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake"
-gem "redis"
+if ENV["REDIS_GEM"] == "edge"
+  gem "redis", github: "redis/redis-rb"
+else
+  gem "redis", ENV.fetch("REDIS_GEM", "< 5")
+end
 gem "redis-namespace"
 gem "redis-client"
 gem "rails", "~> 6.0"

--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -46,8 +46,6 @@ module Sidekiq
           opts.delete(:network_timeout)
         end
 
-        opts[:driver] ||= Redis::Connection.drivers.last || "ruby"
-
         # Issue #3303, redis-rb will silently retry an operation.
         # This can lead to duplicate jobs if Sidekiq::Client's LPUSH
         # is performed twice but I believe this is much, much rarer

--- a/test/test_redis_connection.rb
+++ b/test/test_redis_connection.rb
@@ -113,7 +113,7 @@ describe Sidekiq::RedisConnection do
       pool = Sidekiq::RedisConnection.create(id: nil)
       assert_equal client_class, pool.checkout.class
       client = client_for(pool.checkout)
-      if self.class.redis_client?
+      if self.class.redis_client? || ::Redis::VERSION >= "5"
         assert_nil client.id
       else
         assert_equal "redis://localhost:6379/15", client.id
@@ -132,7 +132,7 @@ describe Sidekiq::RedisConnection do
         pool = Sidekiq::RedisConnection.create
         redis = pool.checkout
 
-        if self.class.redis_client?
+        if self.class.redis_client? || ::Redis::VERSION >= "5"
           assert_equal 1.0, client_for(redis).read_timeout
         else
           assert_equal 5, client_for(redis).read_timeout
@@ -209,7 +209,7 @@ describe Sidekiq::RedisConnection do
 
           assert_equal RedisClient::RubyConnection, config.driver
         end
-      else
+      elsif Redis::VERSION < "5"
         it "uses redis' ruby driver" do
           pool = Sidekiq::RedisConnection.create
           redis = pool.checkout


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/1135

All but one changes are purely test things.

The only actual change is:

```ruby
opts[:driver] ||= Redis::Connection.drivers.last || "ruby"
```

Which is unclear to me why it's even there since it has been the redis-rb default behavior for over a decade:
https://github.com/redis/redis-rb/blame/4.x/lib/redis/client.rb#L511