### PR TITLE
Adds a color override for alert-warning to make it readable in dark mode

### DIFF
--- a/web/assets/stylesheets/application-dark.css
+++ b/web/assets/stylesheets/application-dark.css
@@ -72,6 +72,10 @@ table {
   background-color: #31708f;
 }
 
+.alert-warning {
+  background-color: #c47612;
+}
+
 a:link, a:active, a:hover, a:visited {
   color: #ddd;
 }


### PR DESCRIPTION
Of the 4 types of [Bootstrap alerts](https://getbootstrap.com/docs/3.4/components/#alerts-examples), `alert-warning` was missing an override background color for dark mode which made it difficult to read. Although `alert-warning` is not used anywhere in the existing pages our organization has built some custom pages that uses it and it's difficult to read as is.

Current:

<img width="767" alt="Screenshot 2022-11-06 at 11 39 49 AM" src="https://user-images.githubusercontent.com/1631278/200183308-7c20af00-6076-4915-89a4-6a650da53f94.png">

New:

<img width="768" alt="Screenshot 2022-11-06 at 11 39 41 AM" src="https://user-images.githubusercontent.com/1631278/200183362-b53cb68e-a85d-4f96-a067-62a668b2e3e5.png">

