### PR TITLE
Use configured Redis pool in Sidekiq::Deploy

### DIFF
--- a/lib/sidekiq/deploy.rb
+++ b/lib/sidekiq/deploy.rb
@@ -25,7 +25,7 @@ module Sidekiq
       Sidekiq::Deploy.new.mark(label: label)
     end
 
-    def initialize(pool = Sidekiq::RedisConnection.create)
+    def initialize(pool = Sidekiq.default_configuration.redis_pool)
       @pool = pool
     end
 


### PR DESCRIPTION
I noticed this when discussing https://github.com/mperham/sidekiq/issues/5632#issuecomment-1320451422

now

```ruby
Sidekiq::default_configuration.redis_pool.with {|c| c.call("PING") }
=> "PONG"
```

was

```ruby
Sidekiq::RedisConnection.create.with {|c| c.call("PING") }
/app/vendor/bundle/ruby/3.1.0/gems/redis-client-0.11.1/lib/redis_client/ruby_connection.rb:62:in `connect_nonblock': SSL_connect returned=1 errno=0 peeraddr=IP:PORT state=error: certificate verify failed (self signed certificate in certificate chain) (RedisClient::CannotConnectError)
```