### PR TITLE
Metrics: Refreshes chart and table every minute

### DIFF
--- a/web/views/_poll_link.erb
+++ b/web/views/_poll_link.erb
@@ -1,4 +1,4 @@
-<% if current_path != '' %>
-    <a class="live-poll-start live-poll btn btn-primary"><%= t('LivePoll') %></a>
-    <a class="live-poll-stop live-poll btn btn-primary active"><%= t('StopPolling') %></a>
+<% if ['', 'metrics'].exclude?(current_path) %>
+  <a class="live-poll-start live-poll btn btn-primary"><%= t('LivePoll') %></a>
+  <a class="live-poll-stop live-poll btn btn-primary active"><%= t('StopPolling') %></a>
 <% end %>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -11,35 +11,25 @@
   </div>
 </div>
 
-<%
-  table_limit = 20
-  chart_limit = 5
-  job_results = @query_result.job_results.sort_by { |(kls, jr)| jr.totals["s"] }.reverse.first(table_limit)
-  visible_kls = job_results.first(chart_limit).map(&:first)
-%>
 
-<% if job_results.any? %>
-  <canvas id="job-metrics-overview-chart"></canvas>
+<canvas id="job-metrics-overview-chart"></canvas>
 
-  <script>
-    window.jobMetricsChart = new JobMetricsOverviewChart(
-      document.getElementById("job-metrics-overview-chart"),
-      <%= Sidekiq.dump_json({
-        series: job_results.map { |(kls, jr)| [kls, jr.dig("series", "s")] }.to_h,
-        marks: @query_result.marks.map { |m| [m.bucket, m.label] },
-        labels: @query_result.buckets,
-        visibleKls: visible_kls,
-        yLabel: t('TotalExecutionTime'),
-        units: t('Seconds').downcase,
-        markLabel: t('Deploy'),
-      }) %>
-    )
-  </script>
-<% end %>
+<script>
+  window.jobMetricsChart = new JobMetricsOverviewChart(
+    "job-metrics-overview-chart",
+    "job-metrics-table-body",
+    {
+      markLabel: "<%= t('Deploy') %>",
+      units: "<%= t('Seconds').downcase %>",
+      yLabel: "<%= t('TotalExecutionTime') %>",
+      noDataFound: "<%= t('NoDataFound') %>",
+    }
+  )
+</script>
 
 <div class="table_container">
   <table class="table table-bordered table-striped table-hover">
-    <tbody>
+    <thead>
       <tr>
         <th><%= t('Name') %></th>
         <th><%= t('Success') %></th>
@@ -47,34 +37,13 @@
         <th><%= t('TotalExecutionTime') %></th>
         <th><%= t('AvgExecutionTime') %></th>
       </tr>
-      <% if job_results.any? %>
-        <% job_results.each_with_index do |(kls, jr), i| %>
-          <tr>
-            <td>
-              <div class="metrics-swatch-wrapper">
-                <% id = "metrics-swatch-#{kls}" %>
-                <input
-                  type="checkbox"
-                  id="<%= id %>"
-                  class="metrics-swatch"
-                  value="<%= kls %>"
-                  <%= visible_kls.include?(kls) ? 'checked' : '' %>
-                />
-                <code><a href="<%= root_path %>metrics/<%= kls %>"><%= kls %></a></code>
-              </div>
-              <script>jobMetricsChart.registerSwatch("<%= id %>")</script>
-            </td>
-            <td><%= jr.dig("totals", "p") - jr.dig("totals", "f") %></td>
-            <td><%= jr.dig("totals", "f") %></td>
-            <td><%= jr.dig("totals", "s").round(2) %> seconds</td>
-            <td><%= jr.total_avg("s").round(2) %> seconds</td>
-          </tr>
-        <% end %>
-      <% else %>
-          <tr><td colspan=5><%= t("NoDataFound") %></td></tr>
-      <% end %>
+    </thead>
+    <tbody id="job-metrics-table-body">
+      <tr><td colspan=5><%= t("Loading") %></td></tr>
     </tbody>
   </table>
 </div>
 
-<p><small>Data from <%= @query_result.starts_at %> to <%= @query_result.ends_at %></small></p>
+<p>
+  <small id="metrics-data-from"></small>
+</p>


### PR DESCRIPTION
- Related to issue #5505, only updating the index view and not
  the /metrics/:job view.
- It was hard to introduce a new paradigm of updating a html table in pure javascript,
  would probably be possible to do some other abstractions to make it easier to work with.
