### PR TITLE
Add missing and improve existing translations for zh locales

### DIFF
--- a/web/locales/zh-cn.yml
+++ b/web/locales/zh-cn.yml
@@ -7,6 +7,7 @@ zh-cn: # <---- change this to your locale code
   Realtime: 实时
   History: 历史记录
   Busy: 执行中
+  Utilization: 利用率
   Processed: 已处理
   Failed: 已失败
   Scheduled: 已计划
@@ -17,15 +18,15 @@ zh-cn: # <---- change this to your locale code
   StopPolling: 停止轮询
   Queue: 队列
   Class: 类别
-  Job: 作业
+  Job: 任务
   Arguments: 参数
   Extras: 额外的
   Started: 已开始
   ShowAll: 显示全部
-  CurrentMessagesInQueue: 目前在<span class='title'>%{queue}</span>的作业
+  CurrentMessagesInQueue: 目前在<span class='title'>%{queue}</span>的任务
   Delete: 删除
   AddToQueue: 添加至队列
-  AreYouSureDeleteJob: 你确定要删除这个作业么？
+  AreYouSureDeleteJob: 你确定要删除这个任务么？
   AreYouSureDeleteQueue: 你确定要删除%{queue}这个队列？
   Queues: 队列
   Size: 容量
@@ -33,20 +34,22 @@ zh-cn: # <---- change this to your locale code
   NextRetry: 下次重试
   RetryCount: 重试次數
   RetryNow: 现在重试
+  Kill: 终止
   LastRetry: 最后一次重试
   OriginallyFailed: 原本已失败
   AreYouSure: 你确定？
-  DeleteAll: 删除全部
-  RetryAll: 重试全部
+  DeleteAll: 全部删除
+  RetryAll: 全部重试
+  KillAll: 全部终止
   NoRetriesFound: 沒有发现可重试
   Error: 错误
   ErrorClass: 错误类别
   ErrorMessage: 错误消息
-  ErrorBacktrace: 错误的回调追踪
+  ErrorBacktrace: 错误细节
   GoBack: ← 返回
-  NoScheduledFound: 沒有发现计划作业
+  NoScheduledFound: 沒有发现计划任务
   When: 当
-  ScheduledJobs: 计划作业
+  ScheduledJobs: 计划任务
   idle: 闲置
   active: 活动中
   Version: 版本
@@ -59,10 +62,32 @@ zh-cn: # <---- change this to your locale code
   ThreeMonths: 三个月
   SixMonths: 六个月
   Failures: 失败
-  DeadJobs: 已停滞作业
-  NoDeadJobsFound: 沒有发现任何已停滞的作业
+  DeadJobs: 已停滞任务
+  NoDeadJobsFound: 沒有发现任何已停滞的任务
   Dead: 已停滞
+  Process: 进程
   Processes: 处理中
+  Name: 名称
   Thread: 线程
   Threads: 线程
-  Jobs: 作业
+  Jobs: 任务
+  Paused: 已暫停
+  Stop: 強制暫停
+  Quiet: 暫停
+  StopAll: 全部強制暫停
+  QuietAll: 全部暫停
+  PollingInterval: 輪詢週期
+  Plugins: 套件
+  NotYetEnqueued: 尚未進入佇列
+  CreatedAt: 建立時間
+  BackToApp: 回首頁
+  Latency: 延時
+  Pause: 暫停
+  Unpause: 取消暂停
+  Metrics: 指标
+  NoDataFound: 无数据
+  TotalExecutionTime: 总执行时间
+  AvgExecutionTime: 平均执行时间
+  Context: 上下文
+  Bucket: 桶
+  NoJobMetricsFound: 无任务相关指标数据

--- a/web/locales/zh-tw.yml
+++ b/web/locales/zh-tw.yml
@@ -7,6 +7,7 @@ zh-tw: # <---- change this to your locale code
   Realtime: 即時
   History: 歷史資料
   Busy: 忙碌
+  Utilization: 使用率
   Processed: 已處理
   Failed: 已失敗
   Scheduled: 已排程
@@ -25,26 +26,28 @@ zh-tw: # <---- change this to your locale code
   CurrentMessagesInQueue: 目前在<span class='title'>%{queue}</span>的工作
   Delete: 刪除
   AddToQueue: 增加至佇列
-  AreYouSureDeleteJob: 你確定要刪除這個工作嗎？
-  AreYouSureDeleteQueue: 你確定要刪除%{queue}這個佇列？
+  AreYouSureDeleteJob: 確定要刪除這個工作嗎？
+  AreYouSureDeleteQueue: 確定要刪除%{queue}佇列？這會刪除佇列裡的所有工作，佇列將會在有新工作時重新出現。
   Queues: 佇列
   Size: 容量
   Actions: 動作
   NextRetry: 下次重試
   RetryCount: 重試次數
   RetryNow: 馬上重試
+  Kill: 取消
   LastRetry: 最後一次重試
   OriginallyFailed: 原本已失敗
   AreYouSure: 你確定？
-  DeleteAll: 刪除全部
-  RetryAll: 重試全部
-  NoRetriesFound: 沒有發現可重試
+  DeleteAll: 全部刪除
+  RetryAll: 全部重試
+  KillAll: 全部取消
+  NoRetriesFound: 找無可重試的工作
   Error: 錯誤
   ErrorClass: 錯誤類別
   ErrorMessage: 錯誤訊息
-  ErrorBacktrace: 錯誤的回調追踨
+  ErrorBacktrace: 詳細錯誤訊息
   GoBack: ← 返回
-  NoScheduledFound: 沒有發現已排程的工作
+  NoScheduledFound: 找無已排程的工作
   When: 當
   ScheduledJobs: 已排程的工作
   idle: 閒置
@@ -62,7 +65,29 @@ zh-tw: # <---- change this to your locale code
   DeadJobs: 停滯工作
   NoDeadJobsFound: 沒有發現任何停滯的工作
   Dead: 停滯
+  Process: 程序
   Processes: 處理中
+  Name: 名稱
   Thread: 執行緒
   Threads: 執行緒
   Jobs: 工作
+  Paused: 已暫停
+  Stop: 強制暫停
+  Quiet: 暫停
+  StopAll: 全部強制暫停
+  QuietAll: 全部暫停
+  PollingInterval: 輪詢週期
+  Plugins: 套件
+  NotYetEnqueued: 尚未進入佇列
+  CreatedAt: 建立時間
+  BackToApp: 回首頁
+  Latency: 延時
+  Pause: 暫停
+  Unpause: 取消暫停
+  Metrics: 計量
+  NoDataFound: 找無資料
+  TotalExecutionTime: 總執行時間
+  AvgExecutionTime: 平均執行時間
+  Context: 上下文
+  Bucket: 桶
+  NoJobMetricsFound: 找無工作相關計量資料


### PR DESCRIPTION
While working on #5531, I found there are some missing and weird translations. This PR improves existing `zh` translations. 

- [x] Quick sanity check that main translations ([en.yml](https://github.com/mperham/sidekiq/blob/d11c9c09f25a05db3d7bcf83a2e18d6b30007b51/web/locales/en.yml) has 93 entries)