### PR TITLE
Support Custom Logged Attributes

### DIFF
--- a/lib/sidekiq/config.rb
+++ b/lib/sidekiq/config.rb
@@ -292,10 +292,6 @@ module Sidekiq
       @logger = logger
     end
 
-    def logged_job_attributes
-      @options[:logged_job_attributes]
-    end
-
     private def parameter_size(handler)
       target = handler.is_a?(Proc) ? handler : handler.method(:call)
       target.parameters.size

--- a/lib/sidekiq/job_logger.rb
+++ b/lib/sidekiq/job_logger.rb
@@ -30,7 +30,7 @@ module Sidekiq
         class: job_hash["wrapped"] || job_hash["class"]
       }
 
-      @config.logged_job_attributes.each do |attr|
+      @config[:logged_job_attributes].each do |attr|
         h[attr.to_sym] = job_hash[attr] if job_hash.has_key?(attr)
       end
 

--- a/test/job_logger_test.rb
+++ b/test/job_logger_test.rb
@@ -96,7 +96,7 @@ describe "Job logger" do
   end
 
   it "tests custom log attributes" do
-    @cfg.logged_job_attributes << "trace_id"
+    @cfg[:logged_job_attributes] << "trace_id"
     jl = Sidekiq::JobLogger.new(@cfg)
     job = {"class" => "FooJob", "trace_id" => "xxx"}
     jl.prepare(job) do


### PR DESCRIPTION
Provides support for a custom log preparer to allow the sidekiq context to be customized so that all sidekiq logs can have added context when needed. See #6845.