### PR TITLE
Optimize traversing middleware chain

### DIFF
--- a/lib/sidekiq/middleware/chain.rb
+++ b/lib/sidekiq/middleware/chain.rb
@@ -166,22 +166,25 @@ module Sidekiq
 
       # Used by Sidekiq to execute the middleware at runtime
       # @api private
-      def invoke(*args)
+      def invoke(*args, &block)
         return yield if empty?
 
         chain = retrieve
-        traverse_chain = proc do
-          if chain.empty?
-            yield
-          else
-            chain.shift.call(*args, &traverse_chain)
+        traverse(chain, 0, args, &block)
+      end
+
+      private
+
+      def traverse(chain, index, args, &block)
+        if index >= chain.size
+          yield
+        else
+          chain[index].call(*args) do
+            traverse(chain, index + 1, args, &block)
           end
         end
-        traverse_chain.call
       end
     end
-
-    private
 
     # Represents each link in the middleware chain
     # @api private


### PR DESCRIPTION
Follow up to https://github.com/mperham/sidekiq/pull/5768

I noticed, that `redis-client` consumes quite some memory and was able to optimize it - https://github.com/redis-rb/redis-client/pull/90. Hope the PR will be merged.

But I also noticed that we can optimize traversing middleware chain, which allocates a proc each time the job is enqueued/performed.

Ran on 100k jobs:
```
$ THREADS=1 LATENCY=0 PROFILE=1 bundle exec ruby-memory-profiler --scale-bytes --out tmp/memory_profiler.txt bin/sidekiqload
```

### Before (with the changes from `redis-client` PR)
```
Total allocated: 600.07 MB (5626286 objects)
Total retained:  2.57 MB (22682 objects)

allocated memory by gem
-----------------------------------
 231.46 MB  json-2.6.2
 194.04 MB  sidekiq/lib
  78.64 MB  redis-client/lib
  50.74 MB  connection_pool-2.3.0
  22.96 MB  other
   9.69 MB  lib
   3.32 MB  concurrent-ruby-1.1.10
   2.44 MB  ruby-prof-1.4.5
   1.78 MB  activesupport-7.0.4.2
   1.67 MB  activerecord-7.0.4.2
   1.18 MB  rake-13.0.6
 858.80 kB  yard-0.9.28
 398.82 kB  sqlite3-1.6.0-x86_64-darwin
 376.28 kB  activemodel-7.0.4.2
 322.80 kB  i18n-1.12.0
 110.02 kB  toxiproxy-2.0.2
  57.47 kB  after_commit_everywhere-1.3.0
  10.76 kB  bundler-2.3.22
   4.02 kB  rubygems

allocated memory by file
-----------------------------------
 231.34 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb
  60.06 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb
  48.08 MB  /Users/fatkodima/Desktop/oss/redis-client/lib/redis_client/ruby_connection/buffered_io.rb
  44.91 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/client.rb
  42.63 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb
  39.23 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/fetch.rb
  24.04 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/middleware/chain.rb
  16.82 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/job_logger.rb
  12.06 MB  /Users/fatkodima/Desktop/oss/redis-client/lib/redis_client/decorator.rb
   9.27 MB  /Users/fatkodima/Desktop/oss/redis-client/lib/redis_client/ruby_connection/resp3.rb
   8.88 MB  /Users/fatkodima/Desktop/oss/redis-client/lib/redis_client/command_builder.rb
....
```

### After
```
Total allocated: 584.05 MB (5425893 objects)
Total retained:  2.56 MB (22664 objects)

allocated memory by gem
-----------------------------------
 231.43 MB  json-2.6.2
 178.06 MB  sidekiq/lib
  78.66 MB  redis-client/lib
  50.77 MB  connection_pool-2.3.0
  22.98 MB  other
   9.58 MB  lib
   3.33 MB  concurrent-ruby-1.1.10
   2.45 MB  ruby-prof-1.4.5
   1.78 MB  activesupport-7.0.4.2
   1.67 MB  activerecord-7.0.4.2
   1.18 MB  rake-13.0.6
 858.64 kB  yard-0.9.28
 398.82 kB  sqlite3-1.6.0-x86_64-darwin
 376.34 kB  activemodel-7.0.4.2
 322.49 kB  i18n-1.12.0
 110.02 kB  toxiproxy-2.0.2
  57.38 kB  after_commit_everywhere-1.3.0
  24.76 kB  byebug-11.1.3
  11.18 kB  bundler-2.3.22
   4.02 kB  rubygems

allocated memory by file
-----------------------------------
 231.31 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/json-2.6.2/lib/json/common.rb
  60.06 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/processor.rb
  48.08 MB  /Users/fatkodima/Desktop/oss/redis-client/lib/redis_client/ruby_connection/buffered_io.rb
  44.91 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/client.rb
  42.65 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool.rb
  39.23 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/fetch.rb
  16.82 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/job_logger.rb
  12.06 MB  /Users/fatkodima/Desktop/oss/redis-client/lib/redis_client/decorator.rb
   9.28 MB  /Users/fatkodima/Desktop/oss/redis-client/lib/redis_client/ruby_connection/resp3.rb
   8.89 MB  /Users/fatkodima/Desktop/oss/redis-client/lib/redis_client/command_builder.rb
   8.63 MB  <internal:timev>
   8.09 MB  /Users/fatkodima/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/connection_pool-2.3.0/lib/connection_pool/timed_stack.rb
   8.04 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/metrics/tracking.rb
   8.04 MB  /Users/fatkodima/Desktop/oss/sidekiq/lib/sidekiq/middleware/chain.rb
   8.01 MB  <internal:pack>
....
```

Not very large, but worth considering, I think.