### PR TITLE
Remove titleize / use localization

### DIFF
--- a/web/views/metrics_for_job.erb
+++ b/web/views/metrics_for_job.erb
@@ -16,7 +16,7 @@
 <% if job_result.totals["s"] > 0 %>
   <div class="header-container">
     <h1>
-      <a href="<%= root_path %>metrics"><%= t(:metrics).to_s.titleize %></a> /
+      <a href="<%= root_path %>metrics"><%= t('Metrics') %></a> /
       <%= h @name %>
     </h1>
 
@@ -61,7 +61,7 @@
   <p><small>Data from <%= @query_result.starts_at %> to <%= @query_result.ends_at %></small></p>
 <% else %>
   <h1>
-    <a href="<%= root_path %>/metrics"><%= t(:metrics).to_s.titleize %></a> /
+    <a href="<%= root_path %>/metrics"><%= t('Metrics') %></a> /
     <%= h @name %>
   </h1>
 


### PR DESCRIPTION
`titleize` is an ActiveSupport method and causes errors when using a standalone sidekiq/web. 

https://apidock.com/rails/String/titleize

Replace with proper call to localization:

https://github.com/mperham/sidekiq/blob/74f4b93ad44db6120de3fb9d3981a10f3ab7482b/web/locales/en.yml#L93
