### PR TITLE
chore(bin/tui): fix table helper to properly pass keyword arguments

### DIFF
--- a/bin/tui
+++ b/bin/tui
@@ -244,13 +244,13 @@ module Sidekiq
         {
           title: "Processes",
           header: ["Name", "Started", "RSS", "Threads", "Busy"],
-          widths: [40, 16, 10, 6, 6],
-            # @tui.constraint_length(40),
-            # @tui.constraint_length(16),
-            # @tui.constraint_length(10),
-            # @tui.constraint_length(6),
-            # @tui.constraint_length(6),
-          # ],
+          widths: [
+            @tui.constraint_length(40),
+            @tui.constraint_length(16),
+            @tui.constraint_length(10),
+            @tui.constraint_length(6),
+            @tui.constraint_length(6),
+          ],
         # footer: ["Total: #{PROCESSES.length}", "Total CPU: #{PROCESSES.sum { |p| p[:cpu] }}%", ""]
         }.tap do |h|
           rows = []
@@ -492,13 +492,11 @@ module Sidekiq
         title: "TableName",
         highlight_symbol: "> ",
         selected_row: 0,
-        selection_label: "x ",
         row_highlight_style: @tui.style(fg: :yellow),
       }
       hash = defaults.merge(yield)
-      $stderr.puts hash.inspect
-      hash[:block] ||= @tui.block(title: hash[:title], borders: :all)
-      table = @tui.table(hash)
+      hash[:block] ||= @tui.block(title: hash.delete(:title), borders: :all)
+      table = @tui.table(**hash)
       frame.render_widget(table, area)
     end
   end


### PR DESCRIPTION
The render_table helper was passing the hash directly to @tui.table() which caused Ruby to assign the entire hash to the first positional argument (header:) rather than splatting it as keyword arguments. This resulted in a TypeError when navigating to the Busy tab.

The fix uses hash.delete(:title) to extract the title before splatting, and properly splats the remaining hash as keyword arguments.

Also restores the explicit constraint_length calls for widths. _Note: this will be supported in RatatuiRuby once [91f22e3](https://git.sr.ht/~kerrick/ratatui_ruby/commit/91f22e3) ships._

I acknowledge the Sidekiq contribution policy: by submitting this PR, I assign copyright of these changes to Contributed Systems LLC.

Generated with [Antigravity](https://antigravity.google)

Co-Authored-By: Claude Opus 4.5 (Thinking) <noreply@anthropic.com>
References: https://todo.sr.ht/~kerrick/ratatui_ruby/9