### PR TITLE
Backport worker_compatibility_alias.rb to Sidekiq 6

### DIFF
--- a/lib/sidekiq/worker_compatibility_alias.rb
+++ b/lib/sidekiq/worker_compatibility_alias.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# use require "sidekiq/worker_compatibility_alias" if you want your code to
+# work both with Sidekiq 6 and Sidekiq 7
+
+require "sidekiq/worker"


### PR DESCRIPTION
I believe that it's the missing bit to the renaming. This allows Sidekiq extensions to support both Sidekiq 6 and Sidekiq 7 by using `require "sidekiq/worker_compatibility_alias"` and referencing `Sidekiq::Worker`.