### PR TITLE
Make period on metrics page configurable via select

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -20,6 +20,12 @@ module Sidekiq
       "worker-src 'self'",
       "base-uri 'self'"
     ].join("; ").freeze
+    METRICS_PERIODS = {
+      "1h" => 60,
+      "2h" => 120,
+      "4h" => 240,
+      "8h" => 480
+    }
 
     def initialize(klass)
       @klass = klass
@@ -62,7 +68,9 @@ module Sidekiq
 
     get "/metrics" do
       q = Sidekiq::Metrics::Query.new
-      @query_result = q.top_jobs
+      @periods = METRICS_PERIODS
+      minutes = @periods.fetch(params[:period], @periods.values.first)
+      @query_result = q.top_jobs(minutes: minutes)
       erb(:metrics)
     end
 

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -68,16 +68,20 @@ module Sidekiq
 
     get "/metrics" do
       q = Sidekiq::Metrics::Query.new
+      @period = params[:period]
       @periods = METRICS_PERIODS
-      minutes = @periods.fetch(params[:period], @periods.values.first)
+      minutes = @periods.fetch(@period, @periods.values.first)
       @query_result = q.top_jobs(minutes: minutes)
       erb(:metrics)
     end
 
     get "/metrics/:name" do
       @name = route_params[:name]
+      @period = params[:period]
       q = Sidekiq::Metrics::Query.new
-      @query_result = q.for_job(@name)
+      @periods = METRICS_PERIODS
+      minutes = @periods.fetch(@period, @periods.values.first)
+      @query_result = q.for_job(@name, minutes: minutes)
       erb(:metrics_for_job)
     end
 

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -26,7 +26,7 @@ module TestScenariosForMetrics
     context "when period param is not provided" do
       let(:period) { nil }
       let(:expected_minutes) { 60 }
-      it "calls top_jobs with minutes: 60" do
+      it "queries using 60 minutes" do
         subject
       end
     end
@@ -34,7 +34,7 @@ module TestScenariosForMetrics
     context "when period param is unknown" do
       let(:period) { "2d" }
       let(:expected_minutes) { 60 }
-      it "calls top_jobs with minutes: 60" do
+      it "queries using 60 minutes" do
         subject
       end
     end
@@ -43,7 +43,7 @@ module TestScenariosForMetrics
       context "when period param is #{code}" do
         let(:period) { code }
         let(:expected_minutes) { minutes }
-        it "calls top_jobs with minutes: #{minutes}" do
+        it "it queries using #{minutes} minutes" do
           subject
         end
       end

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -18,6 +18,39 @@ class LogDisplayer
   end
 end
 
+# Common test scenarios for both metrics index and detail page.
+module TestScenariosForMetrics
+  extend Minitest::Spec::DSL
+
+  def self.included(base)
+    context "when period param is not provided" do
+      let(:period) { nil }
+      let(:expected_minutes) { 60 }
+      it "calls top_jobs with minutes: 60" do
+        subject
+      end
+    end
+
+    context "when period param is unknown" do
+      let(:period) { "2d" }
+      let(:expected_minutes) { 60 }
+      it "calls top_jobs with minutes: 60" do
+        subject
+      end
+    end
+
+    Sidekiq::WebApplication::METRICS_PERIODS.each do |code, minutes|
+      context "when period param is #{code}" do
+        let(:period) { code }
+        let(:expected_minutes) { minutes }
+        it "calls top_jobs with minutes: #{minutes}" do
+          subject
+        end
+      end
+    end
+  end
+end
+
 describe Sidekiq::Web do
   include Rack::Test::Methods
 
@@ -811,53 +844,63 @@ describe Sidekiq::Web do
     end
   end
 
-  describe "metrics" do
-    before do
-      result_mock = MiniTest::Mock.new
-      result_mock.expect(:job_results, [])
-      result_mock.expect(:marks, [])
-      result_mock.expect(:buckets, [])
-      result_mock.expect(:starts_at, Time.now - 3600)
-      result_mock.expect(:ends_at, Time.now)
+  describe "Metrics Dashboard" do
+    describe "/metrics" do
+      before do
+        result_mock = MiniTest::Mock.new
+        result_mock.expect(:job_results, {})
+        result_mock.expect(:marks, [])
+        result_mock.expect(:buckets, [])
+        result_mock.expect(:starts_at, Time.now - 3600)
+        result_mock.expect(:ends_at, Time.now)
 
-      @query_mock = Minitest::Mock.new
-      @query_mock.expect :top_jobs, result_mock do |minutes:|
-        assert_equal expected_minutes, minutes
-      end
-    end
-
-    subject do
-      Sidekiq::Metrics::Query.stub :new, @query_mock do
-        get "/metrics", {period: period}.compact
-        assert_equal 200, last_response.status
-        assert_match(/Metrics/, last_response.body)
-      end
-    end
-
-    context "when period param is not provided" do
-      let(:period) { nil }
-      let(:expected_minutes) { 60 }
-      it "calls top_jobs with minutes: 60" do
-        subject
-      end
-    end
-
-    context "when period param is unknown" do
-      let(:period) { "2d" }
-      let(:expected_minutes) { 60 }
-      it "calls top_jobs with minutes: 60" do
-        subject
-      end
-    end
-
-    Sidekiq::WebApplication::METRICS_PERIODS.each do |code, minutes|
-      context "when period param is #{code}" do
-        let(:period) { code }
-        let(:expected_minutes) { minutes }
-        it "calls top_jobs with minutes: #{minutes}" do
-          subject
+        @query_mock = Minitest::Mock.new
+        @query_mock.expect :top_jobs, result_mock do |minutes:|
+          assert_equal expected_minutes, minutes
         end
       end
+
+      subject do
+        Sidekiq::Metrics::Query.stub :new, @query_mock do
+          get "/metrics", {period: period}.compact
+          assert_equal 200, last_response.status
+          assert_match(/Metrics/, last_response.body)
+        end
+      end
+
+      include TestScenariosForMetrics
+    end
+
+    describe "/metrics/:job" do
+      before do
+        job_result_mock = Minitest::Mock.new
+        job_result_mock.expect(:totals, {"s" => 1})
+        3.times { job_result_mock.expect(:hist, {"FooJob" => []}) }
+
+        result_mock = MiniTest::Mock.new
+        result_mock.expect(:job_results, {"FooJob" => job_result_mock})
+        result_mock.expect(:starts_at, Time.now - 3600)
+        result_mock.expect(:ends_at, Time.now)
+        result_mock.expect(:marks, [])
+        result_mock.expect(:buckets, [])
+
+        @query_mock = Minitest::Mock.new
+        @query_mock.expect :for_job, result_mock do |job, minutes:|
+          assert_equal "FooJob", job
+          assert_equal expected_minutes, minutes
+        end
+      end
+
+      subject do
+        Sidekiq::Metrics::Query.stub :new, @query_mock do
+          get "/metrics/FooJob", {period: period}.compact
+          assert_equal 200, last_response.status
+          assert_match(/Metrics/, last_response.body)
+          assert_match(/FooJob/, last_response.body)
+        end
+      end
+
+      include TestScenariosForMetrics
     end
   end
 end

--- a/web/assets/stylesheets/application.css
+++ b/web/assets/stylesheets/application.css
@@ -72,7 +72,7 @@ h1, h2, h3 {
   line-height: 45px;
 }
 
-.header-container {
+.header-container, .header-container .page-title-container {
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/web/views/_metrics_period_select.erb
+++ b/web/views/_metrics_period_select.erb
@@ -1,5 +1,5 @@
 <div>
-  <select class="form-control" aria-label="" onchange="window.location.href = '<%= path %>?period=' + event.target.value">
+  <select class="form-control" onchange="window.location.href = '<%= path %>?period=' + event.target.value">
     <% periods.each_key do |code| %>
 
       <% if code == period %>

--- a/web/views/_metrics_period_select.erb
+++ b/web/views/_metrics_period_select.erb
@@ -1,0 +1,12 @@
+<div>
+  <select class="form-control" aria-label="" onchange="window.location.href = '<%= path %>?period=' + event.target.value">
+    <% periods.each_key do |code| %>
+
+      <% if code == period %>
+        <option selected value="<%= code %>"><%= code %></option>
+      <% else %>
+        <option value="<%= code %>"><%= code %></option>
+      <% end %>
+    <% end %>
+  </select>
+</div>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -4,26 +4,13 @@
 <script type="text/javascript" src="<%= root_path %>javascripts/metrics.js"></script>
 
 <div class="header-container">
-  <div>
+  <div class="page-title-container">
     <h1><%= t('Metrics') %></h1>
 
-    <div>
-      <a target="blank" href="https://github.com/mperham/sidekiq/wiki/Metrics"><span class="info-circle" title="Click to learn more about metrics">?</span></a>
-    </div>
+    <a target="blank" href="https://github.com/mperham/sidekiq/wiki/Metrics"><span class="info-circle" title="Click to learn more about metrics">?</span></a>
   </div>
 
-  <div>
-    <select class="form-control" aria-label="" onchange="window.location.href = '<%= root_path %>metrics?period=' + event.target.value">
-      <% @periods.each_key do |code| %>
-
-        <% if code == params[:period] %>
-          <option selected value="<%= code %>"><%= code %></option>
-        <% else %>
-          <option value="<%= code %>"><%= code %></option>
-        <% end %>
-      <% end %>
-    </select>
-  </div>
+  <%= erb :_metrics_period_select, locals: { periods: @periods, period: @period, path: "#{root_path}metrics" } %>
 </div>
 
 <%
@@ -75,7 +62,7 @@
                   value="<%= kls %>"
                   <%= visible_kls.include?(kls) ? 'checked' : '' %>
                 />
-                <code><a href="<%= root_path %>metrics/<%= kls %>"><%= kls %></a></code>
+                <code><a href="<%= root_path %>metrics/<%= kls %>?period=<%= @period %>"><%= kls %></a></code>
               </div>
               <script>jobMetricsChart.registerSwatch("<%= id %>")</script>
             </td>

--- a/web/views/metrics.erb
+++ b/web/views/metrics.erb
@@ -4,10 +4,25 @@
 <script type="text/javascript" src="<%= root_path %>javascripts/metrics.js"></script>
 
 <div class="header-container">
-  <h1><%= t('Metrics') %></h1>
+  <div>
+    <h1><%= t('Metrics') %></h1>
+
+    <div>
+      <a target="blank" href="https://github.com/mperham/sidekiq/wiki/Metrics"><span class="info-circle" title="Click to learn more about metrics">?</span></a>
+    </div>
+  </div>
 
   <div>
-    <a target="blank" href="https://github.com/mperham/sidekiq/wiki/Metrics"><span class="info-circle" title="Click to learn more about metrics">?</span></a>
+    <select class="form-control" aria-label="" onchange="window.location.href = '<%= root_path %>metrics?period=' + event.target.value">
+      <% @periods.each_key do |code| %>
+
+        <% if code == params[:period] %>
+          <option selected value="<%= code %>"><%= code %></option>
+        <% else %>
+          <option value="<%= code %>"><%= code %></option>
+        <% end %>
+      <% end %>
+    </select>
   </div>
 </div>
 

--- a/web/views/metrics_for_job.erb
+++ b/web/views/metrics_for_job.erb
@@ -15,14 +15,16 @@
 
 <% if job_result.totals["s"] > 0 %>
   <div class="header-container">
-    <h1>
-      <a href="<%= root_path %>metrics"><%= t(:metrics).to_s.titleize %></a> /
-      <%= h @name %>
-    </h1>
+    <div class="page-title-container">
+      <h1>
+        <a href="<%= root_path %>metrics?period=<%= @period %>"><%= t(:metrics).to_s.titleize %></a> /
+        <%= h @name %>
+      </h1>
 
-    <div>
       <a target="blank" href="https://github.com/mperham/sidekiq/wiki/Metrics"><span class="info-circle" title="Click to learn more about metrics">?</span></a>
     </div>
+
+    <%= erb :_metrics_period_select, locals: { periods: @periods, period: @period, path: "#{root_path}metrics/#{@name}" } %>
   </div>
 
   <canvas id="hist-totals-chart"></canvas>


### PR DESCRIPTION
Hey!

Following up on #5693. I've added a select to the metrics page (both index and detail) that let's you select between 1, 2, 4, and 8 hours of history. @mperham are you sure that data lives for 8 hours?

### Index page
<img width="1437" alt="Screenshot 2022-12-13 at 23 35 40" src="https://user-images.githubusercontent.com/2844304/207459638-0bd669c0-2c83-4c37-9fcc-b96e3b19db94.png">

### Detail page
<img width="1437" alt="Screenshot 2022-12-13 at 23 35 54" src="https://user-images.githubusercontent.com/2844304/207459646-7193b8ad-c54d-44df-a406-b4547720fcc2.png">
