### PR TITLE
Use `Sidekiq.load_json` everywhere

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -702,7 +702,7 @@ module Sidekiq
     def find_job(jid)
       Sidekiq.redis do |conn|
         conn.zscan(name, match: "*#{jid}*", count: 100) do |entry, score|
-          job = JSON.parse(entry)
+          job = Sidekiq.load_json(entry)
           matched = job["jid"] == jid
           return SortedEntry.new(self, score, entry) if matched
         end


### PR DESCRIPTION
In all other places `Sidekiq.load_json/dump_json` is already used (so users can monkey patch these methods with other json implementations if they will).