### PR TITLE
Fix perform_inline to enforce strict_args!

### DIFF
--- a/lib/sidekiq/job.rb
+++ b/lib/sidekiq/job.rb
@@ -226,6 +226,8 @@ module Sidekiq
         end
         return nil unless result
 
+        verify_json(item)
+
         # round-trip the payload via JSON
         msg = Sidekiq.load_json(Sidekiq.dump_json(item))
 

--- a/test/iterable/iterable_test.rb
+++ b/test/iterable/iterable_test.rb
@@ -333,11 +333,11 @@ describe Sidekiq::Job::Iterable do
       assert_equal [0, 1], objects
     end
 
-    it "mangles keyword arguments, per JSON" do
+    it "passes hash arguments through JSON round-trip" do
       args = {}
       DynamicCallbackJob.reset
       DynamicCallbackJob::CB[:on_start] << -> { args[:on_start] = arguments }
-      DynamicCallbackJob.perform_inline("first", mike: 456, bob: "string")
+      DynamicCallbackJob.perform_inline("first", {"mike" => 456, "bob" => "string"})
       assert_equal(args, {on_start: ["first", {"mike" => 456, "bob" => "string"}]})
     end
   end

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -183,5 +183,12 @@ describe Sidekiq::Job do
       MyCustomJob.perform_inline($my_recorder)
       assert_equal $my_recorder.flatten, %w[1-client-before 1-client-after 1-server-before work_performed 1-server-after]
     end
+
+    it "raises an error when using a symbol as an argument" do
+      error = assert_raises ArgumentError do
+        MySetJob.perform_inline(:symbol)
+      end
+      assert_match(/but :symbol is a Symbol/, error.message)
+    end
   end
 end


### PR DESCRIPTION
Resolves: https://github.com/sidekiq/sidekiq/issues/6718

`perform_inline` bypasses `Sidekiq::Client` and was missing the `verify_json` call that enforces `strict_args!`

This caused jobs with non-JSON-native args pass in tests using `perform_inline`.

**Changes:**
- Add `verify_json(item)` call to `Setter#perform_inline`
- Add tests for strict_args! enforcement in perform_inline