### PR TITLE
Add ability to parse capsules from a config file

### DIFF
--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -280,6 +280,13 @@ module Sidekiq # :nodoc:
         cap.queues = opts[:queues]
         cap.concurrency = opts[:concurrency] || @config[:concurrency]
       end
+
+      opts[:capsules]&.each do |name, cap_config|
+        @config.capsule(name.to_s) do |cap|
+          cap.queues = cap_config[:queues]
+          cap.concurrency = cap_config[:concurrency]
+        end
+      end
     end
 
     def boot_application

--- a/test/cfg/config_capsules.yml
+++ b/test/cfg/config_capsules.yml
@@ -1,0 +1,17 @@
+---
+:verbose:      false
+:require:      ./test/fake_env.rb
+:concurrency:  50
+:queues:
+  - [<%="very_"%>often, 2]
+  - [seldom, 1]
+:capsules:
+  :non_concurrent:
+    :queues:
+      - non_concurrent
+    :concurrency: 1
+  :binary:
+    :queues:
+      - sirius
+      - sirius_b
+    :concurrency: 2

--- a/test/cli.rb
+++ b/test/cli.rb
@@ -22,6 +22,10 @@ describe Sidekiq::CLI do
     @cli.config.concurrency
   end
 
+  def capsules
+    @cli.config.capsules
+  end
+
   describe "#parse" do
     describe "options" do
       it "accepts -r" do
@@ -196,6 +200,15 @@ describe Sidekiq::CLI do
 
           assert_equal(expected_file, config.fetch(:__FILE__))
           assert_equal(expected_dir, config.fetch(:__dir__))
+        end
+
+        it "configures capsules defined in the config file" do
+          @cli.parse(%w[sidekiq -C ./test/cfg/config_capsules.yml])
+          assert_equal 1, capsules["non_concurrent"].concurrency
+          assert_equal %w[non_concurrent], capsules["non_concurrent"].queues
+
+          assert_equal 2, capsules["binary"].concurrency
+          assert_equal %w[sirius sirius_b], capsules["binary"].queues
         end
       end
 


### PR DESCRIPTION
I figured I would throw this together really quick, as it would be beneficial for cases like ours where we use multiple sidekiq config files and would like to configure a capsule for a single one of them. 