### PR TITLE
Reduce # of opened files in tests

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -15,7 +15,7 @@ module Sidekiq
       # so extensions can be localized
       @strings[lang] ||= settings.locales.each_with_object({}) do |path, global|
         find_locale_files(lang).each do |file|
-          strs = YAML.safe_load(File.open(file))
+          strs = YAML.safe_load(File.read(file))
           global.merge!(strs[lang])
         end
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -25,6 +25,7 @@ if ENV["COVERAGE"]
 end
 
 ENV["REDIS_URL"] ||= "redis://localhost/15"
+NULL_LOGGER = Logger.new(IO::NULL)
 
 def reset!
   # tidy up any open but unreferenced Redis connections so we don't run out of file handles
@@ -35,7 +36,7 @@ def reset!
 
   RedisClient.new(url: ENV["REDIS_URL"]).call("flushall")
   cfg = Sidekiq::Config.new
-  cfg.logger = ::Logger.new("/dev/null")
+  cfg.logger = NULL_LOGGER
   cfg.logger.level = Logger::WARN
   Sidekiq.instance_variable_set :@config, cfg
   cfg


### PR DESCRIPTION
~once in 5-10 test runs I get an error regarding too many opened files.
Something like:
```
Error:
Sidekiq::CLI::#parse::#run#test_0001_prints rails info:
Errno::EMFILE: Too many open files
    lib/sidekiq/cli.rb:49:in `pipe'
    lib/sidekiq/cli.rb:49:in `run'
    test/cli_test.rb:383:in `block (6 levels) in <top (required)>'

rails test /Users/fatkodima/Desktop/oss/sidekiq/test/cli_test.rb:380
``` 

or 
```
Traceback (most recent call last):
	25: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:83:in `block in autorun'
	24: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:159:in `run'
	23: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:182:in `__run'
	22: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:182:in `map'
	21: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:182:in `block in __run'
	20: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:350:in `run'
	19: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:378:in `with_info_handler'
	18: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:391:in `on_signal'
	17: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:351:in `block in run'
	16: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:351:in `each'
	15: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:352:in `block (2 levels) in run'
	14: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:365:in `run_one_method'
	13: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:890:in `record'
	12: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:890:in `each'
	11: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:891:in `block in record'
	10: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/railties-7.0.4.2/lib/rails/test_unit/reporter.rb:23:in `record'
	 9: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest/pride_plugin.rb:74:in `puts'
	 8: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest/pride_plugin.rb:74:in `map!'
	 7: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest/pride_plugin.rb:75:in `block in puts'
	 6: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:568:in `to_s'
	 5: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:568:in `map'
	 4: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:569:in `block in to_s'
	 3: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:955:in `message'
	 2: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/minitest-5.16.3/lib/minitest.rb:265:in `filter_backtrace'
	 1: from /Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/maxitest-4.4.0/lib/maxitest/shorted_backtrace.rb:4:in `filter'
/Users/fatkodima/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/maxitest-4.4.0/lib/maxitest/shorted_backtrace.rb:4:in `pwd': Too many open files - getcwd (Errno::EMFILE)
```