### PR TITLE
UI tweaks for metrics pages

### DIFF
--- a/myapp/config/initializers/sidekiq.rb
+++ b/myapp/config/initializers/sidekiq.rb
@@ -1,4 +1,3 @@
-Sidekiq.default_job_options = {queue: "something"}
 Sidekiq.configure_client do |config|
   config.redis = {size: 2}
 end

--- a/web/assets/javascripts/metrics.js
+++ b/web/assets/javascripts/metrics.js
@@ -153,7 +153,13 @@ class HistTotalsChart extends BaseChart {
         y: {
           beginAtZero: true,
           title: {
-            text: "Total jobs",
+            text: "Jobs",
+            display: true,
+          },
+        },
+        x: {
+          title: {
+            text: "Execution Time",
             display: true,
           },
         },

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -72,8 +72,10 @@ h1, h2, h3 {
   line-height: 45px;
 }
 
-.header-with-subheader h2 {
-  margin-top: -18px;
+.header-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .centered {

--- a/web/locales/el.yml
+++ b/web/locales/el.yml
@@ -82,6 +82,6 @@ el: # <---- change this to your locale code
   Unpause: Κατάργηση Παύσης
   Metrics: Μετρήσεις
   NoDataFound: Δεν βρέθηκαν δεδομένα
-  ExecutionTime: Συνολικός Χρόνος Εκτέλεσης
+  TotalExecutionTime: Συνολικός Χρόνος Εκτέλεσης
   AvgExecutionTime: Μέσος Χρόνος Εκτέλεσης
   # Context: Context

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -25,6 +25,7 @@ en:
   Extras: Extras
   Failed: Failed
   Failures: Failures
+  Failure: Failure
   GoBack: ← Back
   History: History
   Job: Job
@@ -72,6 +73,7 @@ en:
   Stop: Stop
   StopAll: Stop All
   StopPolling: Stop Polling
+  Success: Success
   Thread: Thread
   Threads: Threads
   ThreeMonths: 3 months

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -74,6 +74,7 @@ en:
   StopAll: Stop All
   StopPolling: Stop Polling
   Success: Success
+  Summary: Summary
   Thread: Thread
   Threads: Threads
   ThreeMonths: 3 months
@@ -88,7 +89,7 @@ en:
   idle: idle
   Metrics: Metrics
   NoDataFound: No data found
-  ExecutionTime: Total Execution Time
+  TotalExecutionTime: Total Execution Time
   AvgExecutionTime: Average Execution Time
   Context: Context
   Bucket: Bucket

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -2,7 +2,13 @@
 <script type="text/javascript" src="<%= root_path %>javascripts/chartjs-plugin-annotation.min.js"></script>
 <script type="text/javascript" src="<%= root_path %>javascripts/metrics.js"></script>
 
-<h2>Total execution time</h2>
+<div class="header-container">
+  <h1><%= t('Metrics') %></h1>
+
+  <div>
+    <a target="blank" href="https://github.com/mperham/sidekiq/wiki/Metrics"><span class="info-circle" title="Click to learn more about metrics">?</span></a>
+  </div>
+</div>
 
 <%
   table_limit = 20
@@ -25,8 +31,6 @@
   )
 </script>
 
-<h2>Most Time-Consuming Jobs</h2>
-
 <div class="table_container">
   <table class="table table-bordered table-striped table-hover">
     <tbody>
@@ -34,7 +38,7 @@
         <th><%= t('Name') %></th>
         <th><%= t('Success') %></th>
         <th><%= t('Failure') %></th>
-        <th><%= t('ExecutionTime') %></th>
+        <th><%= t('TotalExecutionTime') %></th>
         <th><%= t('AvgExecutionTime') %></th>
       </tr>
       <% if job_results.any? %>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -32,8 +32,8 @@
     <tbody>
       <tr>
         <th><%= t('Name') %></th>
-        <th><%= t('Processed') %></th>
-        <th><%= t('Failed') %></th>
+        <th><%= t('Success') %></th>
+        <th><%= t('Failure') %></th>
         <th><%= t('ExecutionTime') %></th>
         <th><%= t('AvgExecutionTime') %></th>
       </tr>
@@ -53,7 +53,7 @@
               </div>
               <script>jobMetricsChart.registerSwatch("<%= id %>")</script>
             </td>
-            <td><%= jr.dig("totals", "p") %></td>
+            <td><%= jr.dig("totals", "p") - jr.dig("totals", "f") %></td>
             <td><%= jr.dig("totals", "f") %></td>
             <td><%= jr.dig("totals", "s").round(2) %> seconds</td>
             <td><%= jr.total_avg("s").round(2) %> seconds</td>

--- a/web/views/metrics_for_job.erb
+++ b/web/views/metrics_for_job.erb
@@ -13,12 +13,15 @@
 %>
 
 <% if job_result.totals["s"] > 0 %>
-  <div class="header-with-subheader">
+  <div class="header-container">
     <h1>
       <a href="<%= root_path %>/metrics"><%= t(:metrics).to_s.titleize %></a> /
       <%= h @name %>
     </h1>
-    <h2>Histogram summary</h2>
+
+    <div>
+      <a target="blank" href="https://github.com/mperham/sidekiq/wiki/Metrics"><span class="info-circle" title="Click to learn more about metrics">?</span></a>
+    </div>
   </div>
 
   <canvas id="hist-totals-chart"></canvas>
@@ -32,8 +35,6 @@
       }) %>
     )
   </script>
-
-  <h2>Performance over time</h2>
 
   <canvas id="hist-bubble-chart"></canvas>
 
@@ -49,33 +50,6 @@
     )
   </script>
 
-  <div class="table_container">
-    <table class="table table-bordered table-striped table-hover">
-      <tbody>
-        <tr>
-          <th><%= t('Time') %></th>
-          <th><%= t('Processed') %></th>
-          <th><%= t('Failed') %></th>
-          <th><%= t('ExecutionTime') %></th>
-          <th><%= t('AvgExecutionTime') %></th>
-        </tr>
-        <% @query_result.buckets.reverse.each do |bucket| %>
-          <tr>
-            <td><%= bucket %></td>
-            <td><%= job_result.series.dig("p", bucket) %></td>
-            <td><%= job_result.series.dig("f", bucket) %></td>
-            <% if (total_sec = job_result.series.dig("s", bucket)) > 0 %>
-              <td><%= total_sec.round(2) %> seconds</td>
-              <td><%= job_result.series_avg("s")[bucket].round(2) %> seconds</td>
-            <% else %>
-              <td>&mdash;</td>
-              <td>&mdash;</td>
-            <% end %>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
   <p><small>Data from <%= @query_result.starts_at %> to <%= @query_result.ends_at %></small></p>
 <% else %>
   <h1>

--- a/web/views/metrics_for_job.erb
+++ b/web/views/metrics_for_job.erb
@@ -15,7 +15,7 @@
 <% if job_result.totals["s"] > 0 %>
   <div class="header-container">
     <h1>
-      <a href="<%= root_path %>/metrics"><%= t(:metrics).to_s.titleize %></a> /
+      <a href="<%= root_path %>metrics"><%= t(:metrics).to_s.titleize %></a> /
       <%= h @name %>
     </h1>
 


### PR DESCRIPTION
## Metrics overview page

Before:

<img width="1552" alt="CleanShot 2022-09-08 at 16 39 16@2x" src="https://user-images.githubusercontent.com/372/189221494-11a673d9-5712-4fcc-b642-dab4e4b48043.png">

After:

<img width="1552" alt="CleanShot 2022-09-08 at 16 38 31@2x" src="https://user-images.githubusercontent.com/372/189221499-d4c5153e-42f1-4687-a5ea-279e9a687f21.png">


## Metrics for job page

Before:

<img width="1552" alt="CleanShot 2022-09-08 at 16 39 22@2x" src="https://user-images.githubusercontent.com/372/189221537-804cd734-35e4-4c9e-99f3-54cab343e1c7.png">

After:

<img width="1552" alt="CleanShot 2022-09-08 at 16 38 39@2x" src="https://user-images.githubusercontent.com/372/189221555-93bf701a-7871-4079-9281-ee9a15787b6d.png">
