### PR TITLE
Fix thread safe issues related to hash initialization in metrics

### DIFF
--- a/lib/sidekiq/metrics/tracking.rb
+++ b/lib/sidekiq/metrics/tracking.rb
@@ -14,8 +14,12 @@ module Sidekiq
         @config = config
         @jobs = Hash.new(0)
         @totals = Hash.new(0)
-        @grams = Hash.new { |hash, key| hash[key] = Histogram.new(key) }
         @lock = Mutex.new
+        @grams = Hash.new do |hash, key| 
+          @lock.synchronize do 
+            hash[key] = Histogram.new(key)
+          end
+        end  
       end
 
       def track(queue, klass)
@@ -121,7 +125,11 @@ module Sidekiq
       def reset_instance_variables
         @totals = Hash.new(0)
         @jobs = Hash.new(0)
-        @grams = Hash.new { |hash, key| hash[key] = Histogram.new(key) }
+        @grams = Hash.new do |hash, key| 
+          @lock.synchronize do 
+            hash[key] = Histogram.new(key)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
<details>
<summary>Full stack trace by clicking on the arrow on the left</summary>

    
    RuntimeError: can't add a new key into hash during iteration (RuntimeError)
    from sidekiq/metrics/tracking.rb:124:in 'block in Sidekiq::Metrics::ExecutionTracker#reset_instance_variables'
    from sidekiq/metrics/tracking.rb:107:in 'block in Sidekiq::Metrics::ExecutionTracker#track_time'
    from sidekiq/metrics/tracking.rb:106:in 'synchronize'
    from sidekiq/metrics/tracking.rb:106:in 'track_time'
    from sidekiq/metrics/tracking.rb:34:in 'track'
    from sidekiq/metrics/tracking.rb:136:in 'call'
    from sidekiq/middleware/chain.rb:182:in 'traverse'
    from sidekiq/middleware/chain.rb:173:in 'invoke'
    from sidekiq/processor.rb:191:in 'block (3 levels) in Sidekiq::Processor#process'
    from sidekiq/processor.rb:151:in 'block (7 levels) in Sidekiq::Processor#dispatch'
    from sidekiq/job_retry.rb:118:in 'local'
    from sidekiq/processor.rb:150:in 'block (6 levels) in Sidekiq::Processor#dispatch'
    from sidekiq/rails.rb:19:in 'block in Sidekiq::Rails::Reloader#call'
    from active_support/reloader.rb:77:in 'block in ActiveSupport::Reloader.wrap'
    from active_support/execution_wrapper.rb:91:in 'ActiveSupport::ExecutionWrapper.wrap'
    from active_support/reloader.rb:74:in 'ActiveSupport::Reloader.wrap'
    from sidekiq/rails.rb:18:in 'call'
    from sidekiq/processor.rb:145:in 'block (5 levels) in Sidekiq::Processor#dispatch'
    from sidekiq/processor.rb:123:in 'profile'
    from sidekiq/processor.rb:140:in 'block (4 levels) in Sidekiq::Processor#dispatch'
    from sidekiq/processor.rb:288:in 'stats'
    from sidekiq/processor.rb:139:in 'block (3 levels) in Sidekiq::Processor#dispatch'
    from sidekiq/job_logger.rb:15:in 'call'
    from sidekiq/processor.rb:138:in 'block (2 levels) in Sidekiq::Processor#dispatch'
    from sidekiq/job_retry.rb:85:in 'global'
    from sidekiq/processor.rb:137:in 'block in Sidekiq::Processor#dispatch'
    from sidekiq/job_logger.rb:42:in 'prepare'
    from sidekiq/processor.rb:136:in 'dispatch'
    from sidekiq/processor.rb:190:in 'block (2 levels) in Sidekiq::Processor#process'
    from sidekiq/processor.rb:189:in 'Thread.handle_interrupt'
    from sidekiq/processor.rb:189:in 'block in Sidekiq::Processor#process'
    from sidekiq/processor.rb:188:in 'Thread.handle_interrupt'
    from sidekiq/processor.rb:188:in 'process'
    from sidekiq/processor.rb:87:in 'process_one'
    from sidekiq/processor.rb:77:in 'run'
    from sidekiq/component.rb:38:in 'watchdog'
    from sidekiq/component.rb:47:in 'block in Sidekiq::Component#safe_thread'
</details> 

<img width="1107" height="883" alt="image" src="https://github.com/user-attachments/assets/d1148de2-305a-49ba-9f1f-589b371e479a" />
