### PR TITLE
Performance improvements

### DIFF
--- a/lib/sidekiq/component.rb
+++ b/lib/sidekiq/component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sidekiq
   ##
   # Sidekiq::Component assumes a config instance is available at @config

--- a/lib/sidekiq/metrics/tracking.rb
+++ b/lib/sidekiq/metrics/tracking.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "time"
 require "sidekiq"
 require "sidekiq/metrics/shared"

--- a/lib/sidekiq/processor.rb
+++ b/lib/sidekiq/processor.rb
@@ -146,6 +146,9 @@ module Sidekiq
       end
     end
 
+    IGNORE_SHUTDOWN_INTERRUPTS = {Sidekiq::Shutdown => :never}
+    private_constant :IGNORE_SHUTDOWN_INTERRUPTS
+
     def process(uow)
       jobstr = uow.job
       queue = uow.queue_name
@@ -195,7 +198,7 @@ module Sidekiq
       ensure
         if ack
           # We don't want a shutdown signal to interrupt job acknowledgment.
-          Thread.handle_interrupt(Sidekiq::Shutdown => :never) do
+          Thread.handle_interrupt(IGNORE_SHUTDOWN_INTERRUPTS) do
             uow.acknowledge
           end
         end


### PR DESCRIPTION
1. I measured memory allocated by whole `bin/sidekiqload` script to process 100k jobs using 1 thread:

### Before
```
Total allocated: 953.37 MB (7861488 objects)
Total retained:  1.18 MB (1004 objects)

allocated memory by gem
-----------------------------------
 387.22 MB  json-2.6.2
 244.71 MB  sidekiq/lib
 176.20 MB  redis-client-0.12.1
 119.38 MB  connection_pool-2.3.0
  21.58 MB  other
   4.15 MB  lib
 129.17 kB  concurrent-ruby-1.1.10
   3.94 kB  rubygems
   2.86 kB  toxiproxy-2.0.2
  120.00 B  activesupport-7.0.4.2

allocated memory by file
-----------------------------------
 387.22 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb
 111.21 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb
 107.05 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb
  93.66 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb
  48.10 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/buffered_io.rb
  44.86 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/client.rb
  39.23 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/fetch.rb
  24.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/middleware/chain.rb
  16.82 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/job_logger.rb
  16.06 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/metrics/tracking.rb
  12.03 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/decorator.rb
   9.07 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/component.rb
   8.96 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/command_builder.rb
   8.64 MB  <internal:timev>
   8.18 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool/timed_stack.rb
   8.01 MB  <internal:pack>
   4.93 MB  bin/sidekiqload
   4.00 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/securerandom.rb

allocated memory by location
-----------------------------------
 284.01 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb:216
  60.37 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:54
  52.80 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb:198
  50.40 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb:312
  44.80 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb:300
  36.53 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb:61
  36.53 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb:64
  36.00 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/buffered_io.rb:104
  33.60 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/client.rb:124
  31.20 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/fetch.rb:47
  17.07 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:55
  17.05 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb:68
  17.05 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb:71
  16.80 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/job_logger.rb:27
  16.80 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb:264
  16.22 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:99
  16.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/middleware/chain.rb:173
  16.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb:143
  12.08 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/buffered_io.rb:97
  12.02 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/decorator.rb:27
   8.64 MB  <internal:timev>:225
   8.01 MB  <internal:pack>:30
   8.00 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb:215
   8.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/component.rb:30
   8.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/client.rb:126
   5.31 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:38
   4.94 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/command_builder.rb:9
   4.80 MB  bin/sidekiqload:128
   4.08 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:69
   4.06 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool/timed_stack.rb:63
   4.06 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool/timed_stack.rb:41
   4.06 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb:60
   4.02 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/command_builder.rb:35
   4.00 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/securerandom.rb:65
   4.00 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:165
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/metrics/tracking.rb:34
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/metrics/tracking.rb:45
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/fetch.rb:20
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/fetch.rb:48
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/metrics/tracking.rb:35
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/metrics/tracking.rb:46
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/middleware/chain.rb:160
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/middleware/chain.rb:198
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb:137
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb:176
   1.05 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/component.rb:15
``` 

### After
```
Total allocated: 679.60 MB (6256593 objects)
Total retained:  1.18 MB (1004 objects)

allocated memory by gem
-----------------------------------
 231.15 MB  json-2.6.2
 195.12 MB  sidekiq/lib
 176.24 MB  redis-client-0.12.1
  51.22 MB  connection_pool-2.3.0
  21.59 MB  other
   4.15 MB  lib
 129.17 kB  concurrent-ruby-1.1.10
   3.94 kB  rubygems
   2.86 kB  toxiproxy-2.0.2
  120.00 B  activesupport-7.0.4.2

allocated memory by file
-----------------------------------
 231.15 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb
 107.09 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb
  60.06 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb
  48.10 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/buffered_io.rb
  44.86 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/client.rb
  43.04 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb
  39.23 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/fetch.rb
  24.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/middleware/chain.rb
  16.82 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/job_logger.rb
  12.03 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/decorator.rb
   8.97 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/command_builder.rb
   8.64 MB  <internal:timev>
   8.19 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool/timed_stack.rb
   8.06 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/metrics/tracking.rb
   8.01 MB  <internal:pack>
   4.93 MB  bin/sidekiqload
   4.00 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/securerandom.rb
   1.07 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/component.rb

allocated memory by location
-----------------------------------
 158.41 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb:216
  60.39 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:54
  46.34 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb:312
  36.00 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/buffered_io.rb:104
  33.60 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/client.rb:124
  31.20 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/fetch.rb:47
  22.40 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb:300
  19.49 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb:64
  19.49 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb:67
  19.20 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb:200
  17.07 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:55
  16.80 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/job_logger.rb:27
  16.80 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb:266
  16.22 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:99
  16.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/middleware/chain.rb:173
  16.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb:143
  12.08 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/buffered_io.rb:97
  12.03 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/decorator.rb:27
   8.64 MB  <internal:timev>:225
   8.01 MB  <internal:pack>:30
   8.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/client.rb:126
   5.31 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:38
   4.94 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/command_builder.rb:9
   4.80 MB  bin/sidekiqload:128
   4.08 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:69
   4.06 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool/timed_stack.rb:63
   4.06 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool/timed_stack.rb:41
   4.06 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb:63
   4.02 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/command_builder.rb:35
   4.00 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/securerandom.rb:65
   4.00 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/redis-client-0.12.1/lib/redis_client/ruby_connection/resp3.rb:165
   4.00 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb:215
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/metrics/tracking.rb:36
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/metrics/tracking.rb:47
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/fetch.rb:20
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/fetch.rb:48
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/middleware/chain.rb:160
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/middleware/chain.rb:198
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb:137
   4.00 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb:178
   1.05 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/component.rb:17
```

So, `~30%` less memory allocated 🔥 

2. I noticed, that while pushing jobs into redis, a lots of memory gets allocated by (and time spent by) json. A good part of it is in a newly implemented feature of checking if payload is json-safe.

Measured time spent to push 500k jobs to redis:

### Before
`Created 500000 jobs in 9.466118 sec`
```
  Mode: wall(1000)
  Samples: 9453 (0.05% miss rate)
  GC: 1660 (17.56%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      3219  (34.1%)        1748  (18.5%)     JSON::Ext::Generator::State#generate
      1528  (16.2%)        1528  (16.2%)     (sweeping)
      1471  (15.6%)        1471  (15.6%)     Float#to_s
       686   (7.3%)         686   (7.3%)     IO#wait_readable
       722   (7.6%)         528   (5.6%)     Class#new
      7726  (81.7%)         391   (4.1%)     Sidekiq::Client#push_bulk
      3975  (42.1%)         170   (1.8%)     JSON.generate
       162   (1.7%)         162   (1.7%)     Array#==
       185   (2.0%)         157   (1.7%)     JSON::Ext::Generator::State#configure
       222   (2.3%)         155   (1.6%)     RedisClient::RESP3.dump_string
      2087  (22.1%)         145   (1.5%)     Sidekiq::JobUtil#json_safe?
       132   (1.4%)         132   (1.4%)     (marking)
       127   (1.3%)         127   (1.3%)     Hash#merge
       121   (1.3%)         121   (1.3%)     JSON::Ext::Parser#parse
      6210  (65.7%)         114   (1.2%)     Array#map
       105   (1.1%)         105   (1.1%)     String#unpack1
      3110  (32.9%)         105   (1.1%)     Sidekiq::Client#atomic_push
        98   (1.0%)          98   (1.0%)     Random.urandom
       169   (1.8%)          86   (0.9%)     JSON::Ext::Parser#initialize
       125   (1.3%)          84   (0.9%)     Enumerable#flat_map
       564   (6.0%)          79   (0.8%)     JSON.parse
      2161  (22.9%)          74   (0.8%)     Sidekiq::JobUtil#verify_json
       334   (3.5%)          73   (0.8%)     RedisClient::RESP3.dump_any
      1215  (12.9%)          73   (0.8%)     JSON.dump
       376   (4.0%)          70   (0.7%)     Random::Formatter#hex
      3183  (33.7%)          54   (0.6%)     Enumerator#with_index
        51   (0.5%)          51   (0.5%)     IO#write_nonblock
       149   (1.6%)          51   (0.5%)     SecureRandom.gen_random_urandom
       201   (2.1%)          51   (0.5%)     Random::Formatter#random_bytes
       516   (5.5%)          45   (0.5%)     Array#each
```

```
$ stackprof tmp/stackprof.dump --method 'Sidekiq::JobUtil#json_safe?'
Sidekiq::JobUtil#json_safe? (/Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/job_util.rb:69)
  samples:   145 self (1.5%)  /   2087 total (22.1%)
  callers:
    2087  (  100.0%)  Sidekiq::JobUtil#verify_json
  callees (1942 total):
    1215  (   62.6%)  JSON.dump
     564  (   29.0%)  JSON.parse
     162  (    8.3%)  Array#==
       1  (    0.1%)  (garbage collection)
```

So, `22.1%` is spent in `json_safe?`

### After
`Created 500000 jobs in 6.463861 sec`
```
  Mode: wall(1000)
  Samples: 6454 (0.06% miss rate)
  GC: 810 (12.55%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1501  (23.3%)        1501  (23.3%)     Float#to_s
      2594  (40.2%)        1093  (16.9%)     JSON::Ext::Generator::State#generate
       720  (11.2%)         720  (11.2%)     (sweeping)
       660  (10.2%)         660  (10.2%)     IO#wait_readable
      5589  (86.6%)         315   (4.9%)     Sidekiq::Client#push_bulk
       228   (3.5%)         167   (2.6%)     Sidekiq::JobUtil#json_safe?
       180   (2.8%)         159   (2.5%)     Class#new
       215   (3.3%)         149   (2.3%)     RedisClient::RESP3.dump_string
       128   (2.0%)         128   (2.0%)     Hash#merge
      3127  (48.5%)          93   (1.4%)     Sidekiq::Client#atomic_push
      4108  (63.7%)          93   (1.4%)     Array#map
        92   (1.4%)          92   (1.4%)     Random.urandom
        90   (1.4%)          90   (1.4%)     (marking)
       314   (4.9%)          86   (1.3%)     Sidekiq::JobUtil#verify_json
      2846  (44.1%)          78   (1.2%)     JSON.generate
       340   (5.3%)          68   (1.1%)     RedisClient::RESP3.dump_any
       108   (1.7%)          68   (1.1%)     Enumerable#flat_map
        67   (1.0%)          67   (1.0%)     Module#===
       122   (1.9%)          56   (0.9%)     Array#all?
        51   (0.8%)          51   (0.8%)     String#unpack1
        51   (0.8%)          51   (0.8%)     IO#write_nonblock
       141   (2.2%)          49   (0.8%)     SecureRandom.gen_random_urandom
       515   (8.0%)          43   (0.7%)     Array#each
        42   (0.7%)          42   (0.7%)     Integer#to_s
      1071  (16.6%)          42   (0.7%)     Enumerator#with_index
       259   (4.0%)          37   (0.6%)     Random::Formatter#hex
        47   (0.7%)          32   (0.5%)     Hash#fetch
       403   (6.2%)          31   (0.5%)     RedisClient::RESP3.dump_array
        76   (1.2%)          30   (0.5%)     Array#map!
        81   (1.3%)          28   (0.4%)     RedisClient::CommandBuilder#generate
```

```
$ stackprof tmp/stackprof.dump --method 'Sidekiq::JobUtil#json_safe?'
Sidekiq::JobUtil#json_safe? (/Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/job_util.rb:69)
  samples:   167 self (2.6%)  /    228 total (3.5%)
  callers:
     228  (  100.0%)  Sidekiq::JobUtil#verify_json
      64  (   28.1%)  Array#all?
      41  (   18.0%)  Sidekiq::JobUtil#json_safe?
  callees (61 total):
      92  (  150.8%)  Array#all?
      41  (   67.2%)  Sidekiq::JobUtil#json_safe?
      33  (   54.1%)  Module#===
```

So, `3.5%` is spent in `json_safe?`. 🔥 

### Benchmark for `json_safe?`

I also included in comparison a "recursive hash" technique, [suggested](https://github.com/mperham/sidekiq/pull/4303#issuecomment-538085487) by @schneems in another PR from the past.
It is 1.5x more faster than the suggested method, but `3.5 / 1.5 = 2.3%` vs `3.5%` is probably not much of a difference, but the implementation is a little more complex.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
  gem "benchmark-ips"
end

require "json"

def json_safe?(item)
  JSON.parse(JSON.dump(item)) == item
  # JSON.parse(JSON.dump(item["args"])) == item["args"]
end

def json_safe_optimized?(item)
  case item
  when String, Integer, Float, TrueClass, FalseClass, NilClass
    true
  when Array
    item.all? { |e| json_safe_optimized?(e) }
  when Hash
    item.all? { |k, v| String === k && json_safe_optimized?(v) }
  else
    false
  end
end

RECURSIVE_HASH = {
  Integer => -> (val) { true },
  Float => -> (val) { true },
  TrueClass => -> (val) { true },
  FalseClass => -> (val) { true },
  NilClass => -> (val) { true },
  String => ->(val) { true },
  Array => ->(val) {
    val.all? { |e| RECURSIVE_HASH[e.class].call(e) }
  },
  Hash => ->(val) {
    item.all? { |k, v| String === k && RECURSIVE_HASH[v.class].call(v) }
  }
}

RECURSIVE_HASH.default_proc = ->(_, _) { false }
RECURSIVE_HASH.compare_by_identity

def json_safe_recursive_hash?(item)
  RECURSIVE_HASH[item.class].call(item)
end

obj = {
  "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
  "wrapped" => "ActionMailer::MailDeliveryJob",
  "queue" => "mailers",
  "args": [
    { "job_class" => "ActionMailer::MailDeliveryJob",
      "job_id" => "2f967da1-a389-479c-9a4e-5cc059e6d65c",
      "provider_job_id" => nil,
      "queue_name" => "mailers",
      "priority" => nil,
      "arguments" => [
        "ApiMailer",
        "test_email",
        "deliver_now",
        { "args" => [1,2,3], "_aj_symbol_keys" => ["args"]}
      ],
      "executions" => 0,
      "exception_executions" => {},
      "locale" => "en",
      "timezone" => "UTC",
      "enqueued_at" => "2019-09-12T16:28:37Z"
    }],
    "retry" => true,
    "jid" => "469979df52bb9ef9f48b49e1",
    "created_at" => 1568305717.9457421,
    "enqueued_at" => 1568305717.9457731
}

Benchmark.ips do |x|
  x.report("json_safe?") do
    json_safe?(obj["args"])
  end

  x.report("json_safe_optimized?") do
    json_safe_optimized?(obj["args"])
  end

  x.report("json_safe_recursive_hash?") do
    json_safe_recursive_hash?(obj["args"])
  end

  x.compare!
end
```

```
Warming up --------------------------------------
          json_safe?    17.740k i/100ms
json_safe_optimized?   326.408k i/100ms
json_safe_recursive_hash?
                       500.825k i/100ms
Calculating -------------------------------------
          json_safe?    245.209k (±13.1%) i/s -      1.206M in   5.001675s
json_safe_optimized?      3.348M (± 0.8%) i/s -     16.973M in   5.070253s
json_safe_recursive_hash?
                          5.148M (± 0.9%) i/s -     26.043M in   5.059561s

Comparison:
json_safe_recursive_hash?:  5147682.2 i/s
json_safe_optimized?:  3347798.7 i/s - 1.54x  (± 0.00) slower
          json_safe?:   245208.9 i/s - 20.99x  (± 0.00) slower
```

I also made a small improvement to `connection_pool`, which reduced the memory too, so will open a PR into it separately, if this will be accepted.