### PR TITLE
Update rack dependency requirement to allow for 1.x versions for Sidekiq Version 5.x

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,12 +2,17 @@
 
 [Sidekiq Changes](https://github.com/mperham/sidekiq/blob/master/Changes.md) | [Sidekiq Pro Changes](https://github.com/mperham/sidekiq/blob/master/Pro-Changes.md) | [Sidekiq Enterprise Changes](https://github.com/mperham/sidekiq/blob/master/Ent-Changes.md)
 
+5.2.11
+---------
+- Relax `rack` requirement to allow for 1.xx versions
+
 5.2.10
 ---------
 
 - Backport fix for CVE-2022-23837.
 - Migrate to `exists?` for redis-rb.
 - Lock redis-rb to <4.6 to avoid deprecations.
+- **BREAKING CHANGE**: Require a 4.5 minimum of version of [`redis`](https://github.com/redis/redis-rb).
 
 5.2.9
 ---------

--- a/sidekiq.gemspec
+++ b/sidekiq.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "redis", "~> 4.5", "< 4.6.0"
   gem.add_dependency 'connection_pool', '~> 2.2', '>= 2.2.2'
-  gem.add_dependency 'rack', '~> 2.0'
+  gem.add_dependency 'rack', '< 3'
   gem.add_dependency 'rack-protection', '>= 1.5.0'
 end


### PR DESCRIPTION
- Updated `rack` version dependency requirement to address `BREAKING CHANGE` from [this commit](https://github.com/mperham/sidekiq/commit/e2de6826337d2d7bc5020eed3248c712f7351cad) to allow for version 1.xx versions of `rack`. It _seemed_ like the goal was to prevent any major version changes after looking at the [`rack CHANGELOG`](https://github.com/rack/rack/blob/main/CHANGELOG.md).
  - I'm not too familiar with the test suite setup for this repo with `travis`. However, I installed a `rack` version 1.x on my machine from the `gemspec`, ran the tests and all was passing. Happy to update any tests for this.
- Updated `CHANGELOG` for [this commit](https://github.com/mperham/sidekiq/commit/3f963816202940f36809561aef8e22f0cc1aea22) for `BREAKING CHANGE` that required a higher `redis-rb` version.
- Both of these patches were breaking changes. When upgrading legacy applications, it can not be  assumed that everyone will have the ability to upgrade to a higher version of `rack` (especially for `rails` applications etc).


I understand it is better to upgrade to sidekiq 6, then 7. However, if people can not update patch versions without breaking changes, this makes it difficult. We should allow others to ensure they can get the fix for `CVE-2022-23837`.