### PR TITLE
Fix flaky test

### DIFF
--- a/test/test_web.rb
+++ b/test/test_web.rb
@@ -141,12 +141,12 @@ describe Sidekiq::Web do
     end
 
     get "/queues/default?count=3" # direction is 'desc' by default
-    assert_match(/1005/, last_response.body)
-    refute_match(/1002/, last_response.body)
+    assert_match(/\b1005\b/, last_response.body)
+    refute_match(/\b1002\b/, last_response.body)
 
     get "/queues/default?count=3&direction=asc"
-    assert_match(/1000/, last_response.body)
-    refute_match(/1003/, last_response.body)
+    assert_match(/\b1000\b/, last_response.body)
+    refute_match(/\b1003\b/, last_response.body)
   end
 
   it "can delete a queue" do


### PR DESCRIPTION
Test was failing because "1003" showed up in a timestamp on the page:

<img width="1286" alt="185748627-3744d246-88ee-47b5-897d-18be748669ad" src="https://user-images.githubusercontent.com/372/189644537-a8efeba8-57b3-449f-bcde-0e89f27e1bfc.png">

