### PR TITLE
Update 8.0 Upgrade docs with error_handler breaking change

### DIFF
--- a/docs/8.0-Upgrade.md
+++ b/docs/8.0-Upgrade.md
@@ -26,6 +26,10 @@ Previously Sidekiq stored 8 hours of job execution metrics.
 This has been increased to 72 hours, allowing you to see a full weekend of data and multi-day patterns.
 By aggregating the data, a 9x increase in visibility only requires 2x the storage in Redis.
 
+### Breaking API Changes
+
+- An `error_handler` now takes a third config argument `->(ex, context, config)`.
+
 ### Data Model Changes
 
 - The underlying class for Active Jobs has changed from `ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper` to `Sidekiq::ActiveJob::Wrapper`.


### PR DESCRIPTION
When upgrading, this was a problematic one to figure out. We encountered it as we recently switched from Bugsnag to Datadog for error reporting but the latter is a downgrade when it comes to Sidekiq integration for errors so we had to add our own error handler. I figure adding one isn't too common.

Resources: 
- https://github.com/sidekiq/sidekiq/blob/v8.1.2/lib/sidekiq/config.rb#L311
- https://github.com/sidekiq/sidekiq/pull/6051