### PR TITLE
Add pagination to "Busy" page

### DIFF
--- a/lib/sidekiq/paginator.rb
+++ b/lib/sidekiq/paginator.rb
@@ -43,5 +43,13 @@ module Sidekiq
         end
       end
     end
+
+    def page_items(items, pageidx = 1, page_size = 25)
+      current_page = pageidx.to_i < 1 ? 1 : pageidx.to_i
+      pageidx = current_page - 1
+      starting = pageidx * page_size
+      items = items.to_a
+      [current_page, items.size, items[starting, page_size]]
+    end
   end
 end

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -74,6 +74,9 @@ module Sidekiq
     end
 
     get "/busy" do
+      @count = (params["count"] || 100).to_i
+      (@current_page, @total_size, @workset) = page_items(workset, params["page"], @count)
+
       erb(:busy)
     end
 

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -96,6 +96,11 @@
   <div class="col-sm-7">
     <h3><%= t('Jobs') %></h3>
   </div>
+  <% if @workset.size > 0 && @total_size > @count %>
+    <div class="col-sm-4">
+      <%= erb :_paging, locals: { url: "#{root_path}busy" } %>
+    </div>
+  <% end %>
 </div>
 
 <div class="table_container">
@@ -109,7 +114,7 @@
       <th><%= t('Arguments') %></th>
       <th><%= t('Started') %></th>
     </thead>
-    <% workset.each do |process, thread, msg| %>
+    <% @workset.each do |process, thread, msg| %>
       <% job = Sidekiq::JobRecord.new(msg['payload']) %>
       <tr>
         <td><%= process %></td>


### PR DESCRIPTION
Closes #5555.

The pagination is slower (compared to `/retries` etc pages), because we need to get all of the entries to sort them (by `run_at`) before returning. But now this loads with no problems.

Seems like it is also problematic to add mass actions like "Kill"/"Delete", because we will need to inefficiently iterate over the large list `list` (compared to `/retries` page where we can efficiently remove from the `zset`).

You mentioned filtering in the issue. This is Pro/Ent feature, right? So I have not access to it. Better to be implemented by you or someone else who has access.