### PR TITLE
Show iterable job state in web UI

### DIFF
--- a/lib/sidekiq/api.rb
+++ b/lib/sidekiq/api.rb
@@ -478,6 +478,12 @@ module Sidekiq
       self["jid"]
     end
 
+    def iterable_state
+      return @iterable_state if defined?(@iterable_state)
+
+      @iterable_state = Sidekiq::IterableJobState.fetch(jid)
+    end
+
     def bid
       self["bid"]
     end
@@ -1395,6 +1401,60 @@ module Sidekiq
 
     def data
       Sidekiq.redis { |c| c.hget(key, "data") }
+    end
+  end
+
+  # Persisted iteration state from Redis for jobs using Sidekiq::IterableJob.
+  class IterableJobState
+    # Fetch iteration state for a single JID.
+    def self.fetch(jid)
+      bulk_fetch([jid])[jid]
+    end
+
+    # Batch-fetch iteration state for multiple JIDs in a single Redis pipeline.
+    # Returns a Hash of { jid => IterableJobState } for JIDs that have iteration state.
+    def self.bulk_fetch(jids)
+      jids_to_fetch = Array(jids).compact.uniq
+      return {} if jids_to_fetch.empty?
+
+      results = Sidekiq.redis do |conn|
+        conn.pipelined do |pipe|
+          jids_to_fetch.each { |jid| pipe.hgetall("it-#{jid}") }
+        end
+      end
+
+      states = {}
+      jids_to_fetch.each_with_index do |jid, i|
+        raw = results[i]
+        next if raw.nil? || raw.empty?
+
+        states[jid] = new(raw)
+      end
+      states
+    end
+
+    def initialize(raw)
+      @raw = raw
+    end
+
+    def executions
+      @raw["ex"].to_i
+    end
+
+    def runtime
+      @raw["rt"].to_f
+    end
+
+    def cursor
+      @cursor ||= begin
+        Sidekiq.load_json(@raw["c"])
+      rescue JSON::ParserError
+        @raw["c"]
+      end
+    end
+
+    def cancelled
+      @raw["cancelled"]&.to_i
     end
   end
 end

--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -92,6 +92,8 @@ module Sidekiq
         @count = (url_params("count") || 100).to_i
         (@current_page, @total_size, @workset) = page_items(workset, url_params("page"), @count)
 
+        @iterable_states = Sidekiq::IterableJobState.bulk_fetch(@workset.map { |_, _, work| work.job.jid })
+
         erb(:busy)
       end
 
@@ -225,6 +227,8 @@ module Sidekiq
           (@current_page, @total_size, @retries) = page("retry", url_params("page"), @count)
           @retries = @retries.map { |msg, score| Sidekiq::SortedEntry.new(nil, score, msg) }
         end
+
+        @iterable_states = Sidekiq::IterableJobState.bulk_fetch(@retries.map(&:jid))
 
         erb(:retries)
       end

--- a/test/web_test.rb
+++ b/test/web_test.rb
@@ -92,22 +92,27 @@ describe Sidekiq::Web do
     end
 
     it "can display workers" do
+      jid = SecureRandom.hex(12)
       @config.redis do |conn|
         conn.incr("busy")
         conn.sadd("processes", ["foo:1234"])
         conn.hset("foo:1234", "info", Sidekiq.dump_json("hostname" => "foo", "started_at" => Time.now.to_f, "capsules" => {}, "concurrency" => 10), "at", Time.now.to_f, "busy", 4)
         identity = "foo:1234:work"
-        hash = {queue: "critical", payload: Sidekiq.dump_json({"class" => WebJob.name, "args" => [1, "abc"], "tags" => %w[foobar_100 <eviltag/>]}), run_at: Time.now.to_i}
+        hash = {queue: "critical", payload: Sidekiq.dump_json({"class" => WebJob.name, "args" => [1, "abc"], "jid" => jid, "tags" => %w[foobar_100 <eviltag/>]}), run_at: Time.now.to_i}
         conn.hset(identity, 1001, Sidekiq.dump_json(hash))
       end
+      add_iteration_state(jid, cursor: {"offset" => 500}, executions: 7)
       assert_equal ["1001"], Sidekiq::WorkSet.new.map { |pid, tid, data| tid }
 
       get "/busy"
       assert_equal 200, last_response.status
       assert_match(/critical/, last_response.body)
       assert_match(/WebJob/, last_response.body)
+      assert_match(/#{jid}/, last_response.body)
       assert_match(/jobtag-foobar_100/, last_response.body)
       assert_match(/jobtag-&lt;eviltag\/&gt;/, last_response.body)
+      assert_match(/offset/, last_response.body)
+      assert_match(/exec=7/, last_response.body)
     end
 
     it "can quiet all processes" do
@@ -331,6 +336,18 @@ describe Sidekiq::Web do
     assert_equal 200, last_response.status
     refute_match(/found/, last_response.body)
     assert_match(/HardJob/, last_response.body)
+  end
+
+  it "displays iteration state on retry detail page" do
+    jid = SecureRandom.hex(12)
+    params = add_retry(jid)
+    add_iteration_state(jid, cursor: {"id" => 42}, executions: 3, runtime: 12.345)
+
+    get "/retries/#{job_params(*params)}"
+    assert_equal 200, last_response.status
+    assert_match(/Iteration/, last_response.body)
+    assert_match(/cursor=/, last_response.body)
+    assert_match(/exec=3/, last_response.body)
   end
 
   it "displays custom job info" do
@@ -898,6 +915,12 @@ describe Sidekiq::Web do
       conn.zadd("dead", score, job)
     end
     [job, score]
+  end
+
+  def add_iteration_state(jid, cursor: {"id" => 42}, executions: 3, runtime: 12.345)
+    @config.redis do |conn|
+      conn.hset("it-#{jid}", "ex", executions, "c", Sidekiq.dump_json(cursor), "rt", runtime)
+    end
   end
 
   def add_xss_retry(job_id = SecureRandom.hex(12))

--- a/web/views/_job_info.html.erb
+++ b/web/views/_job_info.html.erb
@@ -34,6 +34,14 @@
             <code><%= job.jid %></code>
           </td>
         </tr>
+        <% if (state = job.iterable_state) %>
+        <tr>
+          <th>Iteration</th>
+          <td>
+            <code>cursor=<%= h(state.cursor.inspect) %>; exec=<%= state.executions %>; rt=<%= number_with_delimiter(state.runtime, precision: 3) %>s</code>
+          </td>
+        </tr>
+        <% end %>
         <% if job.bid %>
         <tr>
           <th>BID</th>

--- a/web/views/busy.html.erb
+++ b/web/views/busy.html.erb
@@ -138,7 +138,12 @@
           <td>
             <code><div class="args"><%= display_args(job.display_args) %></div></code>
           </td>
-          <td><%= relative_time(work.run_at) %></td>
+          <td>
+            <%= relative_time(work.run_at) %>
+            <% if (state = @iterable_states[job.jid]) %>
+              <div><small>cursor=<%= h(truncate(state.cursor.inspect, 100)) %>; exec=<%= state.executions %>; rt=<%= number_with_delimiter(state.runtime, precision: 3) %>s</small></div>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </table>

--- a/web/views/retries.html.erb
+++ b/web/views/retries.html.erb
@@ -52,6 +52,9 @@
               </td>
               <td>
                 <div><a href="<%= root_path %>retries/<%= job_params(entry.item, entry.score) %>"><%= h truncate("#{entry['error_class']}: #{entry['error_message']}", 200) %></a></div>
+                <% if (state = @iterable_states[entry.jid]) %>
+                  <div><small>cursor=<%= h(truncate(state.cursor.inspect, 100)) %>; exec=<%= state.executions %>; rt=<%= number_with_delimiter(state.runtime, precision: 3) %>s</small></div>
+                <% end %>
               </td>
             </tr>
           <% end %>


### PR DESCRIPTION
Displays cursor, executions, runtime for Iterable jobs on the busy page, queue/retries list, and job detail pages (retry/scheduled/dead).

Iterates on #6787. Batches the calls to Redis.

Busy list:
<img width="1276" height="655" alt="Screenshot 2026-04-21 at 11 17 32 AM" src="https://github.com/user-attachments/assets/aa998f55-4b7f-4aef-81a9-b34d0b7cb5c1" />

Queue/Retries list:
<img width="1275" height="440" alt="Screenshot 2026-04-21 at 11 27 42 AM" src="https://github.com/user-attachments/assets/b96e6588-27b9-4a3d-a713-ef1fe42797cb" />

Job Detail:
<img width="1277" height="857" alt="Screenshot 2026-04-21 at 11 36 26 AM" src="https://github.com/user-attachments/assets/5d8c3b09-75cc-47a5-8f48-23bc15e45174" />
