### PR TITLE
Adds a helper function to get batch id, and provides a link from the job info section

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -262,6 +262,10 @@ module Sidekiq
       end
     end
 
+    def batch_id(job)
+      job.item['bid']
+    end
+
     def format_memory(rss_kb)
       return "0" if rss_kb.nil? || rss_kb == 0
 

--- a/web/locales/en.yml
+++ b/web/locales/en.yml
@@ -7,6 +7,7 @@ en:
   AreYouSureDeleteQueue: Are you sure you want to delete the %{queue} queue? This will delete all jobs within the queue, it will reappear if you push more jobs to it in the future.
   Arguments: Arguments
   BackToApp: Back to App
+  Batch: Batch
   Busy: Busy
   Class: Class
   Connections: Connections

--- a/web/views/_job_info.erb
+++ b/web/views/_job_info.erb
@@ -84,6 +84,12 @@
           <td><%= relative_time(job.at) if job['retry_count'] %></td>
         </tr>
       <% end %>
+      <% unless batch_id(job).nil? %>
+        <tr>
+          <th><%= t('Batch') %></th>
+          <td><a href="<%= root_path %>batches/<%= batch_id(job) %>"><%= batch_id(job) %></td>
+        </tr>
+      <% end %>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
This PR is in reference to [this issue](https://github.com/mperham/sidekiq/issues/5613), and adds parsing the job details to look for `bid`, indicating this is from a Sidekiq Batch. If found it outputs the ID as a link to the batch status.

Example (with a fake ID):

<img width="1211" alt="Screenshot 2022-11-06 at 1 06 00 PM" src="https://user-images.githubusercontent.com/1631278/200187455-095c1031-c730-4946-a712-a8f06ff73bb3.png">
