### PR TITLE
Only modify logger if it's an instance of `::Logger`.

### DIFF
--- a/lib/sidekiq/config.rb
+++ b/lib/sidekiq/config.rb
@@ -248,7 +248,10 @@ module Sidekiq
         return
       end
 
-      logger.extend(Sidekiq::LoggingUtils)
+      if logger.is_a?(::Logger)
+        logger.extend(Sidekiq::LoggingUtils)
+      end
+
       @logger = logger
     end
 


### PR DESCRIPTION
https://github.com/mperham/sidekiq/discussions/5673

At least don't assume that the `logger` argument is compatible with `extend(Sidekiq::LoggingUtils)`.