### PR TITLE
Allow shift-clicking to select ranges of jobs

### DIFF
--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -31,6 +31,7 @@ function addListeners() {
     node.addEventListener("click", addDataToggleListeners)
   })
 
+  addShiftClickListeners()
   updateFuzzyTimes();
   setLivePollFromUrl();
 
@@ -69,6 +70,23 @@ function addDataToggleListeners(event) {
   } else {
     full.style.display = 'block';
   }
+}
+
+function addShiftClickListeners() {
+  let checkboxes = Array.from(document.querySelectorAll(".shift_clickable"));
+  let lastChecked = null;
+  checkboxes.forEach(checkbox => {
+    checkbox.addEventListener("click", (e) => {
+      if (e.shiftKey && lastChecked) {
+        let myIndex = checkboxes.indexOf(checkbox);
+        let lastIndex = checkboxes.indexOf(lastChecked);
+        let [min, max] = [myIndex, lastIndex].sort();
+        let newState = checkbox.checked;
+        checkboxes.slice(min, max).forEach(c => c.checked = newState);
+      }
+      lastChecked = checkbox;
+    });
+  });
 }
 
 function updateFuzzyTimes() {

--- a/web/views/morgue.erb
+++ b/web/views/morgue.erb
@@ -33,7 +33,7 @@
           <tr>
             <td class="table-checkbox">
               <label>
-                <input type='checkbox' name='key[]' value='<%= job_params(entry.item, entry.score) %>' />
+                <input type='checkbox' name='key[]' value='<%= job_params(entry.item, entry.score) %>' class='shift_clickable' />
               </label>
             </td>
             <td>

--- a/web/views/retries.erb
+++ b/web/views/retries.erb
@@ -34,7 +34,7 @@
           <tr>
             <td class="table-checkbox">
               <label>
-                <input type='checkbox' name='key[]' value='<%= job_params(entry.item, entry.score) %>' />
+                <input type='checkbox' name='key[]' value='<%= job_params(entry.item, entry.score) %>' class='shift_clickable' />
               </label>
             </td>
             <td>

--- a/web/views/scheduled.erb
+++ b/web/views/scheduled.erb
@@ -30,7 +30,7 @@
         <% @scheduled.each do |entry| %>
           <tr>
             <td>
-              <input type='checkbox' name='key[]' value='<%= job_params(entry.item, entry.score) %>' />
+              <input type='checkbox' name='key[]' value='<%= job_params(entry.item, entry.score) %>' class='shift_clickable' />
             </td>
             <td>
                <a href="<%= root_path %>scheduled/<%= job_params(entry.item, entry.score) %>"><%= relative_time(entry.at) %></a>


### PR DESCRIPTION
Any interest in something like this to allow you to shift-click ranges of checkboxes on the retries/scheduled-jobs pages? 