### PR TITLE
Assure that Sidekiq.server? and other similar methods return true/false

### DIFF
--- a/lib/sidekiq.rb
+++ b/lib/sidekiq.rb
@@ -48,7 +48,7 @@ module Sidekiq
   end
 
   def self.server?
-    defined?(Sidekiq::CLI)
+    !!defined?(Sidekiq::CLI)
   end
 
   def self.load_json(string)
@@ -60,11 +60,11 @@ module Sidekiq
   end
 
   def self.pro?
-    defined?(Sidekiq::Pro)
+    !!defined?(Sidekiq::Pro)
   end
 
   def self.ent?
-    defined?(Sidekiq::Enterprise)
+    !!defined?(Sidekiq::Enterprise)
   end
 
   def self.redis_pool

--- a/lib/sidekiq/cli.rb
+++ b/lib/sidekiq/cli.rb
@@ -34,7 +34,7 @@ module Sidekiq # :nodoc:
     end
 
     def jruby?
-      defined?(::JRUBY_VERSION)
+      !!defined?(::JRUBY_VERSION)
     end
 
     # Code within this method is not tested because it alters


### PR DESCRIPTION
It looks like few environment-checking methods like `Sidekiq.server?` return `nil` instead of `false`.

I have the following line in Rails config:
```
config.eager_load = Sidekiq.server?
```

and Rails complains:
```
config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true
```

So I'd like to suggest a small improvement so this and other similar methods always return either `true` or `false`.