### PR TITLE
Web `/stats` endpoint does not return Valkey or Dragonfly Versions

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -9,7 +9,7 @@ module Sidekiq
       extend Router
       include Router
 
-      REDIS_KEYS = %w[redis_version uptime_in_days connected_clients used_memory_human used_memory_peak_human]
+      REDIS_KEYS = %w[dragonfly_version redis_version valkey_version uptime_in_days connected_clients used_memory_human used_memory_peak_human]
 
       CSP_HEADER_TEMPLATE = [
         "default-src 'self' https: http:",

--- a/web/assets/javascripts/dashboard.js
+++ b/web/assets/javascripts/dashboard.js
@@ -11,11 +11,21 @@ var updateStatsSummary = function(data) {
 }
 
 var updateRedisStats = function(data) {
-  document.getElementById('redis_version').innerText = data.redis_version;
+  document.getElementById('redis_version').innerText = getStoreVersion(data);
   document.getElementById('uptime_in_days').innerText = data.uptime_in_days;
   document.getElementById('connected_clients').innerText = data.connected_clients;
   document.getElementById('used_memory_human').innerText = data.used_memory_human;
   document.getElementById('used_memory_peak_human').innerText = data.used_memory_peak_human;
+}
+
+var getStoreVersion = function(data) {
+  if (data.dragonfly_version) {
+    return data.dragonfly_version;
+  }
+  if (data.valkey_version) {
+    return data.valkey_version;
+  }
+  return data.redis_version;
 }
 
 var updateFooterUTCTime = function(time) {


### PR DESCRIPTION
We noticed that after migrating to Valkey and Sidekiq 8, the initial dashboard page load would display the correct 8.0.1 version number for Valkey. But after the auto-refresh of data, that number would switch back to 7.2.4.

This change introduces a JavaScript helper function that returns the correct version number for the backing store. The order is the same as the behavior in `#store_version` in helpers.rb.