### PR TITLE
Get max retry job count from job class

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -138,7 +138,12 @@ module Sidekiq
     # instantiate the job instance.  All access must be guarded and
     # best effort.
     def process_retry(jobinst, msg, queue, exception)
-      max_retry_attempts = retry_attempts_from(msg["retry"], @max_retries)
+      job_max_retries = if jobinst && jobinst.class.respond_to?(:get_sidekiq_options)
+                          retry_attempts_from(jobinst.class.get_sidekiq_options["retry"], @max_retries)
+                        else
+                          @max_retries
+                        end
+      max_retry_attempts = retry_attempts_from(msg["retry"], job_max_retries)
 
       msg["queue"] = (msg["retry_queue"] || queue)
 

--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -340,7 +340,7 @@ module Sidekiq
       # Legal options:
       #
       #   queue - use a named queue for this Worker, default 'default'
-      #   retry - enable the RetryJobs middleware for this Worker, *true* to use the default
+      #   retry - enable retries via JobRetry, *true* to use the default
       #      or *Integer* count
       #   backtrace - whether to save any error backtrace in the retry payload to display in web UI,
       #      can be true, false or an integer number of lines to save, default *false*

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -105,10 +105,10 @@ describe Sidekiq::JobRetry do
 
     it "allows a max_retries option in initializer" do
       max_retries = 7
+      @config[:max_retries] = max_retries
       1.upto(max_retries + 1) do |i|
         assert_raises RuntimeError do
           job = i > 1 ? jobstr("retry_count" => i - 2) : jobstr
-          @config[:max_retries] = max_retries
           handler.local(worker, job, "default") do
             raise "kerblammo!"
           end


### PR DESCRIPTION
The [job class has a `retry` option](https://github.com/rwstauner/sidekiq/blob/rwstauner/job-retry-count/lib/sidekiq/worker.rb#L343
) that can be an integer,
but the [default job options](https://github.com/rwstauner/sidekiq/blob/rwstauner/job-retry-count/lib/sidekiq.rb#L237,L239
) set `retry` to `true`
and the retry logic is currently only checking the message,
so when a worker specifies a `retry` integer, it is being ignored and the max (25) is used.