### PR TITLE
Fix natural sorting for processes

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -148,25 +148,15 @@ module Sidekiq
       @processes ||= Sidekiq::ProcessSet.new
     end
 
-    # Sorts processes by hostname following the natural sort order so that
-    # 'worker.1' < 'worker.2' < 'worker.10' < 'worker.20'
-    # '2.1.1.1' < '192.168.0.2' < '192.168.0.10'
+    # Sorts processes by hostname following the natural sort order
     def sorted_processes
       @sorted_processes ||= begin
         return processes unless processes.all? { |p| p["hostname"] }
 
-        split_characters = /[._-]+/
-
-        padding = processes.flat_map { |p| p["hostname"].split(split_characters) }.map(&:size).max
-
         processes.to_a.sort_by do |process|
-          process["hostname"].split(split_characters).map do |substring|
-            # Left-pad the substring with '0' if it starts with a number or 'a'
-            # otherwise, so that '25' < 192' < 'a' ('025' < '192' < 'aaa')
-            padding_char = substring[0].match?(/\d/) ? "0" : "a"
-
-            substring.rjust(padding, padding_char)
-          end
+          # Kudos to `shurikk` on StackOverflow
+          # https://stackoverflow.com/a/15170063/575547
+          process["hostname"].split(/(\d+)/).map { |a| /\d+/.match?(a) ? a.to_i : a }
         end
       end
     end

--- a/test/web_helpers.rb
+++ b/test/web_helpers.rb
@@ -2,7 +2,6 @@
 
 require_relative "helper"
 require "sidekiq/web"
-require "pry"
 
 class Helpers
   include Sidekiq::WebHelpers

--- a/test/web_helpers.rb
+++ b/test/web_helpers.rb
@@ -2,6 +2,7 @@
 
 require_relative "helper"
 require "sidekiq/web"
+require "pry"
 
 class Helpers
   include Sidekiq::WebHelpers
@@ -162,5 +163,22 @@ describe "Web helpers" do
 
     assert obj.sorted_processes.all? { |process| assert_instance_of Sidekiq::Process, process }
     assert_equal ["2.1.1.1", "192.168.0.2", "192.168.0.10", "a.1", "a.2", "a.10.1", "a.10.2", "a.23", "busybee-2__34", "busybee--10_1"], obj.sorted_processes.map { |process| process["hostname"] }
+  end
+
+  it "sorts processes with multiple dividers correctly" do
+    ["worker_critical.2", "worker_default.1", "worker_critical.1", "worker_default.2", "worker_critical.10"].each do |hostname|
+      pdata = {"hostname" => hostname, "pid" => "123", "started_at" => Time.now.to_i}
+      key = "#{hostname}:123"
+
+      Sidekiq.redis do |conn|
+        conn.sadd("processes", [key])
+        conn.hmset(key, "info", Sidekiq.dump_json(pdata), "busy", 0, "beat", Time.now.to_f)
+      end
+    end
+
+    obj = Helpers.new
+
+    assert obj.sorted_processes.all? { |process| assert_instance_of Sidekiq::Process, process }
+    assert_equal ["worker_critical.1", "worker_critical.2", "worker_critical.10", "worker_default.1", "worker_default.2"], obj.sorted_processes.map { |process| process["hostname"] }
   end
 end


### PR DESCRIPTION
The processes sorting was not correct for hostnames with `_` in it.
Ref: #5585 

This changes it so that all cases work.

Kudos to `shurikk` on Stackoverflow:
https://stackoverflow.com/a/15170063/575547