### PR TITLE
Support profiling ActiveJob jobs

### DIFF
--- a/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -63,19 +63,19 @@ begin
         def enqueue(job)
           # NB: Active Job only serializes keys it recognizes. We
           # cannot set arbitrary key/values here.
-          wrapper = Sidekiq::ActiveJob::Wrapper.set(
-            wrapped: job.class,
-            queue: job.queue_name
-          )
+          options = {wrapped: job.class, queue: job.queue_name}
+          options[:profile] = job.profile if job.respond_to?(:profile) && !job.profile.nil?
+
+          wrapper = Sidekiq::ActiveJob::Wrapper.set(options)
           job.provider_job_id = wrapper.perform_async(job.serialize)
         end
 
         # @api private
         def enqueue_at(job, timestamp)
-          job.provider_job_id = Sidekiq::ActiveJob::Wrapper.set(
-            wrapped: job.class,
-            queue: job.queue_name
-          ).perform_at(timestamp, job.serialize)
+          options = {wrapped: job.class, queue: job.queue_name}
+          options[:profile] = job.profile if job.respond_to?(:profile) && !job.profile.nil?
+
+          job.provider_job_id = Sidekiq::ActiveJob::Wrapper.set(options).perform_at(timestamp, job.serialize)
         end
 
         # @api private

--- a/lib/sidekiq/profiler.rb
+++ b/lib/sidekiq/profiler.rb
@@ -21,7 +21,7 @@ module Sidekiq
       return yield unless job["profile"]
 
       token = job["profile"]
-      type = job["class"]
+      type = job["wrapped"] || job["class"]
       jid = job["jid"]
       started_at = Time.now
 

--- a/test/profiling_test.rb
+++ b/test/profiling_test.rb
@@ -89,6 +89,19 @@ describe "profiling" do
     assert_equal "/profiles", last_response.headers["Location"]
   end
 
+  it "configures the type as the wrapped job class for AJ" do
+    skip("Not a usable Ruby") if RUBY_VERSION < "3.3"
+
+    s = Sidekiq::Profiler.new(@config)
+    job = {"profile" => "oli", "class" => "Sidekiq::ActiveJob::Wrapper", "wrapped" => "MyActiveJob", "jid" => "1234"}
+    result = s.call(job) { nil }
+
+    assert_kind_of Vernier::Result, result
+
+    ps = Sidekiq::ProfileSet.new
+    assert_equal %w[MyActiveJob], ps.map(&:type)
+  end
+
   include Rack::Test::Methods
 
   def app


### PR DESCRIPTION
Hello 👋 ,

This PR proposes a few minor changes to facilitate profiling ActiveJob jobs. As the [wiki page on Profiling](https://github.com/sidekiq/sidekiq/wiki/Profiling#active-job) states this is currently quite awkward because: 

> Active Job does not support adding arbitrary key/values to the job payload via set, making it impossible to dynamically enable profiling in your Active Jobs, e.g. `SomeJob.set(profile: "sometoken").perform_later(...)` will not work because `ActiveJob::Core#set` will discard the profile element.

This PR proposes updating the AJ Sidekiq adapter to check if a job instance `responds_to?(:profile)`. If it does then the profile option is set on the base Sidekiq job hash.

To profile ActiveJobs the end-user would still need a minor change to their application, for example:

```ruby
# app/jobs/concerns/profileable_job.rb
module ProfileableJob
  attr_accessor :profile

  def set(options = {})
    self.profile = options[:profile] || options["profile"]
    super
  end
end

# app/jobs/application_job.rb
class ApplicationJob < ActiveJob::Base
  include ProfileableJob
end

# Usage:
MyActiveJob.set(profile: "oli").perform_later
```

Or they could specify a `#profile` method on individual jobs if preferred.

I hope this suggestion is simple enough it could be added to the wiki, and provide support for profiling ActiveJobs whilst avoiding the need for Sidekiq as a library to patch `ActiveJob::Core#set` to support it.

## Notes

I've initially left out support for the profile option in `ActiveJob::QueueAdapters::SidekiqAdapter#enqueue_all` because bulk enqueueing jobs to be profiled feels contrary to the wiki advice to profile sparingly:

> Be careful not to profile every job and quickly fill up your Redis! Profiling data expires after 24 hours.

## Preview

Testing this branch locally I can see the profile in Sidekiq Web as expected:

<img width="1277" height="332" alt="sidekiq-activejob-profile" src="https://github.com/user-attachments/assets/cb393e2a-f9b9-4c57-a1db-dad82e76ff78" />