### PR TITLE
Minor doc changes

### DIFF
--- a/docs/7.0-Upgrade.md
+++ b/docs/7.0-Upgrade.md
@@ -24,12 +24,12 @@ See the [Embedding](https://github.com/mperham/sidekiq/wiki/Embedding) wiki page
 
 Sidekiq 7.0 allows you to define "capsules" which execute jobs from queues.
 The `default` capsule spins up `5` Threads to fetch jobs from the `default` queue.
-You can change these values and/or define your own separate Capsules if you wish to throttle execution from a given queue.
+You can change these values and/or define your own separate capsules if you wish to throttle job execution from a given queue.
 For instance, here's how to define a single-threaded capsule for thread-unsafe jobs:
 
 ```ruby
 Sidekiq.configure_server do |config|
-  # edits the default capsule
+  # edit the default capsule
   config.queues = %w[critical default low]
   config.concurrency = 5
 
@@ -77,7 +77,7 @@ One option is to use Redis's numbered databases instead.
 - Rails 6.0+ is now supported
 
 Support is only guaranteed for the current and previous major versions.
-With the release of Sidekiq 7, Sidekiq 5.x is no longer supported.
+With the release of Sidekiq 7.0, Sidekiq 5.x is no longer supported.
 
 ## Upgrade
 


### PR DESCRIPTION
inspired by https://github.com/mperham/sidekiq/pull/5551

Minor doc changes

- `throttle execution` -> `throttle job execution`
- Capsules -> capsules (to stay consitent)
- edits -> edit
- `Sidekiq 7` -> `Sidekiq 7.0` (not sure about this)