### PR TITLE
Fix ReferenceError in checkResponse function

### DIFF
--- a/web/assets/javascripts/application.js
+++ b/web/assets/javascripts/application.js
@@ -154,7 +154,7 @@ function livePollCallback() {
 
 function checkResponse(resp) {
   if (!resp.ok) {
-    throw response.error();
+    throw resp.error();
   }
   return resp
 }


### PR DESCRIPTION
The `checkResponse` function in `web/assets/javascripts/application.js` had a bug where it referenced an undefined variable `response` instead of the function parameter `resp`. This caused a `ReferenceError` when live polling encountered a non-OK HTTP response.

<img width="464" height="101" alt="Screenshot 2025-12-27 at 11 53 38 PM" src="https://github.com/user-attachments/assets/157a211a-4d1d-484b-be0c-a7b80795f59a" />
