### PR TITLE
feat: Add "Run" button to Sidekiq Web UI for immediate job execution

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -155,6 +155,16 @@ module Sidekiq
         redirect_with_query("#{root_path}queues/#{CGI.escape(name)}")
       end
 
+      post "/queues/:name/run" do
+        name = route_params(:name)
+        job = Sidekiq::JobRecord.new(url_params("key_val"), name)
+        klass = Object.const_get(job.klass)
+        klass.new.perform(*job.args)
+        job.delete
+
+        redirect_with_query("#{root_path}queues/#{CGI.escape(name)}")
+      end
+
       get "/morgue" do
         x = url_params("substr")
 

--- a/web/views/queue.html.erb
+++ b/web/views/queue.html.erb
@@ -43,7 +43,12 @@
             <%= h(job["cattr"].inspect) if job["cattr"]&.any? %>
           </td>
           <td>
-            <form action="<%= root_path %>queues/<%= CGI.escape(@name) %>/delete" method="post">
+            <form action="<%= root_path %>queues/<%= CGI.escape(@name) %>/run" method="post" style="display:inline">
+              <%= csrf_tag %>
+              <input name="key_val" value="<%= h job.value %>" type="hidden">
+              <input class="btn btn-primary" type="submit" name="run" value="Run" data-confirm="<%= t('AreYouSure') %>">
+            </form>
+            <form action="<%= root_path %>queues/<%= CGI.escape(@name) %>/delete" method="post" style="display:inline">
               <%= csrf_tag %>
               <input name="key_val" value="<%= h job.value %>" type="hidden">
               <input class="btn btn-danger" type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSure') %>">


### PR DESCRIPTION
This pull request introduces a new feature to the Sidekiq web UI that allows users to manually run jobs directly from the queue view. The changes add a "Run" button for each job in the queue, and implement the backend logic to execute the job and remove it from the queue upon completion.

New job execution feature:

* Added a POST route `/queues/:name/run` in `lib/sidekiq/web/application.rb` to execute a job immediately by instantiating the job's class, calling `perform` with its arguments, and deleting the job record after execution.
* Updated the queue view in `web/views/queue.html.erb` to include a "Run" button for each job, which submits a form to the new run endpoint, allowing users to manually trigger job execution from the UI.