### PR TITLE
myapp: Removes activestorage config

### DIFF
--- a/myapp/config/environments/development.rb
+++ b/myapp/config/environments/development.rb
@@ -33,9 +33,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
-
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/myapp/config/environments/production.rb
+++ b/myapp/config/environments/production.rb
@@ -31,9 +31,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
-
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
   # config.action_cable.url = "wss://example.com/cable"

--- a/myapp/config/environments/test.rb
+++ b/myapp/config/environments/test.rb
@@ -33,9 +33,6 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Store uploaded files on the local file system in a temporary directory.
-  config.active_storage.service = :test
-
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.


### PR DESCRIPTION
The railtie for ActiveStorage is not included in the myapp/config/application.rb, so the configuration fails.