### PR TITLE
Set error source on Rails 7.1+

### DIFF
--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -11,7 +11,10 @@ module Sidekiq
       end
 
       def call
-        @app.reloader.wrap do
+        params = ::Rails::VERSION::STRING >= '7.1' ? {source: "sidekiq.active_job"} : {}
+        @app.reloader.wrap(**params) do
+          yield
+        end
           yield
         end
       end

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -15,8 +15,6 @@ module Sidekiq
         @app.reloader.wrap(**params) do
           yield
         end
-          yield
-        end
       end
 
       def inspect

--- a/lib/sidekiq/rails.rb
+++ b/lib/sidekiq/rails.rb
@@ -11,7 +11,7 @@ module Sidekiq
       end
 
       def call
-        params = ::Rails::VERSION::STRING >= '7.1' ? {source: "sidekiq.active_job"} : {}
+        params = ::Rails::VERSION::STRING >= '7.1' ? {source: "job.sidekiq"} : {}
         @app.reloader.wrap(**params) do
           yield
         end


### PR DESCRIPTION
Rails 7.1 (in alpha) adds a [`source` keyword argument](https://edgeguides.rubyonrails.org/error_reporting.html#:~:text=source%3A%20a%20String,aren%27t%20interested%20in.) to its ErrorReporter interface. By default, [this is set to `application.active_support`](https://github.com/rails/rails/blob/32af4cd969834c9ec5ff4409f42a59d1c99acaad/activesupport/lib/active_support/execution_wrapper.rb#L87), which is misleading for errors raised from Sidekiq. We should set this correctly for maximum framework compatibility. At the very least, we need this at Honeybadger so we can ignore errors from Sidekiq and let the SIdekiq error handler handle it.

Couldn't find a way to add Rails 7-specific tests, but I tested this with my Rails 7 installation.