### PR TITLE
Bump redis-client to 0.8.1

### DIFF
--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
     "source_code_uri" => "https://github.com/mperham/sidekiq"
   }
 
-  gem.add_dependency "redis-client", ">= 0.8.0"
+  gem.add_dependency "redis-client", ">= 0.8.1"
   gem.add_dependency "connection_pool", ">= 2.3.0"
   gem.add_dependency "rack", ">= 2.2.4"
   gem.add_dependency "concurrent-ruby", "< 2"


### PR DESCRIPTION
That release contain a fairly important fix for people who abuse `Timeout.timeout` or `Thread.kill`

Ref: https://github.com/redis-rb/redis-client/commit/5f82254583c75b1f914590ae6a3e159ed07c0ac9