### PR TITLE
fix: guard against nil workset when page offset exceeds collection size

### DIFF
--- a/lib/sidekiq/paginator.rb
+++ b/lib/sidekiq/paginator.rb
@@ -62,7 +62,7 @@ module Sidekiq
       pageidx = current_page - 1
       starting = pageidx * page_size
       items = items.to_a
-      [current_page, items.size, items[starting, page_size]]
+      [current_page, items.size, items[starting, page_size] || []]
     end
   end
 end

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -150,6 +150,11 @@ describe Sidekiq::Web do
       assert_equal 302, last_response.status
       assert_equal "TERM", @config.redis { |c| c.lpop signals_key }
     end
+
+    it "renders without error when requesting a page beyond available workers" do
+      get "/busy?page=99"
+      assert_equal 200, last_response.status
+    end
   end
 
   it "can display queues" do


### PR DESCRIPTION
When the requested page exceeds available workers, `@workset` was set to `nil`, crashing the busy page. Guard `page_items` result with `|| []`.