### PR TITLE
Update error_handler proc to include config parameter

### DIFF
--- a/lib/sidekiq/config.rb
+++ b/lib/sidekiq/config.rb
@@ -255,7 +255,7 @@ module Sidekiq
     # Register a proc to handle any error which occurs within the Sidekiq process.
     #
     #   Sidekiq.configure_server do |config|
-    #     config.error_handlers << proc {|ex,ctx_hash| MyErrorService.notify(ex, ctx_hash) }
+    #     config.error_handlers << proc {|ex,ctx_hash,config| MyErrorService.notify(ex, ctx_hash) }
     #   end
     #
     # The default error handler logs errors to @logger.

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -125,8 +125,8 @@ describe Sidekiq::Processor do
   describe "exception handling" do
     let(:errors) { [] }
     let(:error_handler) do
-      proc do |exception, context|
-        errors << {exception: exception, context: context}
+      proc do |exception, context, config|
+        errors << {exception: exception, context: context, config: config}
       end
     end
 


### PR DESCRIPTION
This was one of the first places I looked at on the v8 tag when upgrading from v7 and dealing with breakage. Since the documented code example is adding a custom error handler, it needs to take 3 arguments for it to be valid on v8. I noticed the processor test was only with 2 arguments so perhaps that is intentional and not needed but figured I would include.