### PR TITLE
fix typo [ci skip]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,15 +3,14 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake"
-RAILS_VERSION = '~> 7.0.4'
-gem 'actionmailer', RAILS_VERSION
-gem 'actionpack', RAILS_VERSION
-gem 'activejob', RAILS_VERSION
-gem 'activerecord', RAILS_VERSION
-gem 'railties', RAILS_VERSION
+RAILS_VERSION = "~> 7.0.4"
+gem "actionmailer", RAILS_VERSION
+gem "actionpack", RAILS_VERSION
+gem "activejob", RAILS_VERSION
+gem "activerecord", RAILS_VERSION
+gem "railties", RAILS_VERSION
 gem "redis-client"
 # gem "debug"
-
 
 gem "sqlite3", platforms: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby

--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -80,7 +80,7 @@ module Sidekiq
   end
 
   # Creates a Sidekiq::Config instance that is more tuned for embedding
-  # within an arbitrary Ruby process. Noteably it reduces concurrency by
+  # within an arbitrary Ruby process. Notably it reduces concurrency by
   # default so there is less contention for CPU time with other threads.
   #
   #   inst = Sidekiq.configure_embed do |config|

--- a/myapp/Gemfile
+++ b/myapp/Gemfile
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.1.2'
+ruby "3.1.2"
 
-RAILS_VERSION = '~> 7.0.4'
-gem 'actionmailer', RAILS_VERSION
-gem 'actionpack', RAILS_VERSION
-gem 'activejob', RAILS_VERSION
-gem 'activerecord', RAILS_VERSION
-gem 'railties', RAILS_VERSION
+RAILS_VERSION = "~> 7.0.4"
+gem "actionmailer", RAILS_VERSION
+gem "actionpack", RAILS_VERSION
+gem "activejob", RAILS_VERSION
+gem "activerecord", RAILS_VERSION
+gem "railties", RAILS_VERSION
 
-gem 'puma', '~> 5.0'
-gem 'sidekiq', path: '..'
-gem 'sqlite3', '~> 1.4'
+gem "puma", "~> 5.0"
+gem "sidekiq", path: ".."
+gem "sqlite3", "~> 1.4"
 
-gem 'after_commit_everywhere'
+gem "after_commit_everywhere"

--- a/myapp/config/application.rb
+++ b/myapp/config/application.rb
@@ -1,16 +1,15 @@
 require_relative "boot"
 
 require "rails"
-%w(
+%w[
   active_record/railtie
   action_controller/railtie
   action_view/railtie
   action_mailer/railtie
   active_job/railtie
-).each do |railtie|
+].each do |railtie|
   require railtie
 end
-
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
-  just a small typo fix.
- usage of double quotes to match the rest of the code style.