### PR TITLE
Update changelog with version 5.x breaking changes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -432,12 +432,14 @@ See the [Logging wiki page](https://github.com/mperham/sidekiq/wiki/Logging) for
 - Backport fix for CVE-2022-23837.
 - Migrate to `exists?` for redis-rb.
 - Lock redis-rb to <4.6 to avoid deprecations.
+- **BREAKING CHANGE**: Require a minimum 4.5 version of `redis-rb`
 
 5.2.9
 ---------
 
 - Release Rack lock due to a cascade of CVEs. [#4566]
   Pro-tip: don't lock Rack.
+- **BREAKING CHANGE**: Require a minimum 2.0 version of `rack`
 
 5.2.8
 ---------


### PR DESCRIPTION
- Updated changelog to specify breaking changes sidekiq version 5.x
  - 5.9 change from [this commit](https://github.com/mperham/sidekiq/commit/e2de6826337d2d7bc5020eed3248c712f7351cad)
  - 5.10 change from [this commit](https://github.com/mperham/sidekiq/commit/3f963816202940f36809561aef8e22f0cc1aea22)
- **Related PR**: https://github.com/mperham/sidekiq/pull/5650

Although this is an older version of sidekiq, it is still worth noting what is breaking/blocking when people are upgrading applications.