### PR TITLE
Fix pagination active page visibility in dark mode

### DIFF
--- a/web/assets/stylesheets/style.css
+++ b/web/assets/stylesheets/style.css
@@ -534,6 +534,8 @@ input[type="checkbox"] { accent-color: var(--color-primary); }
 
 .pagination a { text-decoration: none; }
 
+.pagination .active a { color: var(--color-primary); font-weight: 700; }
+
 .pagination .disabled { opacity: 0.3; }
 
 div:has(.pagination.pull-right) { margin-left: auto; }

--- a/web/views/_paging.html.erb
+++ b/web/views/_paging.html.erb
@@ -10,7 +10,7 @@
           <a href="<%= url %>?<%= qparams(page: @current_page - 1) %>"><%= @current_page - 1 %></a>
         </li>
       <% end %>
-      <li class="disabled">
+      <li class="active">
         <a href="<%= url %>?<%= qparams(page: @current_page) %>"><%= @current_page %></a>
       </li>
       <% if @total_size > @current_page * @count %>


### PR DESCRIPTION
## Summary

Fixes #6929

The pagination component makes it impossible to distinguish the currently active page from other pages. All page numbers share the same styling, the current page uses `class="disabled"` which only reduces opacity, making it look like a disabled nav arrow rather than the active page indicator.

**Changes:**
- Change current page `<li>` from `class="disabled"` to `class="active"` so it's semantically correct
- Add `.pagination .active a` styling with `color: var(--color-primary)` and `font-weight: 700`, uses existing CSS variables so it works in both light and dark mode

### Before
<img width="2400" height="100" alt="before-dark-final" src="https://github.com/user-attachments/assets/16deaff8-8dbe-4a39-8e20-7e85cbdf8168" />

<img width="2400" height="100" alt="before-light-final" src="https://github.com/user-attachments/assets/13423915-199f-4102-ac89-57984264595a" />


### After
<img width="2400" height="100" alt="after-dark-final" src="https://github.com/user-attachments/assets/19853e5b-c759-4d84-a076-e7c0caf82773" />

<img width="2400" height="100" alt="after-light-final" src="https://github.com/user-attachments/assets/2d8766ee-62c8-43d1-90de-df548c441434" />


## Test plan

- [x] Verify active page is clearly visible in dark mode (bold + primary color)
- [x] Verify active page is clearly visible in light mode
- [x] Verify disabled arrows (`«`/`»`) still appear dimmed on first/last page
- [x] Verify page navigation still works correctly