### PR TITLE
docs: Add missing step to Contributing

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -96,7 +96,8 @@ rails s
 git checkout -b new_feature_name
 ```
 
-### 12. Keep your forked branch up to date with changes in main repo
+#### 12. Keep your forked branch up to date with changes in main repo
+
 ```
 git pull upstream main
 ```


### PR DESCRIPTION
Adds a missing `bundle install` step to the contributing.md section "Beginner's Guide to Local Development Setup".

Also fixes a heading level there.

Small issues, but addressing them can reduce setup friction by a bit.