### PR TITLE
Use bundle exec to run example files

### DIFF
--- a/examples/por.rb
+++ b/examples/por.rb
@@ -1,9 +1,9 @@
 require "sidekiq"
 
 # Start up sidekiq via
-# ./bin/sidekiq -r ./examples/por.rb
+# bundle exec bin/sidekiq -r ./examples/por.rb
 # and then you can open up an IRB session like so:
-# irb -r ./examples/por.rb
+# bundle exec irb -r ./examples/por.rb
 # where you can then say
 # PlainOldRuby.perform_async "like a dog", 3
 #


### PR DESCRIPTION
When showing a junior how to explore how Sidekiq works, we noticed that if you’re running from the source directory, you’ll need to use bundle exec to get the gem on the load path.

Co authored by @musakurel.