### PR TITLE
Internationalize copy on metrics charts

### DIFF
--- a/web/assets/javascripts/metrics.js
+++ b/web/assets/javascripts/metrics.js
@@ -70,7 +70,7 @@ class JobMetricsOverviewChart extends BaseChart {
           ...super.chartOptions.scales.y,
           beginAtZero: true,
           title: {
-            text: "Total Execution Time (sec)",
+            text: this.options.yLabel,
             display: true,
           },
         },
@@ -82,11 +82,14 @@ class JobMetricsOverviewChart extends BaseChart {
           callbacks: {
             title: (items) => `${items[0].label} UTC`,
             label: (item) =>
-              `${item.dataset.label}: ${item.parsed.y.toFixed(1)} seconds`,
+              `${item.dataset.label}: ${item.parsed.y.toFixed(1)} ` +
+              `${this.options.units}`,
             footer: (items) => {
               const bucket = items[0].label;
               const marks = this.options.marks.filter(([b, _]) => b == bucket);
-              return marks.map(([b, msg]) => `Deploy: ${msg}`);
+              return marks.map(
+                ([b, msg]) => `${this.options.markLabel}: ${msg}`
+              );
             },
           },
         },
@@ -121,14 +124,14 @@ class HistTotalsChart extends BaseChart {
           ...super.chartOptions.scales.y,
           beginAtZero: true,
           title: {
-            text: "Jobs",
+            text: this.options.yLabel,
             display: true,
           },
         },
         x: {
           ...super.chartOptions.scales.x,
           title: {
-            text: "Execution Time",
+            text: this.options.xLabel,
             display: true,
           },
         },
@@ -138,7 +141,7 @@ class HistTotalsChart extends BaseChart {
         tooltip: {
           ...super.chartOptions.plugins.tooltip,
           callbacks: {
-            label: (item) => `${item.parsed.y} jobs`,
+            label: (item) => `${item.parsed.y} ${this.options.units}`,
           },
         },
       },
@@ -161,7 +164,7 @@ class HistBubbleChart extends BaseChart {
         if (count > 0) {
           // histogram data is ordered fastest to slowest, but this.histIntervals is
           // slowest to fastest (so it displays correctly on the chart).
-          const index = this.options.histIntervals.length - 1 - histBucket
+          const index = this.options.histIntervals.length - 1 - histBucket;
 
           data.push({
             x: bucket,
@@ -205,7 +208,7 @@ class HistBubbleChart extends BaseChart {
         y: {
           ...super.chartOptions.scales.y,
           title: {
-            text: "Execution Time (sec)",
+            text: this.options.yLabel,
             display: true,
           },
         },
@@ -217,13 +220,13 @@ class HistBubbleChart extends BaseChart {
           callbacks: {
             title: (items) => `${items[0].raw.x} UTC`,
             label: (item) =>
-              `${item.parsed.y} seconds: ${item.raw.count} job${
-                item.raw.count == 1 ? "" : "s"
-              }`,
+              `${item.parsed.y} ${this.options.yUnits}: ${item.raw.count} ${this.options.zUnits}`,
             footer: (items) => {
               const bucket = items[0].raw.x;
               const marks = this.options.marks.filter(([b, _]) => b == bucket);
-              return marks.map(([b, msg]) => `Deploy: ${msg}`);
+              return marks.map(
+                ([b, msg]) => `${this.options.markLabel}: ${msg}`
+              );
             },
           },
         },

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -17,11 +17,13 @@ en:
   DeadJobs: Dead Jobs
   Delete: Delete
   DeleteAll: Delete All
+  Deploy: Deploy
   Enqueued: Enqueued
   Error: Error
   ErrorBacktrace: Error Backtrace
   ErrorClass: Error Class
   ErrorMessage: Error Message
+  ExecutionTime: Execution Time
   Extras: Extras
   Failed: Failed
   Failures: Failures
@@ -65,6 +67,7 @@ en:
   RetryNow: Retry Now
   Scheduled: Scheduled
   ScheduledJobs: Scheduled Jobs
+  Seconds: Seconds
   ShowAll: Show All
   SixMonths: 6 months
   Size: Size

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -29,6 +29,9 @@
         marks: @query_result.marks.map { |m| [m.bucket, m.label] },
         labels: @query_result.buckets,
         visibleKls: visible_kls,
+        yLabel: t('TotalExecutionTime'),
+        units: t('Seconds').downcase,
+        markLabel: t('Deploy'),
       }) %>
     )
   </script>

--- a/web/views/metrics_for_job.erb
+++ b/web/views/metrics_for_job.erb
@@ -33,6 +33,9 @@
       <%= Sidekiq.dump_json({
         series: hist_totals,
         labels: bucket_labels,
+        xLabel: t('ExecutionTime'),
+        yLabel: t('Jobs'),
+        units: t('Jobs').downcase,
       }) %>
     )
   </script>
@@ -47,6 +50,10 @@
         marks: @query_result.marks.map { |m| [m.bucket, m.label] },
         labels: @query_result.buckets,
         histIntervals: bucket_intervals,
+        yLabel: t('ExecutionTime'),
+        markLabel: t('Deploy'),
+        yUnits: t('Seconds').downcase,
+        zUnits: t('Jobs').downcase,
       }) %>
     )
   </script>


### PR DESCRIPTION
All of the highlighted words below are now coming from `en.yml` instead of hardcoded in the JS.

![CleanShot 2022-09-17 at 09 40 00@2x](https://user-images.githubusercontent.com/372/190860009-a07a10d7-24e3-4090-800e-20957a7dc6a4.png)

![CleanShot 2022-09-17 at 09 38 43@2x](https://user-images.githubusercontent.com/372/190860015-86d32967-0870-476e-9067-7f89593f1e54.png)

![CleanShot 2022-09-17 at 09 39 24@2x](https://user-images.githubusercontent.com/372/190860020-47ff07b3-6bf8-42fc-88c5-48dbb6d76b61.png)
