### PR TITLE
Fix missing require for Rack::Session in bare/simple.ru

### DIFF
--- a/bare/simple.ru
+++ b/bare/simple.ru
@@ -1,6 +1,7 @@
 # Easiest way to run Sidekiq::Web.
 # Run with "bundle exec rackup simple.ru"
 
+require "rack/session"
 require "sidekiq/web"
 
 # A Web process always runs as client, no need to configure server


### PR DESCRIPTION
When starting the Sidekiq web UI using `SIDEKIQ_WEB_TESTING=1 bundle exec rackup bare/simple.ru`, encountered the following error:

```ruby
uninitialized constant Rack::Session (NameError)
Did you mean? Rack::RACK_SESSION
```
