### PR TITLE
Corrected a typo on a variable name.

### DIFF
--- a/lib/sidekiq/web/helpers.rb
+++ b/lib/sidekiq/web/helpers.rb
@@ -294,7 +294,7 @@ module Sidekiq
       else
         # DEPRECATED Backwards compatibility with older processes.
         # 'capsules' element added in v8.0.9
-        process.queues.join(", ")
+        pro.queues.join(", ")
       end
     end
 


### PR DESCRIPTION
Hey there 👋 First of all, thank you to you and all contributors for this great project and for the ongoing maintenance efforts!

**- What is it good for**

I stumbled upon this error:

```
undefined local variable or method 'process' for an instance of Sidekiq::Web::Action

lib/sidekiq/web/helpers.rb:297 Sidekiq::WebHelpers#queue_names_by_capsule
  process.queues.join(", ")
  https://github.com/sidekiq/sidekiq/blob/v8.1.1/lib/sidekiq/web/helpers.rb#L297

web/views/busy.html.erb:72 block in Sidekiq::Web::Action#_erb_busy
  <%= queue_names_by_capsule(process) %>
  https://github.com/sidekiq/sidekiq/blob/v8.1.1/web/views/busy.html.erb#L72

web/views/busy.html.erb:53 Array#each
web/views/busy.html.erb:53 Sidekiq::Web::Action#_erb_busy
lib/sidekiq/web/action.rb:167 Sidekiq::Web::Action#_erb
lib/sidekiq/web/action.rb:137 Sidekiq::Web::Action#erb
lib/sidekiq/web/application.rb:95 block in <class:Application>
lib/sidekiq/web/application.rb:436 BasicObject#instance_exec
lib/sidekiq/web/application.rb:436 block in Sidekiq::Web::Application#call
lib/sidekiq/web/application.rb:434 Kernel#catch
lib/sidekiq/web/application.rb:434 Sidekiq::Web::Application#call
```

Caused by a misconfiguration with an older application running Sidekiq 7 on a
Valkey db, and another application running Sidekiq 8 on the same Valkey db.

Suddenly the web application `/busy` route threw a 500 server error.
Investigated the stack trace and found the broken condition branch.

**- What I did**

Just corrected the bad variable name, there is no `process` method on
`Sidekiq::Web::Action`.

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="200" height="255" alt="image" src="https://github.com/user-attachments/assets/f52c1e69-7146-417b-adca-3b48b8fa44ef" />
