### PR TITLE
Remove deprecated worker reference.

### DIFF
--- a/bin/sidekiqload
+++ b/bin/sidekiqload
@@ -19,7 +19,7 @@ x = Sidekiq.configure_embed do |config|
 end
 
 class LoadWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
   sidekiq_options retry: 1
   sidekiq_retry_in do |x|
     1

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -8,6 +8,7 @@ require "sidekiq/logger"
 require "sidekiq/client"
 require "sidekiq/transaction_aware_client"
 require "sidekiq/job"
+require "sidekiq/worker_compatibility_alias"
 require "sidekiq/redis_client_adapter"
 
 require "json"

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -8,7 +8,6 @@ require "sidekiq/logger"
 require "sidekiq/client"
 require "sidekiq/transaction_aware_client"
 require "sidekiq/job"
-require "sidekiq/worker_compatibility_alias"
 require "sidekiq/redis_client_adapter"
 
 require "json"

--- a/lib/sidekiq/testing.rb
+++ b/lib/sidekiq/testing.rb
@@ -211,7 +211,7 @@ module Sidekiq
     #
     # You can also clear and drain all job types:
     #
-    #   Sidekiq::Worker.clear_all # or .drain_all
+    #   Sidekiq::Job.clear_all # or .drain_all
     #
     # This can be useful to make sure jobs don't linger between tests:
     #

--- a/lib/sidekiq/worker_compatibility_alias.rb
+++ b/lib/sidekiq/worker_compatibility_alias.rb
@@ -1,4 +1,4 @@
-require "sidekiq/job"
+# frozen_string_literal: true
 
 module Sidekiq
   # Sidekiq::Job is a new alias for Sidekiq::Worker as of Sidekiq 6.3.0.

--- a/myapp/app/sidekiq/exit_worker.rb
+++ b/myapp/app/sidekiq/exit_worker.rb
@@ -1,5 +1,5 @@
 class ExitWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   def perform
     logger.warn "Success"

--- a/myapp/app/sidekiq/hard_worker.rb
+++ b/myapp/app/sidekiq/hard_worker.rb
@@ -1,5 +1,5 @@
 class HardWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
   sidekiq_options backtrace: 5
 
   def perform(name, count, salt)

--- a/myapp/app/sidekiq/lazy_worker.rb
+++ b/myapp/app/sidekiq/lazy_worker.rb
@@ -1,5 +1,5 @@
 class LazyWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   def perform
   end

--- a/myapp/config/initializers/sidekiq.rb
+++ b/myapp/config/initializers/sidekiq.rb
@@ -17,14 +17,14 @@ Sidekiq.configure_server do |config|
 end
 
 class EmptyWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   def perform
   end
 end
 
 class TimedWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   def perform(start)
     now = Time.now.to_f

--- a/test/client.rb
+++ b/test/client.rb
@@ -502,7 +502,7 @@ describe Sidekiq::Client do
   describe "class attribute race conditions" do
     new_class = -> {
       Class.new do
-        class_eval("include Sidekiq::Worker", __FILE__, __LINE__)
+        class_eval("include Sidekiq::Job", __FILE__, __LINE__)
 
         define_method(:foo) { get_sidekiq_options }
       end

--- a/test/middleware.rb
+++ b/test/middleware.rb
@@ -20,7 +20,7 @@ end
 
 class CustomWorker
   $recorder = []
-  include Sidekiq::Worker
+  include Sidekiq::Job
   def perform(recorder)
     $recorder << ["work_performed"]
   end

--- a/test/processor.rb
+++ b/test/processor.rb
@@ -10,7 +10,7 @@ TestProcessorException = Class.new(StandardError)
 TEST_PROC_EXCEPTION = TestProcessorException.new("kerboom!")
 
 class MockWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
   def perform(args)
     raise TEST_PROC_EXCEPTION if args.to_s == "boom"
     args.pop if args.is_a? Array

--- a/test/retry.rb
+++ b/test/retry.rb
@@ -28,7 +28,7 @@ class SpecialError < StandardError
 end
 
 class CustomWorkerWithException
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   sidekiq_retry_in do |count, exception|
     case exception
@@ -47,7 +47,7 @@ class CustomWorkerWithException
 end
 
 class ErrorWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   sidekiq_retry_in do |count|
     count / 0

--- a/test/retry.rb
+++ b/test/retry.rb
@@ -17,7 +17,7 @@ class BadErrorMessage < StandardError
 end
 
 class CustomWorkerWithoutException
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   sidekiq_retry_in do |count|
     count * 2

--- a/test/testing_fake.rb
+++ b/test/testing_fake.rb
@@ -179,7 +179,7 @@ describe "Sidekiq::Testing.fake" do
   end
 
   it "clears jobs across all workers" do
-    Sidekiq::Worker.jobs.clear
+    Sidekiq::Job.jobs.clear
     FirstWorker.count = 0
     SecondWorker.count = 0
 
@@ -192,7 +192,7 @@ describe "Sidekiq::Testing.fake" do
     assert_equal 1, FirstWorker.jobs.size
     assert_equal 1, SecondWorker.jobs.size
 
-    Sidekiq::Worker.clear_all
+    Sidekiq::Job.clear_all
 
     assert_equal 0, FirstWorker.jobs.size
     assert_equal 0, SecondWorker.jobs.size
@@ -202,7 +202,7 @@ describe "Sidekiq::Testing.fake" do
   end
 
   it "drains jobs across all workers" do
-    Sidekiq::Worker.jobs.clear
+    Sidekiq::Job.jobs.clear
     FirstWorker.count = 0
     SecondWorker.count = 0
 
@@ -218,7 +218,7 @@ describe "Sidekiq::Testing.fake" do
     assert_equal 1, FirstWorker.jobs.size
     assert_equal 1, SecondWorker.jobs.size
 
-    Sidekiq::Worker.drain_all
+    Sidekiq::Job.drain_all
 
     assert_equal 0, FirstWorker.jobs.size
     assert_equal 0, SecondWorker.jobs.size
@@ -240,7 +240,7 @@ describe "Sidekiq::Testing.fake" do
   end
 
   it "drains jobs across all workers even when workers create new jobs" do
-    Sidekiq::Worker.jobs.clear
+    Sidekiq::Job.jobs.clear
     FirstWorker.count = 0
     SecondWorker.count = 0
 
@@ -253,7 +253,7 @@ describe "Sidekiq::Testing.fake" do
 
     assert_equal 1, ThirdWorker.jobs.size
 
-    Sidekiq::Worker.drain_all
+    Sidekiq::Job.drain_all
 
     assert_equal 0, ThirdWorker.jobs.size
 
@@ -262,7 +262,7 @@ describe "Sidekiq::Testing.fake" do
   end
 
   it "drains jobs of workers with symbolized queue names" do
-    Sidekiq::Worker.jobs.clear
+    Sidekiq::Job.jobs.clear
 
     AltQueueWorker.perform_async(5, 6)
     assert_equal 1, AltQueueWorker.jobs.size

--- a/test/testing_fake.rb
+++ b/test/testing_fake.rb
@@ -267,7 +267,7 @@ describe "Sidekiq::Testing.fake" do
     AltQueueWorker.perform_async(5, 6)
     assert_equal 1, AltQueueWorker.jobs.size
 
-    Sidekiq::Worker.drain_all
+    Sidekiq::Job.drain_all
     assert_equal 0, AltQueueWorker.jobs.size
   end
 

--- a/test/web.rb
+++ b/test/web.rb
@@ -5,7 +5,7 @@ require "sidekiq/web"
 require "rack/test"
 
 class WebWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   def perform(a, b)
     a + b


### PR DESCRIPTION
The worker naming was deprecated in sidekiq 6.3. 
In version 7, we can use directly Sidekiq:Job in tests.

Application that depend on Sidekiq::Worker can require "sidekiq/worker_compatibility_alias" in their  application.rb or sidekiq initalizer.