### PR TITLE
Enable to define at argument while pushing in bulk with #perform_bulk

### DIFF
--- a/lib/sidekiq/worker.rb
+++ b/lib/sidekiq/worker.rb
@@ -236,10 +236,12 @@ module Sidekiq
       end
       alias_method :perform_sync, :perform_inline
 
-      def perform_bulk(args, batch_size: 1_000)
+      def perform_bulk(args, batch_size: 1_000, at: nil)
         client = @klass.build_client
         result = args.each_slice(batch_size).flat_map do |slice|
-          client.push_bulk(@opts.merge("class" => @klass, "args" => slice))
+          items = @opts.merge("class" => @klass, "args" => slice)
+          items = items.merge("at" => at) if at.present?
+          client.push_bulk(items)
         end
 
         result.is_a?(Enumerator::Lazy) ? result.force : result

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -331,6 +331,13 @@ describe Sidekiq::Client do
         assert_equal 1_001, jids.size
       end
 
+      it "pushes a large set of jobs with specified 'at' argument" do
+        time = Time.new(2019, 1, 1)
+        jids = MyWorker.perform_bulk((1..1_001).to_a.map { |x| Array(x) }, at: time.to_i)
+        assert_equal 1_001, jids.size
+        assert jids.all? { |jid| Sidekiq::ScheduledSet.new.find_job(jid).at == time }
+      end
+
       it "handles no jobs" do
         jids = MyWorker.perform_bulk([])
         assert_equal 0, jids.size


### PR DESCRIPTION
Provide an iteration on `#perform_bulk` implementation to allow to use `at` argument as a param

Our current project end up using `Sidekiq::Client.push_bulk` directly as we need to be able to define `at`

```
  def self.perform_bulk_in(interval, items)
    at = interval.seconds.from_now.to_f
    Sidekiq::Client.push_bulk("class" => self, "args" => items, "at" => at)
  end
```