### PR TITLE
Extend perform_bulk to accept custom options hash similar to push_bulk

### DIFF
--- a/lib/sidekiq/job.rb
+++ b/lib/sidekiq/job.rb
@@ -237,10 +237,10 @@ module Sidekiq
       end
       alias_method :perform_sync, :perform_inline
 
-      def perform_bulk(args, batch_size: 1_000)
+      def perform_bulk(args, batch_size: 1_000, custom_opts: {})
         client = @klass.build_client
         result = args.each_slice(batch_size).flat_map do |slice|
-          client.push_bulk(@opts.merge("class" => @klass, "args" => slice))
+          client.push_bulk(@opts.merge(custom_opts).merge("class" => @klass, "args" => slice))
         end
 
         result.is_a?(Enumerator::Lazy) ? result.force : result

--- a/test/job.rb
+++ b/test/job.rb
@@ -121,6 +121,21 @@ describe Sidekiq::Job do
       assert_equal 1_001, jids.size
     end
 
+    it "works with custom options on .perform_bulk" do
+      q = Sidekiq::Queue.new("bar")
+      assert_equal 0, q.size
+
+      set = MySetJob.set(queue: "bar")
+      args = (1..1_001).to_a.map { |x| Array(x) }
+      jids = set.perform_bulk(args, custom_opts: { "foo_bar" => 1})
+
+      assert_equal 1_001, q.size
+      assert_equal 1_001, jids.size
+
+      custom_options_value = q.all? {|j| JSON.parse(j.value).key?("foo_bar") }
+      assert_equal true, custom_options_value
+    end
+
     describe ".perform_bulk and lazy enumerators" do
       it "evaluates lazy enumerators" do
         q = Sidekiq::Queue.new("bar")


### PR DESCRIPTION
Some sidekiq plugins use `push_bulk` in sending batch jobs, along with some metadata to be passed along the job that can later be read from the Sidekiq server middleware. However, such a thing is not possible when with `perform_bulk`. It'd be really nice to support this where we can pass in the custom options/attributes and get the benefit of batched redis calls too with `batch_size`

Ex of passing custom options with `push_bulk`:

```ruby
 Sidekiq::Client.push_bulk('class' => YourWorker, 'args' => args, 'tenant_id' => 3)
```

We can do the same with perform_bulk now

```ruby
  set = MySetJob.set('queue' => 'bar')
  set.perform_bulk(args, custom_opts: { 'tenant_id' => 3})
```

Happy to open a tracking issue if thats helpful, let me know. Open to feedback and iterations 🙌🏾 