### PR TITLE
Tiny memory and performance tweak

### DIFF
--- a/lib/sidekiq/job_util.rb
+++ b/lib/sidekiq/job_util.rb
@@ -18,11 +18,13 @@ module Sidekiq
     def verify_json(item)
       job_class = item["wrapped"] || item["class"]
       if Sidekiq::Config::DEFAULTS[:on_complex_arguments] == :raise
-        msg = <<~EOM
-          Job arguments to #{job_class} must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices.
-          To disable this error, add `Sidekiq.strict_args!(false)` to your initializer.
-        EOM
-        raise(ArgumentError, msg) unless json_safe?(item)
+        unless json_safe?(item)
+          msg = <<~EOM
+            Job arguments to #{job_class} must be native JSON types, see https://github.com/mperham/sidekiq/wiki/Best-Practices.
+            To disable this error, add `Sidekiq.strict_args!(false)` to your initializer.
+          EOM
+          raise(ArgumentError, msg)
+        end
       elsif Sidekiq::Config::DEFAULTS[:on_complex_arguments] == :warn
         warn <<~EOM unless json_safe?(item)
           Job arguments to #{job_class} do not serialize to JSON safely. This will raise an error in


### PR DESCRIPTION
While reading sources I noticed variable initialization outside of scope of it's usage. It seems like it was introduced at https://github.com/mperham/sidekiq/commit/b0fd83f5fc2d5d24bee1bfc002173f83b2e71155#diff-e3d2ada183fa5b2ce66ab380c5c6d3c97d9a7aa3c7a3e91a142b47e81f50356bL16-R21

Not a big deal, but nice to have I think