### PR TITLE
Add weights and version to queues on sidekiqmon and Sidekiq UI

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -971,6 +971,14 @@ module Sidekiq
       self["queues"]
     end
 
+    def weights
+      self["weights"]
+    end
+
+    def version
+      self["version"]
+    end
+
     # Signal this process to stop processing new jobs.
     # It will continue to execute jobs it has already fetched.
     # This method is *asynchronous* and it can take 5-10

--- a/lib/sidekiq/launcher.rb
+++ b/lib/sidekiq/launcher.rb
@@ -250,9 +250,11 @@ module Sidekiq
         "pid" => ::Process.pid,
         "tag" => @config[:tag] || "",
         "concurrency" => @config.total_concurrency,
-        "queues" => @config.capsules.values.map { |cap| cap.queues }.flatten.uniq,
+        "queues" => @config.capsules.values.flat_map { |cap| cap.queues }.uniq,
+        "weights" => @config.capsules.values.flat_map { |cap| cap.queues }.tally,
         "labels" => @config[:labels].to_a,
-        "identity" => identity
+        "identity" => identity,
+        "version" => Sidekiq::VERSION
       }
     end
 

--- a/lib/sidekiq/monitor.rb
+++ b/lib/sidekiq/monitor.rb
@@ -49,10 +49,25 @@ class Sidekiq::Monitor
     def processes
       puts "---- Processes (#{process_set.size}) ----"
       process_set.each_with_index do |process, index|
+        # Keep compatibility with legacy versions since we don't want to break sidekiqmon during rolling upgrades or downgrades.
+        #
+        # Before:
+        #   ["default", "critical"]
+        #
+        # After:
+        #   {"default" => 1, "critical" => 10}
+        queues =
+          if process["weights"]
+            process["weights"].sort_by { |queue| queue[0] }.map { |queue| queue.join(": ") }
+          else
+            process["queues"].sort
+          end
+
         puts "#{process["identity"]} #{tags_for(process)}"
         puts "  Started: #{Time.at(process["started_at"])} (#{time_ago(process["started_at"])})"
         puts "  Threads: #{process["concurrency"]} (#{process["busy"]} busy)"
-        puts "   Queues: #{split_multiline(process["queues"].sort, pad: 11)}"
+        puts "   Queues: #{split_multiline(queues, pad: 11)}"
+        puts "  Version: #{process["version"] || "Unknown"}"
         puts "" unless (index + 1) == process_set.size
       end
     end

--- a/lib/sidekiq/monitor.rb
+++ b/lib/sidekiq/monitor.rb
@@ -67,7 +67,7 @@ class Sidekiq::Monitor
         puts "  Started: #{Time.at(process["started_at"])} (#{time_ago(process["started_at"])})"
         puts "  Threads: #{process["concurrency"]} (#{process["busy"]} busy)"
         puts "   Queues: #{split_multiline(queues, pad: 11)}"
-        puts "  Version: #{process["version"] || "Unknown"}"
+        puts "  Version: #{process["version"] || "Unknown"}" if process["version"] != Sidekiq::VERSION
         puts "" unless (index + 1) == process_set.size
       end
     end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -551,9 +551,9 @@ describe "API" do
       assert_equal 10, data["busy"]
       assert_equal time, data["beat"]
       assert_equal 123, data["pid"]
-      assert_equal(["foo", "bar"], data.queues)
+      assert_equal ["foo", "bar"], data.queues
       assert_equal({"foo" => 1, "bar" => 1}, data.weights)
-      assert_equal(Sidekiq::VERSION, data.version)
+      assert_equal Sidekiq::VERSION, data.version
       data.quiet!
       data.stop!
       signals_string = "#{odata["key"]}-signals"

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -531,7 +531,9 @@ describe "API" do
         "key" => identity_string,
         "identity" => identity_string,
         "started_at" => Time.now.to_f - 15,
-        "queues" => {"foo" => 1, "bar" => 1}
+        "queues" => ["foo", "bar"],
+        "weights" => {"foo" => 1, "bar" => 1},
+        "version" => Sidekiq::VERSION
       }
 
       time = Time.now.to_f
@@ -549,7 +551,9 @@ describe "API" do
       assert_equal 10, data["busy"]
       assert_equal time, data["beat"]
       assert_equal 123, data["pid"]
-      assert_equal({"foo" => 1, "bar" => 1}, data.queues)
+      assert_equal(["foo", "bar"], data.queues)
+      assert_equal({"foo" => 1, "bar" => 1}, data.weights)
+      assert_equal(Sidekiq::VERSION, data.version)
       data.quiet!
       data.stop!
       signals_string = "#{odata["key"]}-signals"

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -531,7 +531,7 @@ describe "API" do
         "key" => identity_string,
         "identity" => identity_string,
         "started_at" => Time.now.to_f - 15,
-        "queues" => ["foo", "bar"]
+        "queues" => {"foo" => 1, "bar" => 1}
       }
 
       time = Time.now.to_f
@@ -549,7 +549,7 @@ describe "API" do
       assert_equal 10, data["busy"]
       assert_equal time, data["beat"]
       assert_equal 123, data["pid"]
-      assert_equal ["foo", "bar"], data.queues
+      assert_equal({"foo" => 1, "bar" => 1}, data.queues)
       data.quiet!
       data.stop!
       signals_string = "#{odata["key"]}-signals"

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -75,12 +75,14 @@
           <% else %>
             <%= process.queues.sort.join(", ") %>
           <% end %>
-          <br>
-          <b><%= "#{t('Version')}: " %></b>
-          <% if process.version %>
-            <%= process.version %>
-          <% else %>
-            <%= t('Unknown') %>
+          <% if process.version != Sidekiq::VERSION %>
+            <br>
+            <b><%= "#{t('Version')}: " %></b>
+            <% if process.version %>
+              <%= process.version %>
+            <% else %>
+              <%= t('Unknown') %>
+            <% end %>
           <% end %>
         </td>
         <td><%= relative_time(Time.at(process['started_at'])) %></td>

--- a/web/views/busy.erb
+++ b/web/views/busy.erb
@@ -70,7 +70,18 @@
           <% end %>
           <br>
           <b><%= "#{t('Queues')}: " %></b>
-          <%= process.queues.join(", ") %>
+          <% if process.weights %>
+            <%= process.weights.sort_by { |weight| weight[0] }.map { |weight| weight.join(": ") }.join(", ") %>
+          <% else %>
+            <%= process.queues.sort.join(", ") %>
+          <% end %>
+          <br>
+          <b><%= "#{t('Version')}: " %></b>
+          <% if process.version %>
+            <%= process.version %>
+          <% else %>
+            <%= t('Unknown') %>
+          <% end %>
         </td>
         <td><%= relative_time(Time.at(process['started_at'])) %></td>
         <td><%= format_memory(process['rss'].to_i) %></td>


### PR DESCRIPTION
It is backwards compatible in a way that sidekiqmon and Sidekiq UI will work during rolling deployments.

You can have one process in the previous version and another one in the new version and sidekiqmon/Sidekiq UI will work on both versions (legacy and new).

Before:

```
$ bundle exec sidekiqmon
Sidekiq 6.4.2
2022-11-17 18:28:14 UTC

---- Overview ----
  Processed: 0
     Failed: 0
       Busy: 0
   Enqueued: 0
    Retries: 0
  Scheduled: 0
       Dead: 0

---- Processes (2) ----
Gabriels-MacBook-Pro.local:60533:888acdb733ff []
  Started: 2022-11-17 15:16:46 -0300 (11 minutes ago)
  Threads: 2 (0 busy)
   Queues: critical, default, low

Gabriels-MacBook-Pro.local:62268:20c6394c86a7 []
  Started: 2022-11-17 15:25:21 -0300 (2 minutes ago)
  Threads: 50 (0 busy)
   Queues: critical, default, low

---- Queues (0) ----
NAME    SIZE  LATENCY
```

After:

```
$ bundle exec sidekiqmon
Sidekiq 7.0.1
2022-11-17 18:25:23 UTC

---- Overview ----
2022-11-17T18:25:23.251Z pid=62277 tid=1d5h INFO: Sidekiq 7.0.1 connecting to Redis with options {:size=>5, :pool_name=>"internal", :url=>nil}
  Processed: 0
     Failed: 0
       Busy: 0
   Enqueued: 0
    Retries: 0
  Scheduled: 0
       Dead: 0

---- Processes (2) ----
Gabriels-MacBook-Pro.local:60533:888acdb733ff []
  Started: 2022-11-17 15:16:46 -0300 (8 minutes ago)
  Threads: 2 (0 busy)
   Queues: critical, default, low
  Version: Unknown

Gabriels-MacBook-Pro.local:62268:20c6394c86a7 []
  Started: 2022-11-17 15:25:21 -0300 (just now)
  Threads: 50 (0 busy)
   Queues: critical: 100, default: 10, low: 1
  Version: 7.0.1

---- Queues (0) ----
NAME    SIZE  LATENCY
```

Before:

<img width="1840" alt="Screen Shot 2022-11-17 at 15 43 48" src="https://user-images.githubusercontent.com/26460/202531416-c9d843d3-82f8-4627-b009-7089d4d21ed5.png">


After:

<img width="1840" alt="Screen Shot 2022-11-17 at 15 36 03" src="https://user-images.githubusercontent.com/26460/202531141-b772f617-d286-4b76-9837-eb6f2fe7f53b.png">


Closes #5640