### PR TITLE
Remove comment with outdated instructions for max_retries config option

### DIFF
--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -47,8 +47,11 @@ module Sidekiq
   # to the job and everyone is using an error service, right?
   #
   # The default number of retries is 25 which works out to about 3 weeks
+  # You can change the default maximum number of retries in your initializer:
   #
-  # You can limit the number of retries for a particular job and send retries to
+  #   Sidekiq.default_configuration[:max_retries] = 7
+  #
+  # or limit the number of retries for a particular job and send retries to
   # a low priority queue with:
   #
   #    class MyJob

--- a/lib/sidekiq/job_retry.rb
+++ b/lib/sidekiq/job_retry.rb
@@ -47,11 +47,8 @@ module Sidekiq
   # to the job and everyone is using an error service, right?
   #
   # The default number of retries is 25 which works out to about 3 weeks
-  # You can change the default maximum number of retries in your initializer:
   #
-  #   Sidekiq.options[:max_retries] = 7
-  #
-  # or limit the number of retries for a particular job and send retries to
+  # You can limit the number of retries for a particular job and send retries to
   # a low priority queue with:
   #
   #    class MyJob


### PR DESCRIPTION
Details in #5704 

@mperham I'm not quite sure if it's fine for you to just remove the outdated instructions or if you would prefer to replace it with a specific explanation taking the new "configuration strategy" into account. Feel free to change it again. Thanks.

