### PR TITLE
Capsule default weights

### DIFF
--- a/lib/sidekiq/capsule.rb
+++ b/lib/sidekiq/capsule.rb
@@ -28,6 +28,7 @@ module Sidekiq
       @name = name
       @config = config
       @queues = ["default"]
+      @weights = { "default" => 0 }
       @concurrency = config[:concurrency]
       @mode = :strict
     end

--- a/test/capsule_test.rb
+++ b/test/capsule_test.rb
@@ -43,6 +43,21 @@ describe Sidekiq::Capsule do
     assert_equal %w[foo baz baz baz], cap.queues
   end
 
+  it "parses weights correctly" do
+    cap = @cap
+    assert_equal({ "default" => 0 }, cap.weights)
+
+    cap.queues = %w[foo bar,2]
+    assert_equal({ "foo" => 0, "bar" => 2 }, cap.weights)
+
+    cap.queues = ["default"]
+    assert_equal({ "default" => 0 }, cap.weights)
+
+    # config/sidekiq.yml input will look like this
+    cap.queues = [["foo"], ["baz", 3]]
+    assert_equal({ "foo" => 0, "baz" => 3 }, cap.weights)
+  end
+
   it "can have customized middleware chains" do
     one = Object.new
     two = Object.new


### PR DESCRIPTION
This PR fixes wrong weights value of Sidekiq process with implicit queues list.

If you do not provide `queues` in configuration explicitly, the default Sidekiq capsule initializes with `default` queue, but the `weights` stays `nil`, so the process's `weights` is `[nil]` instead of `[{"default"=>0}]` with explicit `queues` configuration. And it breaks Sidekiq web UI busy tab.

_Explicit_ queues list:
```ruby
# In config
sidekiq = Sidekiq.configure_embed do |config|
  config.queues = %w[default]
  config.concurrency = 2
end

# In Rails console
Sidekiq::ProcessSet.new.to_a
# => [#<Sidekiq::Process @attribs={..., "queues"=>["default"], "weights"=>[{"default"=>0}], ...}>, ...]
```

_Implicit_ queues list:
```ruby
# In config
sidekiq = Sidekiq.configure_embed do |config|
  config.concurrency = 2
end

# In Rails console
Sidekiq::ProcessSet.new.to_a
# => [#<Sidekiq::Process @attribs={..., "queues"=>["default"], "weights"=>[nil], ...}>, ...]
```