### PR TITLE
Change Rails log level to WARN in `before_setup` rather than `setup`

### DIFF
--- a/test/job_generator.rb
+++ b/test/job_generator.rb
@@ -10,9 +10,9 @@ class JobGeneratorTest < Rails::Generators::TestCase
   destination File.expand_path("../../tmp", __FILE__)
   setup :prepare_destination
 
-  setup do
-    # TODO what's the proper way to silence the generator output?
+  def before_setup
     Rails.logger.level = Logger::WARN
+    super
   end
 
   test "all files are properly created" do


### PR DESCRIPTION
The purpose of this PR is to suppress cluttering/undesired stdout log output like the following in tests:

```
2022-10-29T10:59:39.023Z pid=66755 tid=1hg3 INFO: ------------------------------------------------------------------
2022-10-29T10:59:39.024Z pid=66755 tid=1hg3 INFO: JobGeneratorTest: test_respects_rails_config_test_framework_option
2022-10-29T10:59:39.024Z pid=66755 tid=1hg3 INFO: ------------------------------------------------------------------
```

Assigning `Rails.logger.level = Logger::WARN` in the test `setup` block of the `JobGeneratorTest`, as we were doing before, is too late to suppress the undesired log output in tests; by then, some unwanted log output will already have been written to stdout.

`before_setup` runs early enough to suppress the undesired log output (since it is in `ActiveSupport::Testing::TaggedLogging#before_setup` (which is included into `ActiveSupport::TestCase` [here](https://github.com/rails/rails/blob/v7.0.4/activesupport/lib/active_support/test_case.rb#L125)) that the undesired log output is written at log level `info`, here https://github.com/rails/rails/blob/v7.0.4/activesupport/lib/active_support/testing/tagged_logging.rb#L14-L16 ).

Here's a link to documentation about `before_setup`: https://www.rubydoc.info/gems/minitest/5.16.3/Minitest%2FTest%2FLifecycleHooks:before_setup

It states:

> This hook is meant for libraries to extend minitest. It is not meant to be used by test developers.

In that sense, since we aren't trying to "extend minitest", we are using the `before_setup` method in an unintended way, but I think that it's fine. Our purpose is essentially to override/undo `ActiveSupport::TestCase`'s usage of the `before_setup` hook.

### Before (stdout cluttered by extra logging)

![2022-10-29-05-49-27-b2jp3](https://user-images.githubusercontent.com/8197963/198827731-c5621bbc-8a7b-4674-bc9f-9dfa0594c149.png)

### After (clean stdout test output)

![2022-10-29-05-49-55-s0kzt](https://user-images.githubusercontent.com/8197963/198827753-1966e542-3ac4-401a-8394-c25000cd982a.png)
