### PR TITLE
Update Pro-8.0-Upgrade.md with sidekiq batches migration instructions

### DIFF
--- a/docs/Pro-8.0-Upgrade.md
+++ b/docs/Pro-8.0-Upgrade.md
@@ -26,7 +26,7 @@ If you're fine with stopping sidekiq for a bit, you can run this migration to ma
 
 ```ruby
 Sidekiq.redis do |conn|
-  conn.scan(match:"b-*-failinfo", count: 100, type: "hash") do |key|
+  conn.scan(match: "b-*-failinfo", count: 100, type: "hash") do |key|
     bid = key.split("-")[1]
     jids, ttl = conn.pipelined do |pipeline|
       pipeline.hkeys(key)


### PR DESCRIPTION
Added migration instructions for making 7.x batches compatible with 8.x

I didn't want to run sidekiq-pro 7.3 for a month before upgrading to sidekiq-pro 8.0.

So I've used this script to make redis "schema" compatible with 8.0