### PR TITLE
Adds a hook into job info output to allow custom rows like links to external logs

### DIFF
--- a/lib/sidekiq/web.rb
+++ b/lib/sidekiq/web.rb
@@ -48,6 +48,10 @@ module Sidekiq
       end
       alias_method :tabs, :custom_tabs
 
+      def custom_job_info_rows
+        @custom_job_info_rows ||= []
+      end
+
       def locales
         @locales ||= LOCALES
       end

--- a/web/views/_job_info.erb
+++ b/web/views/_job_info.erb
@@ -84,6 +84,14 @@
           <td><%= relative_time(job.at) if job['retry_count'] %></td>
         </tr>
       <% end %>
+      <% Sidekiq::Web.custom_job_info_rows.each do |processor| %>
+        <% if processor.show_row(job) %>
+          <tr>
+            <th><%= processor.row_name %></th>
+            <td><%= processor.row_contents(job) %></td>
+          </tr>
+        <% end %>
+      <% end %>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
This PR adds a hook into the job info output to allow appending custom rows. For example this could be used to generate links to external log providers such as Datadog.

To use, a class must implement `show_row`, `row_name` and `row_contents`, for example:

```ruby
class CustomJobInfoRowLink
  class << self
    
    EXTERNAL_LOG_LINK = 'https://example.com/logs/job_id='
    
    def show_row(job)
      true
    end
    
    def row_name
      "Logs"
    end
    
    def row_contents(job)
      "<a href='#{EXTERNAL_LOG_LINK}#{job.jid}'>External logs</a>"
    end
  end
end
```

Then during setup of the Sidekiq web component, pass in to `custom_job_info_rows`:

```ruby
Sidekiq::Web.custom_job_info_rows << CustomJobInfoRowLink
```
<img width="700" alt="Screenshot 2022-11-06 at 1 45 11 PM" src="https://user-images.githubusercontent.com/1631278/200189312-58672428-d75d-4e76-8e33-da20dca4b0b5.png">

